### PR TITLE
fix: cache invalidation after parameter writes + new properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.22] - 2025-12-02
+
+### Fixed
+
+- **Cache invalidation after parameter writes** - Critical bug fix:
+  - `write_parameter()` now invalidates cache after successful write
+  - `write_parameters()` now invalidates cache after successful write
+  - `control_function()` now invalidates cache after successful write
+  - Fixes "value bouncing" issue where old values were returned after setting parameters
+  - Root cause: API response cache wasn't cleared, so `refresh(force=True)` still returned stale data
+
+### Added
+
+- **discharge_power_limit property** - New inverter property:
+  - `inverter.discharge_power_limit` - Get current discharge power limit (0-100%)
+  - Returns `None` when parameters not loaded
+
+- **battery_voltage_limits property** - New inverter property for battery protection:
+  - `inverter.battery_voltage_limits` - Get all battery voltage limits as dict
+  - Returns `max_charge_voltage`, `min_charge_voltage`, `max_discharge_voltage`, `min_discharge_voltage` (in volts)
+  - Returns `None` if parameters not loaded or any required voltage limit is missing
+
+### Testing
+
+- ✅ **Total tests**: 652 (all passing)
+- ✅ **Coverage**: 84.15%
+- ✅ **Code style**: 100% (ruff: 0 errors)
+- ✅ **Type safety**: 100% (mypy strict: 0 errors)
+
 ## [0.3.21] - 2025-12-02
 
 ### Added
@@ -868,6 +897,7 @@ ac_power = inverter.ac_charge_power_limit  # Property access (uses 1-hour cache)
 
 ## Version History Summary
 
+- **v0.3.22** (2025-12-02): Cache invalidation fix, discharge_power_limit, battery_voltage_limits properties
 - **v0.3.21** (2025-12-02): Added `system_charge_soc_limit` property to BaseInverter
 - **v0.3.20** (2025-11-28): System charge SOC limit convenience functions (set/get)
 - **v0.3.13** (2025-11-24): Fixed firmware "already latest" exception - now returns proper FirmwareUpdateCheck
@@ -895,6 +925,7 @@ ac_power = inverter.ac_charge_power_limit  # Property access (uses 1-hour cache)
 - **v0.1.1** (2025-11-15): Bug fixes and improvements
 - **v0.1.0** (2025-11-14): Initial release with core functionality
 
+[0.3.22]: https://github.com/joyfulhouse/pylxpweb/compare/v0.3.21...v0.3.22
 [0.3.21]: https://github.com/joyfulhouse/pylxpweb/compare/v0.3.20...v0.3.21
 [0.3.20]: https://github.com/joyfulhouse/pylxpweb/compare/v0.3.19...v0.3.20
 [0.3.19]: https://github.com/joyfulhouse/pylxpweb/compare/v0.3.18...v0.3.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.21"
+version = "0.3.22"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -59,7 +59,7 @@ from .exceptions import (
 )
 from .models import FirmwareUpdateInfo, OperatingMode
 
-__version__ = "0.3.21"
+__version__ = "0.3.22"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -1138,6 +1138,78 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         return int(value) if value is not None else None
 
     # ============================================================================
+    # Discharge Power Control
+    # ============================================================================
+
+    @property
+    def discharge_power_limit(self) -> int | None:
+        """Get current discharge power limit from cached parameters.
+
+        Universal control: All inverters support discharge power limits.
+
+        Returns:
+            Discharge power limit as percentage (0-100%), or None if not loaded
+
+        Example:
+            >>> power = inverter.discharge_power_limit
+            >>> power
+            100
+        """
+        value = self._get_parameter("HOLD_DISCHG_POWER_PERCENT_CMD", 100, int)
+        return int(value) if value is not None else None
+
+    # ============================================================================
+    # Battery Voltage Limits
+    # ============================================================================
+
+    @property
+    def battery_voltage_limits(self) -> dict[str, float] | None:
+        """Get battery voltage limits from cached parameters.
+
+        Universal control: All inverters have battery voltage protection.
+
+        Returns:
+            Dictionary with voltage limits in volts, or None if not loaded:
+            - max_charge_voltage: Maximum charge voltage (V)
+            - min_charge_voltage: Minimum charge voltage (V)
+            - max_discharge_voltage: Maximum discharge voltage (V)
+            - min_discharge_voltage: Minimum discharge voltage (V)
+
+        Example:
+            >>> limits = inverter.battery_voltage_limits
+            >>> limits
+            {'max_charge_voltage': 58.4, 'min_charge_voltage': 48.0,
+             'max_discharge_voltage': 57.6, 'min_discharge_voltage': 46.0}
+        """
+        # Return None if parameters not loaded yet
+        if self.parameters is None:
+            return None
+
+        # Check if all required params are present
+        required_keys = [
+            "HOLD_BAT_VOLT_MAX_CHG",
+            "HOLD_BAT_VOLT_MIN_CHG",
+            "HOLD_BAT_VOLT_MAX_DISCHG",
+            "HOLD_BAT_VOLT_MIN_DISCHG",
+        ]
+        if not all(key in self.parameters for key in required_keys):
+            return None
+
+        # Get values directly from parameters dict (already validated as present)
+        # Battery voltage values are stored as V * 100, so divide by 100
+        max_chg = self.parameters.get("HOLD_BAT_VOLT_MAX_CHG", 0)
+        min_chg = self.parameters.get("HOLD_BAT_VOLT_MIN_CHG", 0)
+        max_dischg = self.parameters.get("HOLD_BAT_VOLT_MAX_DISCHG", 0)
+        min_dischg = self.parameters.get("HOLD_BAT_VOLT_MIN_DISCHG", 0)
+
+        return {
+            "max_charge_voltage": float(max_chg) / 100.0,
+            "min_charge_voltage": float(min_chg) / 100.0,
+            "max_discharge_voltage": float(max_dischg) / 100.0,
+            "min_discharge_voltage": float(min_dischg) / 100.0,
+        }
+
+    # ============================================================================
     # Operating Mode Control (Issue #14)
     # ============================================================================
 

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -165,7 +165,13 @@ class ControlEndpoints(BaseEndpoint):
         response = await self.client._request(
             "POST", "/WManage/web/maintain/remoteSet/write", data=data
         )
-        return SuccessResponse.model_validate(response)
+        result = SuccessResponse.model_validate(response)
+
+        # Invalidate cache after successful write to ensure fresh data on next read
+        if result.success:
+            self.client.invalidate_cache_for_device(inverter_sn)
+
+        return result
 
     async def write_parameters(
         self,
@@ -218,7 +224,13 @@ class ControlEndpoints(BaseEndpoint):
         response = await self.client._request(
             "POST", "/WManage/web/maintain/remoteSet/write", data=data
         )
-        return SuccessResponse.model_validate(response)
+        result = SuccessResponse.model_validate(response)
+
+        # Invalidate cache after successful write to ensure fresh data on next read
+        if result.success:
+            self.client.invalidate_cache_for_device(inverter_sn)
+
+        return result
 
     async def control_function(
         self,
@@ -275,7 +287,13 @@ class ControlEndpoints(BaseEndpoint):
         response = await self.client._request(
             "POST", "/WManage/web/maintain/remoteSet/functionControl", data=data
         )
-        return SuccessResponse.model_validate(response)
+        result = SuccessResponse.model_validate(response)
+
+        # Invalidate cache after successful write to ensure fresh data on next read
+        if result.success:
+            self.client.invalidate_cache_for_device(inverter_sn)
+
+        return result
 
     async def start_quick_charge(
         self, inverter_sn: str, client_type: str = "WEB"

--- a/uv.lock
+++ b/uv.lock
@@ -1048,7 +1048,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.3.21"
+version = "0.3.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

### Cache Invalidation Bug Fix (Critical)

**Root Cause**: When `write_parameter()` or `control_function()` successfully wrote to the API, the response cache wasn't invalidated. This meant that subsequent calls to `refresh(force=True)` would still return cached (stale) data.

**Fix**: Added `client.invalidate_cache_for_device(inverter_sn)` after successful writes in:
- `write_parameter()` - Single parameter writes
- `write_parameters()` - Batch parameter writes  
- `control_function()` - Function enable/disable operations

This fixes the "value bouncing" issue where the UI would show the old value after setting a parameter.

### New Properties

**discharge_power_limit** (`base.py:1144-1159`)
- `inverter.discharge_power_limit` - Get current discharge power limit (0-100%)
- Returns `None` when parameters not loaded

**battery_voltage_limits** (`base.py:1164-1210`)
- `inverter.battery_voltage_limits` - Get all battery voltage limits as dict
- Returns `max_charge_voltage`, `min_charge_voltage`, `max_discharge_voltage`, `min_discharge_voltage` (in volts)
- Returns `None` if parameters not loaded or any required voltage limit is missing

## Test plan

- [x] Run `uv run pytest tests/unit/` - 652 tests passing
- [x] Run `uv run mypy src/pylxpweb/ --strict` - no issues
- [x] Run `uv run ruff check && uv run ruff format` - no issues
- [x] Coverage: 84.15%
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)