### PR TITLE
fix: make TechInfo fields optional for EU Luxpower API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.19] - 2025-11-27
+
+### Fixed
+
+- **EU Luxpower API compatibility** - Made `TechInfo` fields optional in `LoginResponse`:
+  - `techInfoType2` and `techInfo2` are now optional with `None` defaults
+  - EU API returns `techInfoCount: 1` with only one tech info item
+  - Fixes authentication failure on `https://eu.luxpowertek.com` (#53)
+
 ## [0.3.18] - 2025-11-26
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.18"
+version = "0.3.19"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -59,7 +59,7 @@ from .exceptions import (
 )
 from .models import FirmwareUpdateInfo, OperatingMode
 
-__version__ = "0.3.18"
+__version__ = "0.3.19"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -162,12 +162,16 @@ class PlantBasic(BaseModel):
 
 
 class TechInfo(BaseModel):
-    """Technical support information."""
+    """Technical support information.
+
+    Note: techInfoType2/techInfo2 are optional as some regional APIs
+    (e.g., EU Luxpower) may only return one tech info item.
+    """
 
     techInfoType1: str
     techInfo1: str
-    techInfoType2: str
-    techInfo2: str
+    techInfoType2: str | None = None
+    techInfo2: str | None = None
     techInfoCount: int
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1048,7 +1048,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.3.18"
+version = "0.3.19"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Makes `techInfoType2` and `techInfo2` optional in `TechInfo` model
- Fixes authentication failure on EU Luxpower API (`https://eu.luxpowertek.com`)
- EU API returns `techInfoCount: 1` with only one tech info item

## Test plan
- [x] All 637 unit tests pass
- [x] mypy strict passes
- [x] ruff passes

Fixes #53
Relates to #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)