### PR TITLE
chore: release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8] - 2025-11-23
+
+### Added
+
+- **Firmware Update Convenience Properties** - Added public properties to `FirmwareUpdateMixin` for easy access to cached firmware update information:
+  - Added `latest_firmware_version` property - returns latest version string or None
+  - Added `firmware_update_title` property - returns update title or None
+  - Added `firmware_update_summary` property - returns release summary or None
+  - Added `firmware_update_url` property - returns release notes URL or None
+  - All properties provide synchronous access to cached data without API calls
+  - 6 additional unit tests verifying property behavior (22 total for mixin)
+
+### Fixed
+
+- **Firmware Update Summary Formatting** - Fixed release summary to display version numbers in hexadecimal format:
+  - Changed from decimal format (e.g., "v13 → v20") to hex format (e.g., "v0D → v14")
+  - Ensures version numbers in summary match firmware version format (e.g., "IAAB-0D00")
+  - Affects `release_summary` field in `FirmwareUpdateInfo.from_api_response()`
+  - Example: API reports v1=19→22, summary now shows "v13 → v16" (hex) instead of "v19 → v22" (decimal)
+  - Added comprehensive test to verify hex formatting for app and parameter updates
+
+### Testing
+
+- ✅ **Total tests**: 587 (all passing, +7 from v0.3.7)
+- ✅ **Coverage**: >85%
+- ✅ **Code style**: 100% (ruff: 0 errors)
+- ✅ **Type safety**: 100% (mypy strict: 0 errors)
+
 ## [0.3.7] - 2025-11-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.7"
+version = "0.3.8"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -59,7 +59,7 @@ from .exceptions import (
 )
 from .models import FirmwareUpdateInfo, OperatingMode
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -75,6 +75,68 @@ class FirmwareUpdateMixin:
             return None
         return self._firmware_update_info.update_available
 
+    @property
+    def latest_firmware_version(self) -> str | None:
+        """Get latest firmware version from cache.
+
+        Returns:
+            Latest firmware version string, or None if not checked yet.
+
+        Example:
+            >>> await device.check_firmware_updates()
+            >>> print(f"Latest version: {device.latest_firmware_version}")
+        """
+        if self._firmware_update_info is None:
+            return None
+        return self._firmware_update_info.latest_version
+
+    @property
+    def firmware_update_title(self) -> str | None:
+        """Get firmware update title from cache.
+
+        Returns:
+            Firmware update title, or None if not checked yet.
+
+        Example:
+            >>> await device.check_firmware_updates()
+            >>> print(f"Title: {device.firmware_update_title}")
+        """
+        if self._firmware_update_info is None:
+            return None
+        return self._firmware_update_info.title
+
+    @property
+    def firmware_update_summary(self) -> str | None:
+        """Get firmware update summary from cache.
+
+        Returns:
+            Firmware update release summary, or None if not checked yet.
+
+        Example:
+            >>> await device.check_firmware_updates()
+            >>> if device.firmware_update_summary:
+            ...     print(f"Summary: {device.firmware_update_summary}")
+        """
+        if self._firmware_update_info is None:
+            return None
+        return self._firmware_update_info.release_summary
+
+    @property
+    def firmware_update_url(self) -> str | None:
+        """Get firmware update URL from cache.
+
+        Returns:
+            Firmware update release URL, or None if not checked yet.
+
+        Example:
+            >>> await device.check_firmware_updates()
+            >>> if device.firmware_update_url:
+            ...     print(f"Release notes: {device.firmware_update_url}")
+        """
+        if self._firmware_update_info is None:
+            return None
+        return self._firmware_update_info.release_url
+
     async def check_firmware_updates(self, force: bool = False) -> FirmwareUpdateInfo:
         """Check for available firmware updates (cached with 24-hour TTL).
 

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -1172,11 +1172,12 @@ class FirmwareUpdateInfo(BaseModel):
             latest_version = details.fwCodeBeforeUpload
 
         # Generate release summary (max 255 chars for HA)
+        # Format as hex to match firmware version format (e.g., IAAB-1300 means v1=0x13)
         summary_parts = []
         if details.has_app_update:
-            summary_parts.append(f"App firmware: v{details.v1} → v{details.lastV1}")
+            summary_parts.append(f"App firmware: v{details.v1:02X} → v{details.lastV1:02X}")
         if details.has_parameter_update:
-            summary_parts.append(f"Parameter firmware: v{details.v2} → v{details.lastV2}")
+            summary_parts.append(f"Parameter firmware: v{details.v2:02X} → v{details.lastV2:02X}")
         release_summary = "; ".join(summary_parts) if summary_parts else None
 
         # Determine supported features based on API capabilities

--- a/tests/unit/devices/test_firmware_update_mixin.py
+++ b/tests/unit/devices/test_firmware_update_mixin.py
@@ -146,6 +146,83 @@ class TestFirmwareUpdateAvailableProperty:
         assert test_device.firmware_update_available is False
 
 
+class TestFirmwareUpdateCacheProperties:
+    """Tests for cached firmware update info properties."""
+
+    def test_properties_return_none_when_never_checked(
+        self, test_device: FirmwareTestDevice
+    ) -> None:
+        """Test all properties return None when firmware has never been checked."""
+        assert test_device.latest_firmware_version is None
+        assert test_device.firmware_update_title is None
+        assert test_device.firmware_update_summary is None
+        assert test_device.firmware_update_url is None
+
+    def test_latest_firmware_version_returns_cached_value(
+        self, test_device: FirmwareTestDevice
+    ) -> None:
+        """Test latest_firmware_version property returns cached value."""
+        test_device._firmware_update_info = FirmwareUpdateInfo(
+            installed_version="IAAB-1300",
+            latest_version="IAAB-1400",
+            title="Test Firmware",
+        )
+
+        assert test_device.latest_firmware_version == "IAAB-1400"
+
+    def test_firmware_update_title_returns_cached_value(
+        self, test_device: FirmwareTestDevice
+    ) -> None:
+        """Test firmware_update_title property returns cached value."""
+        test_device._firmware_update_info = FirmwareUpdateInfo(
+            installed_version="IAAB-1300",
+            latest_version="IAAB-1400",
+            title="Test Firmware v1.4",
+        )
+
+        assert test_device.firmware_update_title == "Test Firmware v1.4"
+
+    def test_firmware_update_summary_returns_cached_value(
+        self, test_device: FirmwareTestDevice
+    ) -> None:
+        """Test firmware_update_summary property returns cached value."""
+        test_device._firmware_update_info = FirmwareUpdateInfo(
+            installed_version="IAAB-1300",
+            latest_version="IAAB-1400",
+            title="Test Firmware",
+            release_summary="Bug fixes and performance improvements",
+        )
+
+        assert test_device.firmware_update_summary == "Bug fixes and performance improvements"
+
+    def test_firmware_update_url_returns_cached_value(
+        self, test_device: FirmwareTestDevice
+    ) -> None:
+        """Test firmware_update_url property returns cached value."""
+        test_device._firmware_update_info = FirmwareUpdateInfo(
+            installed_version="IAAB-1300",
+            latest_version="IAAB-1400",
+            title="Test Firmware",
+            release_url="https://example.com/release-notes",
+        )
+
+        assert test_device.firmware_update_url == "https://example.com/release-notes"
+
+    def test_properties_return_none_when_release_info_missing(
+        self, test_device: FirmwareTestDevice
+    ) -> None:
+        """Test properties return None when optional release info is missing."""
+        test_device._firmware_update_info = FirmwareUpdateInfo(
+            installed_version="IAAB-1300",
+            latest_version="IAAB-1400",
+            title="Test Firmware",
+        )
+
+        # These are optional and should be None
+        assert test_device.firmware_update_summary is None
+        assert test_device.firmware_update_url is None
+
+
 class TestCheckFirmwareUpdates:
     """Tests for check_firmware_updates() method."""
 

--- a/tests/unit/test_firmware_update_info.py
+++ b/tests/unit/test_firmware_update_info.py
@@ -260,3 +260,35 @@ class TestFirmwareUpdateInfoFromAPIResponse:
         assert info.installed_version == "IAAB-0000"  # v1=0(0x00), v2=0(0x00)
         assert info.latest_version == "IAAB-0000"
         assert info.update_available is False
+
+    def test_release_summary_uses_hex_format(self) -> None:
+        """Test release_summary displays version numbers in hex to match firmware version format."""
+        # Test app firmware update: v1=13 (0x0D) → v1=20 (0x14)
+        api_check_app = _create_firmware_check(v1=13, v2=0, last_v1=20, last_v2=None)
+        info_app = FirmwareUpdateInfo.from_api_response(
+            check=api_check_app,
+            title="Test Firmware",
+        )
+
+        # Should show hex values (0D → 14), not decimal (13 → 20)
+        assert info_app.release_summary == "App firmware: v0D → v14"
+
+        # Test param firmware update: v2=5 (0x05) → v2=10 (0x0A)
+        api_check_param = _create_firmware_check(v1=13, v2=5, last_v1=None, last_v2=10)
+        info_param = FirmwareUpdateInfo.from_api_response(
+            check=api_check_param,
+            title="Test Firmware",
+        )
+
+        # Should show hex values (05 → 0A), not decimal (5 → 10)
+        assert info_param.release_summary == "Parameter firmware: v05 → v0A"
+
+        # Test both updates: v1=19 (0x13) → v1=22 (0x16), v2=0 (0x00) → v2=1 (0x01)
+        api_check_both = _create_firmware_check(v1=19, v2=0, last_v1=22, last_v2=1)
+        info_both = FirmwareUpdateInfo.from_api_response(
+            check=api_check_both,
+            title="Test Firmware",
+        )
+
+        # Should show hex values, not decimal
+        assert info_both.release_summary == "App firmware: v13 → v16; Parameter firmware: v00 → v01"

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Changes

### Added
- **Firmware Update Convenience Properties** - Added public properties to `FirmwareUpdateMixin` for easy access to cached firmware update information:
  - `latest_firmware_version` - returns latest version string or None
  - `firmware_update_title` - returns update title or None
  - `firmware_update_summary` - returns release summary or None
  - `firmware_update_url` - returns release notes URL or None

### Fixed
- **Firmware Update Summary Formatting** - Fixed release summary to display version numbers in hexadecimal format:
  - Changed from decimal format (e.g., "v13 → v20") to hex format (e.g., "v0D → v14")
  - Ensures version numbers match firmware version format (e.g., "IAAB-0D00")

## Testing
- ✅ Total tests: 587 (all passing, +7 from v0.3.7)
- ✅ Coverage: >85%
- ✅ Code style: 100% (ruff: 0 errors)
- ✅ Type safety: 100% (mypy strict: 0 errors)

## Changes
- src/pylxpweb/__init__.py: Bumped version to 0.3.8
- pyproject.toml: Bumped version to 0.3.8
- CHANGELOG.md: Added v0.3.8 release notes
- src/pylxpweb/devices/_firmware_update_mixin.py: Added 4 public properties
- src/pylxpweb/models.py: Fixed hex formatting in release_summary
- tests/unit/devices/test_firmware_update_mixin.py: Added 6 property tests
- tests/unit/test_firmware_update_info.py: Added hex format test