### PR TITLE
fix: make parallelGroups optional in PlantBasic model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.24] - 2025-12-03
+
+### Fixed
+
+- **Optional parallelGroups in PlantBasic** - Made `parallelGroups` field optional with empty list default to support devices that don't return parallel group data (e.g., 12000XP) (Issue #67 reported by @twistedroutes)
+
 ## [0.3.23] - 2025-12-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.23"
+version = "0.3.24"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -59,7 +59,7 @@ from .exceptions import (
 )
 from .models import FirmwareUpdateInfo, OperatingMode
 
-__version__ = "0.3.23"
+__version__ = "0.3.24"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -152,14 +152,17 @@ class ParallelGroupBasic(BaseModel):
 
 
 class PlantBasic(BaseModel):
-    """Plant information from login response."""
+    """Plant information from login response.
+
+    Note: parallelGroups may not be present for all device types (e.g., 12000XP).
+    """
 
     plantId: int
     name: str
     timezoneHourOffset: int
     timezoneMinuteOffset: int
     inverters: list[InverterBasic]
-    parallelGroups: list[ParallelGroupBasic]
+    parallelGroups: list[ParallelGroupBasic] = []
 
 
 class TechInfo(BaseModel):


### PR DESCRIPTION
## Summary

- Made `parallelGroups` field optional with empty list default in `PlantBasic` model
- Some devices (e.g., 12000XP) don't return this field in the API response, causing a Pydantic validation error

## Test plan

- [x] All 652 unit tests pass
- [x] mypy strict mode passes
- [x] ruff linting passes

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)