### PR TITLE
fix: remove misleading Battery.max_battery_charge property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.15] - 2025-11-25
+
+### Removed
+
+- **Battery.max_battery_charge property** - Removed misleading property from individual Battery class:
+  - The API returns the bank total (840 Ah) in each individual battery's `maxBatteryCharge` field
+  - This was confusing since individual batteries have 280 Ah capacity (not 840 Ah)
+  - Use `Battery.current_full_capacity` for individual battery capacity (280 Ah)
+  - Use `BatteryBank.max_capacity` for total bank capacity (840 Ah for 3 batteries)
+
+### Testing
+
+- ✅ **Total tests**: 637 (all passing)
+- ✅ **Coverage**: >82%
+- ✅ **Code style**: 100% (ruff: 0 errors)
+- ✅ **Type safety**: 100% (mypy strict: 0 errors)
+
 ## [0.3.14] - 2025-11-25
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.14"
+version = "0.3.15"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -59,7 +59,7 @@ from .exceptions import (
 )
 from .models import FirmwareUpdateInfo, OperatingMode
 
-__version__ = "0.3.14"
+__version__ = "0.3.15"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",

--- a/src/pylxpweb/devices/battery.py
+++ b/src/pylxpweb/devices/battery.py
@@ -228,15 +228,6 @@ class Battery(BaseDevice):
         # Fallback to 0 if full capacity is 0
         return 0
 
-    @property
-    def max_battery_charge(self) -> int | None:
-        """Get maximum battery charge capacity in amp-hours.
-
-        Returns:
-            Maximum charge capacity in Ah, or None if not available.
-        """
-        return self._data.maxBatteryCharge
-
     # ========== Temperature Properties ==========
 
     @property

--- a/tests/unit/devices/batteries/test_battery.py
+++ b/tests/unit/devices/batteries/test_battery.py
@@ -305,7 +305,6 @@ class TestBatteryEnhancedProperties:
         assert battery.current_remain_capacity == 204
         assert battery.current_full_capacity == 280
         assert battery.capacity_percent == 73
-        assert battery.max_battery_charge == 840
 
     def test_cell_number_properties(
         self, mock_client: LuxpowerClient, sample_battery_module: BatteryModule

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.3.14"
+version = "0.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Remove misleading `Battery.max_battery_charge` property from individual Battery class
- The API returns bank total (840 Ah) in each individual battery's `maxBatteryCharge` field
- This was confusing since individual batteries have 280 Ah capacity
- Users should use `Battery.current_full_capacity` for individual capacity
- Bumps version to 0.3.15

## Test plan

- [x] All 637 unit tests pass
- [x] mypy strict mode passes
- [x] ruff lint/format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)