### PR TITLE
fix: correct energy value scaling (v0.2.9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Station (Plant)
 | Frequency | ÷100 | 5998 → 59.98Hz |
 | Temperature | Direct | 39 → 39°C |
 | Power | Direct | 1030 → 1030W |
-| Energy (API) | ÷10 | 90 → 9.0 kWh |
+| Energy (API) | ÷10 | 184 → 18.4 kWh |
 
 **WARNING**: Note different voltage scaling for battery bank vs individual batteries!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.2.8"
+version = "0.2.9"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -59,7 +59,7 @@ from .exceptions import (
 )
 from .models import OperatingMode
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",

--- a/src/pylxpweb/constants.py
+++ b/src/pylxpweb/constants.py
@@ -330,22 +330,22 @@ INPUT_P_EPS = (30, 31)  # EPS output power (W, 2 registers)
 INPUT_S_EPS = 32  # EPS status
 INPUT_P_TO_GRID = 33  # Export to grid power (W)
 INPUT_P_TO_USER = (34, 35)  # Load consumption power (W, 2 registers)
-INPUT_E_INV_ALL = 36  # Total inverter energy (kWh, /10)
-INPUT_E_REC_ALL = 37  # Total grid import energy (kWh, /10)
-INPUT_E_CHG_ALL = 38  # Total charge energy (kWh, /10)
-INPUT_E_DISCHG_ALL = 39  # Total discharge energy (kWh, /10)
-INPUT_E_EPS_ALL = 40  # Total EPS energy (kWh, /10)
-INPUT_E_TO_GRID_ALL = 41  # Total export energy (kWh, /10)
-INPUT_E_TO_USER_ALL = 42  # Total load energy (kWh, /10)
+INPUT_E_INV_ALL = 36  # Total inverter energy (Wh after /10, divide by 10 for Wh)
+INPUT_E_REC_ALL = 37  # Total grid import energy (Wh after /10, divide by 10 for Wh)
+INPUT_E_CHG_ALL = 38  # Total charge energy (Wh after /10, divide by 10 for Wh)
+INPUT_E_DISCHG_ALL = 39  # Total discharge energy (Wh after /10, divide by 10 for Wh)
+INPUT_E_EPS_ALL = 40  # Total EPS energy (Wh after /10, divide by 10 for Wh)
+INPUT_E_TO_GRID_ALL = 41  # Total export energy (Wh after /10, divide by 10 for Wh)
+INPUT_E_TO_USER_ALL = 42  # Total load energy (Wh after /10, divide by 10 for Wh)
 INPUT_V_BUS1 = 43  # Bus 1 voltage (V, /10)
 INPUT_V_BUS2 = 44  # Bus 2 voltage (V, /10)
-INPUT_E_INV_DAY = (45, 46)  # Daily inverter energy (kWh, /10, 2 registers)
-INPUT_E_REC_DAY = (47, 48)  # Daily grid import (kWh, /10, 2 registers)
-INPUT_E_CHG_DAY = (49, 50)  # Daily charge energy (kWh, /10, 2 registers)
-INPUT_E_DISCHG_DAY = (51, 52)  # Daily discharge energy (kWh, /10, 2 registers)
-INPUT_E_EPS_DAY = (53, 54)  # Daily EPS energy (kWh, /10, 2 registers)
-INPUT_E_TO_GRID_DAY = (55, 56)  # Daily export energy (kWh, /10, 2 registers)
-INPUT_E_TO_USER_DAY = (57, 58)  # Daily load energy (kWh, /10, 2 registers)
+INPUT_E_INV_DAY = (45, 46)  # Daily inverter energy (Wh after /10, 2 registers)
+INPUT_E_REC_DAY = (47, 48)  # Daily grid import (Wh after /10, 2 registers)
+INPUT_E_CHG_DAY = (49, 50)  # Daily charge energy (Wh after /10, 2 registers)
+INPUT_E_DISCHG_DAY = (51, 52)  # Daily discharge energy (Wh after /10, 2 registers)
+INPUT_E_EPS_DAY = (53, 54)  # Daily EPS energy (Wh after /10, 2 registers)
+INPUT_E_TO_GRID_DAY = (55, 56)  # Daily export energy (Wh after /10, 2 registers)
+INPUT_E_TO_USER_DAY = (57, 58)  # Daily load energy (Wh after /10, 2 registers)
 INPUT_V_BAT_LIMIT = 59  # Max charge voltage (V, /100)
 INPUT_I_BAT_LIMIT = 60  # Max charge current (A, /10)
 
@@ -1283,31 +1283,32 @@ INVERTER_RUNTIME_SCALING: dict[str, ScaleFactor] = {
 # ENERGY DATA SCALING
 # ============================================================================
 # Source: EnergyInfo model from getInverterEnergyInfo endpoint
-# All energy values from API are in Wh×10, need ÷10 to get Wh, then ÷1000 for kWh
+# All energy values from API are in 0.1 kWh units, need ÷10 to get kWh directly
+# Example: API returns 184 → 184 ÷ 10 = 18.4 kWh
 
 ENERGY_INFO_SCALING: dict[str, ScaleFactor] = {
-    # Daily Energy (÷10 to get Wh: 90 → 9.0 Wh → 0.009 kWh)
+    # Daily Energy (÷10 to get kWh: 184 → 18.4 kWh)
     "todayYielding": ScaleFactor.SCALE_10,
     "todayCharging": ScaleFactor.SCALE_10,
     "todayDischarging": ScaleFactor.SCALE_10,
     "todayGridImport": ScaleFactor.SCALE_10,
     "todayUsage": ScaleFactor.SCALE_10,
     "todayExport": ScaleFactor.SCALE_10,
-    # Monthly Energy (÷10 to get Wh)
+    # Monthly Energy (÷10 to get kWh)
     "monthYielding": ScaleFactor.SCALE_10,
     "monthCharging": ScaleFactor.SCALE_10,
     "monthDischarging": ScaleFactor.SCALE_10,
     "monthGridImport": ScaleFactor.SCALE_10,
     "monthUsage": ScaleFactor.SCALE_10,
     "monthExport": ScaleFactor.SCALE_10,
-    # Yearly Energy (÷10 to get Wh)
+    # Yearly Energy (÷10 to get kWh)
     "yearYielding": ScaleFactor.SCALE_10,
     "yearCharging": ScaleFactor.SCALE_10,
     "yearDischarging": ScaleFactor.SCALE_10,
     "yearGridImport": ScaleFactor.SCALE_10,
     "yearUsage": ScaleFactor.SCALE_10,
     "yearExport": ScaleFactor.SCALE_10,
-    # Lifetime Total Energy (÷10 to get Wh)
+    # Lifetime Total Energy (÷10 to get kWh)
     "totalYielding": ScaleFactor.SCALE_10,
     "totalCharging": ScaleFactor.SCALE_10,
     "totalDischarging": ScaleFactor.SCALE_10,
@@ -1579,28 +1580,28 @@ def scale_energy_value(field_name: str, value: int | float, to_kwh: bool = True)
 
     Args:
         field_name: Field name from EnergyInfo model
-        value: Raw API value
-        to_kwh: If True, convert to kWh; if False, return Wh
+        value: Raw API value (in 0.1 kWh units)
+        to_kwh: If True, return kWh; if False, return Wh
 
     Returns:
         Scaled value in kWh (if to_kwh=True) or Wh
 
     Example:
-        >>> scale_energy_value("todayYielding", 90, to_kwh=True)
-        0.009  # kWh
-        >>> scale_energy_value("todayYielding", 90, to_kwh=False)
-        9.0  # Wh
+        >>> scale_energy_value("todayYielding", 184, to_kwh=True)
+        18.4  # kWh
+        >>> scale_energy_value("todayYielding", 184, to_kwh=False)
+        18400.0  # Wh
     """
     if field_name not in ENERGY_INFO_SCALING:
         return float(value)
 
-    # Apply API scaling (÷10 to get Wh)
-    wh_value = apply_scale(value, ENERGY_INFO_SCALING[field_name])
+    # Apply API scaling (÷10 to get kWh directly - API uses 0.1 kWh units)
+    kwh_value = apply_scale(value, ENERGY_INFO_SCALING[field_name])
 
-    # Convert to kWh if requested
-    if to_kwh:
-        return wh_value / 1000.0
-    return wh_value
+    # Convert to Wh if requested
+    if not to_kwh:
+        return kwh_value * 1000.0
+    return kwh_value
 
 
 # ==============================================================================

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -356,9 +356,11 @@ class BaseInverter(BaseDevice):
         if self.energy is None:
             return 0.0
 
-        # Get raw value from API (in Wh)
-        raw_value = float(getattr(self.energy, "todayYielding", 0))
-        current_value_kwh = raw_value / 1000.0  # Convert Wh to kWh
+        # Get raw value from API and scale to kWh using proper scaling helper
+        from pylxpweb.constants import scale_energy_value
+
+        raw_value = getattr(self.energy, "todayYielding", 0)
+        current_value_kwh = scale_energy_value("todayYielding", raw_value, to_kwh=True)
 
         # Check for date boundary reset
         if self._should_reset_daily_energy():
@@ -412,9 +414,11 @@ class BaseInverter(BaseDevice):
         if self.energy is None:
             return 0.0
 
-        # Get raw value from API (in Wh)
-        raw_value = float(getattr(self.energy, "totalYielding", 0))
-        current_value_kwh = raw_value / 1000.0  # Convert Wh to kWh
+        # Get raw value from API and scale to kWh using proper scaling helper
+        from pylxpweb.constants import scale_energy_value
+
+        raw_value = getattr(self.energy, "totalYielding", 0)
+        current_value_kwh = scale_energy_value("totalYielding", raw_value, to_kwh=True)
 
         # Lifetime energy should NEVER decrease
         if (

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -369,13 +369,13 @@ class InverterOverviewItem(BaseModel):
     soc: str  # State of charge (e.g., "58 %")
     vBat: int  # Battery voltage (scaled: divide by 10 for actual volts)
     vBatText: str
-    totalYielding: int  # Total energy generated (scaled: divide by 10 for kWh)
+    totalYielding: int  # Total energy generated (raw: divide by 10 for kWh)
     totalYieldingText: str
-    totalDischarging: int  # Total energy discharged (scaled: divide by 10 for kWh)
+    totalDischarging: int  # Total energy discharged (raw: divide by 10 for kWh)
     totalDischargingText: str
-    totalExport: int  # Total energy exported (scaled: divide by 10 for kWh)
+    totalExport: int  # Total energy exported (raw: divide by 10 for kWh)
     totalExportText: str
-    totalUsage: int  # Total energy consumed (scaled: divide by 10 for kWh)
+    totalUsage: int  # Total energy consumed (raw: divide by 10 for kWh)
     totalUsageText: str
     parallelGroup: str
     parallelIndex: str
@@ -526,7 +526,10 @@ class InverterRuntime(BaseModel):
 class EnergyInfo(BaseModel):
     """Energy statistics data.
 
-    All energy values are in Wh (divide by 10 for kWh display).
+    Raw energy values from API are in units of 0.1 kWh:
+    - Divide by 10 to get kWh directly
+    - Example: 184 → 18.4 kWh
+
     Note: serialNum and soc are not present in parallel group energy responses.
     """
 

--- a/tests/unit/devices/inverters/test_base.py
+++ b/tests/unit/devices/inverters/test_base.py
@@ -56,18 +56,18 @@ def sample_energy() -> EnergyInfo:
         success=True,
         serialNum="1234567890",
         soc=85,
-        todayYielding=25500,  # 25.5 kWh in Wh
-        todayCharging=10000,
-        todayDischarging=8000,
-        todayImport=5000,
-        todayExport=3000,
-        todayUsage=15000,
-        totalYielding=5000000,  # 5000 kWh in Wh
-        totalCharging=2000000,
-        totalDischarging=1800000,
-        totalImport=1000000,
-        totalExport=800000,
-        totalUsage=3000000,
+        todayYielding=255,  # 25.5 kWh (raw API value in 0.1 kWh units)
+        todayCharging=100,
+        todayDischarging=80,
+        todayImport=50,
+        todayExport=30,
+        todayUsage=150,
+        totalYielding=50000,  # 5000 kWh (raw API value in 0.1 kWh units)
+        totalCharging=20000,
+        totalDischarging=18000,
+        totalImport=10000,
+        totalExport=8000,
+        totalUsage=30000,
     )
 
 

--- a/tests/unit/test_date_boundaries.py
+++ b/tests/unit/test_date_boundaries.py
@@ -430,7 +430,8 @@ class TestMonotonicEnergyTracking:
         inverter._last_energy_today = 45.5
 
         # API returns higher value
-        inverter.energy = EnergyInfo.model_construct(todayYielding=46500)  # 46.5 kWh (in Wh)
+        # 46.5 kWh (465 in 0.1 kWh units)
+        inverter.energy = EnergyInfo.model_construct(todayYielding=465)
 
         result = inverter.total_energy_today
 
@@ -447,7 +448,8 @@ class TestMonotonicEnergyTracking:
         inverter._last_energy_today = 45.5
 
         # API returns lower value (stale cache)
-        inverter.energy = EnergyInfo.model_construct(todayYielding=45000)  # 45.0 kWh
+        # 45.0 kWh (450 in 0.1 kWh units)
+        inverter.energy = EnergyInfo.model_construct(todayYielding=450)
 
         result = inverter.total_energy_today
 
@@ -485,7 +487,8 @@ class TestMonotonicEnergyTracking:
         inverter._last_energy_lifetime = 12345.6
 
         # API returns lower value
-        inverter.energy = EnergyInfo.model_construct(totalYielding=12300000)  # 12300.0 kWh (in Wh)
+        # 12300.0 kWh (123000 in 0.1 kWh units)
+        inverter.energy = EnergyInfo.model_construct(totalYielding=123000)
 
         result = inverter.total_energy_lifetime
 
@@ -501,7 +504,8 @@ class TestMonotonicEnergyTracking:
         inverter._last_energy_lifetime = 12345.6
 
         # API returns higher value
-        inverter.energy = EnergyInfo.model_construct(totalYielding=12350000)  # 12350.0 kWh
+        # 12350.0 kWh (123500 in 0.1 kWh units)
+        inverter.energy = EnergyInfo.model_construct(totalYielding=123500)
 
         result = inverter.total_energy_lifetime
 

--- a/tests/unit/test_scaling.py
+++ b/tests/unit/test_scaling.py
@@ -189,32 +189,37 @@ class TestEnergyScaling:
     """Test energy data scaling."""
 
     def test_energy_to_wh(self) -> None:
-        """Test energy scaling to Wh (÷10)."""
-        assert scale_energy_value("todayYielding", 90, to_kwh=False) == 9.0
-        assert scale_energy_value("monthYielding", 1500, to_kwh=False) == 150.0
-        assert scale_energy_value("totalYielding", 5000, to_kwh=False) == 500.0
+        """Test energy scaling to Wh (÷10 to get kWh, ×1000 for Wh)."""
+        # 90÷10=9kWh, 9×1000=9000Wh
+        assert scale_energy_value("todayYielding", 90, to_kwh=False) == 9000.0
+        # 1500÷10=150kWh
+        assert scale_energy_value("monthYielding", 1500, to_kwh=False) == 150000.0
+        # 5000÷10=500kWh
+        assert scale_energy_value("totalYielding", 5000, to_kwh=False) == 500000.0
 
     def test_energy_to_kwh(self) -> None:
-        """Test energy scaling to kWh (÷10 then ÷1000)."""
-        assert scale_energy_value("todayYielding", 90, to_kwh=True) == 0.009
-        assert scale_energy_value("monthYielding", 1500, to_kwh=True) == 0.15
-        assert scale_energy_value("totalYielding", 5000, to_kwh=True) == 0.5
+        """Test energy scaling to kWh (÷10 directly - API uses 0.1 kWh units)."""
+        assert scale_energy_value("todayYielding", 90, to_kwh=True) == 9.0  # 90÷10=9kWh
+        assert scale_energy_value("monthYielding", 1500, to_kwh=True) == 150.0  # 1500÷10=150kWh
+        assert scale_energy_value("totalYielding", 5000, to_kwh=True) == 500.0  # 5000÷10=500kWh
 
     def test_all_energy_fields(self) -> None:
         """Test all energy field types."""
-        # Daily
-        assert scale_energy_value("todayCharging", 100, to_kwh=False) == 10.0
-        assert scale_energy_value("todayDischarging", 200, to_kwh=False) == 20.0
+        # Daily - 100÷10=10kWh, ×1000=10000Wh
+        assert scale_energy_value("todayCharging", 100, to_kwh=False) == 10000.0
+        # Daily - 200÷10=20kWh, ×1000=20000Wh
+        assert scale_energy_value("todayDischarging", 200, to_kwh=False) == 20000.0
 
-        # Monthly
-        assert scale_energy_value("monthGridImport", 3000, to_kwh=True) == 0.3
-        assert scale_energy_value("monthExport", 4000, to_kwh=True) == 0.4
+        # Monthly - 3000÷10=300kWh
+        assert scale_energy_value("monthGridImport", 3000, to_kwh=True) == 300.0
+        # Monthly - 4000÷10=400kWh
+        assert scale_energy_value("monthExport", 4000, to_kwh=True) == 400.0
 
-        # Yearly
-        assert scale_energy_value("yearUsage", 50000, to_kwh=True) == 5.0
+        # Yearly - 50000÷10=5000kWh
+        assert scale_energy_value("yearUsage", 50000, to_kwh=True) == 5000.0
 
-        # Total
-        assert scale_energy_value("totalExport", 100000, to_kwh=True) == 10.0
+        # Total - 100000÷10=10000kWh
+        assert scale_energy_value("totalExport", 100000, to_kwh=True) == 10000.0
 
 
 class TestGetScalingForField:
@@ -376,7 +381,8 @@ class TestEdgeCases:
 
     def test_large_values(self) -> None:
         """Test scaling with large values."""
-        assert scale_energy_value("totalYielding", 1000000, to_kwh=True) == 100.0
+        # 1000000÷10=100000kWh
+        assert scale_energy_value("totalYielding", 1000000, to_kwh=True) == 100000.0
         assert scale_runtime_value("pToUser", 15000) == 15000.0
 
 


### PR DESCRIPTION
## Summary
Fixes critical energy scaling bug where values were 100x too small. API returns energy values in **0.1 kWh units**, not Wh.

## Issue
Energy values from downstream applications were displaying incorrectly:
- **Expected**: 18.5 kWh for today's export
- **Actual (before fix)**: 0.185 kWh ❌
- **After fix**: 18.5 kWh ✅

## Root Cause
The library was dividing raw API values by 1000, assuming they were in Wh. Actually, the API returns values in 0.1 kWh units, so we should divide by 10.

## Changes
- ✅ Fixed `BaseInverter.total_energy_today` and `total_energy_lifetime` properties to use correct scaling helper
- ✅ Updated `scale_energy_value()` function to correctly convert to kWh (÷10 directly)
- ✅ Corrected all documentation about energy units
- ✅ Updated scaling reference table in CLAUDE.md
- ✅ Fixed all affected unit tests (463 tests passing)
- ✅ Bumped version to 0.2.9

## Testing
- ✅ All 463 unit tests passing
- ✅ Validated with live API: `inverter.total_energy_today` now returns correct values
- ✅ Code formatted and linted (ruff)

## Breaking Change
This is technically a breaking change as the values returned will be different (100x larger), but the previous values were **incorrect**. Downstream applications relying on these values will need to be aware that the scaling is now correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)