### PR TITLE
fix: update pyproject.toml version to 0.3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.9"
+version = "0.3.10"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Problem
The `pyproject.toml` file was incorrectly left at version 0.3.9 during the v0.3.10 release (PR #38).

When the release workflow built the package for tag v0.3.10, `uv build` read the version from `pyproject.toml` (not `__init__.py`), resulting in version 0.3.9 being packaged instead of 0.3.10.

## Evidence
```bash
$ git show v0.3.10:src/pylxpweb/__init__.py | grep __version__
__version__ = "0.3.10"  # ✅ Correct

$ git show v0.3.10:pyproject.toml | grep "^version"
version = "0.3.9"  # ❌ Wrong - caused build to package 0.3.9
```

Release workflow output:
```
Successfully built dist/pylxpweb-0.3.9.tar.gz
Successfully built dist/pylxpweb-0.3.9-py3-none-any.whl
```

## Solution
Updated `pyproject.toml` version to `0.3.10` to match `__init__.py`.

## Impact
After merge, the v0.3.10 tag will need to be recreated to trigger a new release with the correct version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>