### PR TITLE
fix: derive floating-point precision from source data scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.16] - 2025-11-25
+
+### Changed
+
+- **Dynamic floating-point precision** - Calculated properties now derive precision from source data scaling:
+  - Added `get_precision(ScaleFactor)` and `get_battery_field_precision(field_name)` helper functions
+  - `Battery.power` rounds to voltage precision (2 decimals from SCALE_100)
+  - `Battery.cell_temp_delta` rounds to temperature precision (1 decimal from SCALE_10)
+  - `Battery.cell_voltage_delta` rounds to cell voltage precision (3 decimals from SCALE_1000)
+  - Eliminates floating-point artifacts (e.g., `0.0030000000000001137` → `0.003`)
+
+### Testing
+
+- ✅ **Total tests**: 637 (all passing)
+- ✅ **Coverage**: >82%
+- ✅ **Code style**: 100% (ruff: 0 errors)
+- ✅ **Type safety**: 100% (mypy strict: 0 errors)
+
 ## [0.3.15] - 2025-11-25
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.15"
+version = "0.3.16"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -59,7 +59,7 @@ from .exceptions import (
 )
 from .models import FirmwareUpdateInfo, OperatingMode
 
-__version__ = "0.3.15"
+__version__ = "0.3.16"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",

--- a/src/pylxpweb/constants/__init__.py
+++ b/src/pylxpweb/constants/__init__.py
@@ -265,6 +265,8 @@ from .scaling import (
     _get_scaling_for_field,
     # Scaling functions
     apply_scale,
+    get_battery_field_precision,
+    get_precision,
     scale_battery_value,
     scale_energy_value,
     scale_runtime_value,
@@ -442,6 +444,8 @@ __all__ = [
     "MONTHLY_ENERGY_SENSORS",
     "BATTERY_LIFETIME_SENSORS",
     "apply_scale",
+    "get_precision",
+    "get_battery_field_precision",
     "scale_runtime_value",
     "scale_battery_value",
     "scale_energy_value",

--- a/src/pylxpweb/constants/scaling.py
+++ b/src/pylxpweb/constants/scaling.py
@@ -337,6 +337,49 @@ def apply_scale(value: int | float, scale_factor: ScaleFactor) -> float:
     return float(value) / float(scale_factor.value)
 
 
+def get_precision(scale_factor: ScaleFactor) -> int:
+    """Get decimal precision from a scale factor.
+
+    Args:
+        scale_factor: ScaleFactor enum
+
+    Returns:
+        Number of decimal places (0 for SCALE_NONE, 1 for SCALE_10, etc.)
+
+    Example:
+        >>> get_precision(ScaleFactor.SCALE_10)
+        1
+        >>> get_precision(ScaleFactor.SCALE_1000)
+        3
+    """
+    if scale_factor == ScaleFactor.SCALE_NONE:
+        return 0
+    # log10 of scale factor gives decimal places
+    import math
+
+    return int(math.log10(scale_factor.value))
+
+
+def get_battery_field_precision(field_name: str) -> int:
+    """Get decimal precision for a battery module field.
+
+    Args:
+        field_name: Field name from BatteryModule model
+
+    Returns:
+        Number of decimal places for that field
+
+    Example:
+        >>> get_battery_field_precision("batMaxCellVoltage")
+        3
+        >>> get_battery_field_precision("current")
+        1
+    """
+    if field_name not in BATTERY_MODULE_SCALING:
+        return 0
+    return get_precision(BATTERY_MODULE_SCALING[field_name])
+
+
 def _get_scaling_for_field(
     field_name: str,
     data_type: Literal[

--- a/src/pylxpweb/devices/battery.py
+++ b/src/pylxpweb/devices/battery.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pylxpweb.constants import scale_battery_value
+from pylxpweb.constants import get_battery_field_precision, scale_battery_value
 
 from .base import BaseDevice
 from .models import DeviceClass, DeviceInfo, Entity, StateClass
@@ -164,9 +164,11 @@ class Battery(BaseDevice):
         """Get battery power in watts (calculated from V * I).
 
         Returns:
-            Battery power in watts.
+            Battery power in watts, rounded to voltage precision.
         """
-        return self.voltage * self.current
+        # Use voltage precision (2 decimals) as it's higher than current (1 decimal)
+        precision = get_battery_field_precision("totalVoltage")
+        return round(self.voltage * self.current, precision)
 
     # ========== State of Charge/Health ==========
 
@@ -271,9 +273,11 @@ class Battery(BaseDevice):
         """Get cell temperature imbalance (max - min).
 
         Returns:
-            Temperature difference between hottest and coolest cell in Celsius.
+            Temperature difference between hottest and coolest cell in Celsius,
+            rounded to source data precision.
         """
-        return self.max_cell_temp - self.min_cell_temp
+        precision = get_battery_field_precision("batMaxCellTemp")
+        return round(self.max_cell_temp - self.min_cell_temp, precision)
 
     # ========== Cell Voltage Properties ==========
 
@@ -318,9 +322,11 @@ class Battery(BaseDevice):
         """Get cell voltage imbalance (max - min).
 
         Returns:
-            Voltage difference between highest and lowest cell in volts.
+            Voltage difference between highest and lowest cell in volts,
+            rounded to source data precision.
         """
-        return self.max_cell_voltage - self.min_cell_voltage
+        precision = get_battery_field_precision("batMaxCellVoltage")
+        return round(self.max_cell_voltage - self.min_cell_voltage, precision)
 
     # ========== Charge Parameters ==========
 


### PR DESCRIPTION
## Summary

- Add `get_precision()` and `get_battery_field_precision()` helper functions
- `Battery.power` rounds to voltage precision (2 decimals from SCALE_100)
- `Battery.cell_temp_delta` rounds to temp precision (1 decimal from SCALE_10)
- `Battery.cell_voltage_delta` rounds to cell voltage precision (3 decimals from SCALE_1000)
- Eliminates floating-point artifacts (e.g., `0.0030000000000001137` → `0.003`)

Bumps version to 0.3.16.

## Test plan

- [x] All 637 unit tests pass
- [x] mypy strict mode passes
- [x] ruff lint/format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)