### PR TITLE
Release v0.2.7: Caching and Parameter Architecture Refactor

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release version 0.2.7 with major improvements to caching and parameter access architecture.

## Key Changes

### 🚀 Added
- **TTL-Based Caching** - Comprehensive caching system for inverter data to reduce API calls:
  - Runtime data: 30-second cache
  - Energy statistics: 5-minute cache
  - Battery data: 30-second cache
  - Parameters: 1-hour cache
  - Automatic cache invalidation on parameter writes

### 🔄 Changed
- **Parameter Architecture Refactored** - Major API improvement:
  - Converted async parameter getter methods to synchronous properties
  - Properties auto-fetch parameters on first access with 1-hour cache
  - Concurrent parameter fetching (3 register ranges in parallel)
  - Integrated into `refresh()` cycle with `include_parameters=True` flag

### 🐛 Fixed
- Updated integration tests for new property-based parameter API

## Migration Guide

**Breaking Change**: Parameter getter methods replaced with properties.

**Before (v0.2.6)**:
```python
await inverter.refresh()
soc_limits = await inverter.get_battery_soc_limits()
ac_power = await inverter.get_ac_charge_power()
```

**After (v0.2.7)**:
```python
await inverter.refresh(include_parameters=True)  # Optional
soc_limits = inverter.battery_soc_limits  # Auto-fetches if needed
ac_power = inverter.ac_charge_power_limit  # Uses 1-hour cache
```

## Quality Checks

- ✅ **Unit tests**: 369 tests passing (10 new caching tests)
- ✅ **Type checking**: mypy strict mode passing
- ✅ **Linting**: ruff checks passing
- ✅ **Documentation**: CHANGELOG.md updated

## Commits

- `ff0967b` - feat(caching): add comprehensive caching and refactor parameter architecture
- `ef0ec00` - fix(tests): update integration tests to use new property syntax
- `d2b6a35` - chore: prepare release v0.2.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)