### PR TITLE
feat: add system charge SOC limit convenience functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.20] - 2025-11-28
+
+### Added
+
+- **System charge SOC limit convenience functions** - New API methods for controlling battery charge limits:
+  - `set_system_charge_soc_limit(inverter_sn, percent)` - Set the maximum SOC percentage (0-101%)
+  - `get_system_charge_soc_limit(inverter_sn)` - Get current system charge SOC limit
+  - Value 101 enables top balancing mode (full charge with cell balancing for lithium batteries)
+  - Includes validation with clear error messages for out-of-range values
+
 ## [0.3.19] - 2025-11-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.19"
+version = "0.3.20"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -59,7 +59,7 @@ from .exceptions import (
 )
 from .models import FirmwareUpdateInfo, OperatingMode
 
-__version__ = "0.3.19"
+__version__ = "0.3.20"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",


### PR DESCRIPTION
## Summary

- Add `set_system_charge_soc_limit(inverter_sn, percent)` - Set the maximum SOC percentage (0-101%)
- Add `get_system_charge_soc_limit(inverter_sn)` - Get current system charge SOC limit
- Value 101 enables top balancing mode (full charge with cell balancing for lithium batteries)
- Includes validation with clear error messages for out-of-range values

## Test plan

- [x] 8 unit tests added for the new functionality
- [x] All existing tests pass (31 tests in test_control_helpers.py)
- [x] mypy strict passes
- [x] ruff check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)