### PR TITLE
feat: Add battery backup control mode methods (FUNC_BATTERY_BACKUP_CTRL)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.3.24"
+version = "0.3.25"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -818,6 +818,48 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         """
         return await self._client.api.control.get_battery_backup_status(self.serial_number)
 
+    async def enable_battery_backup_ctrl(self) -> bool:
+        """Enable battery backup control mode (working mode).
+
+        This controls FUNC_BATTERY_BACKUP_CTRL, which is distinct from
+        enable_battery_backup() which controls FUNC_EPS_EN (EPS/off-grid mode).
+
+        Battery backup control is a working mode setting that affects how
+        the inverter manages battery reserves for backup power.
+
+        Universal control: All inverters support this working mode.
+
+        Returns:
+            True if successful
+
+        Example:
+            >>> await inverter.enable_battery_backup_ctrl()
+            True
+        """
+        result = await self._client.api.control.enable_battery_backup_ctrl(self.serial_number)
+        return result.success
+
+    async def disable_battery_backup_ctrl(self) -> bool:
+        """Disable battery backup control mode (working mode).
+
+        This controls FUNC_BATTERY_BACKUP_CTRL, which is distinct from
+        disable_battery_backup() which controls FUNC_EPS_EN (EPS/off-grid mode).
+
+        Battery backup control is a working mode setting that affects how
+        the inverter manages battery reserves for backup power.
+
+        Universal control: All inverters support this working mode.
+
+        Returns:
+            True if successful
+
+        Example:
+            >>> await inverter.disable_battery_backup_ctrl()
+            True
+        """
+        result = await self._client.api.control.disable_battery_backup_ctrl(self.serial_number)
+        return result.success
+
     # ============================================================================
     # AC Charge Power Control (Issue #9)
     # ============================================================================

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -485,6 +485,62 @@ class ControlEndpoints(BaseEndpoint):
             inverter_sn, "FUNC_EPS_EN", False, client_type=client_type
         )
 
+    async def enable_battery_backup_ctrl(
+        self, inverter_sn: str, client_type: str = "WEB"
+    ) -> SuccessResponse:
+        """Enable battery backup control mode (working mode).
+
+        This controls FUNC_BATTERY_BACKUP_CTRL, which is distinct from
+        FUNC_EPS_EN (EPS/off-grid mode). Battery backup control is a
+        working mode setting that affects how the inverter manages
+        battery reserves for backup power.
+
+        Convenience wrapper for control_function(..., "FUNC_BATTERY_BACKUP_CTRL", True).
+
+        Args:
+            inverter_sn: Inverter serial number
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Example:
+            >>> result = await client.control.enable_battery_backup_ctrl("1234567890")
+            >>> result.success
+            True
+        """
+        return await self.control_function(
+            inverter_sn, "FUNC_BATTERY_BACKUP_CTRL", True, client_type=client_type
+        )
+
+    async def disable_battery_backup_ctrl(
+        self, inverter_sn: str, client_type: str = "WEB"
+    ) -> SuccessResponse:
+        """Disable battery backup control mode (working mode).
+
+        This controls FUNC_BATTERY_BACKUP_CTRL, which is distinct from
+        FUNC_EPS_EN (EPS/off-grid mode). Battery backup control is a
+        working mode setting that affects how the inverter manages
+        battery reserves for backup power.
+
+        Convenience wrapper for control_function(..., "FUNC_BATTERY_BACKUP_CTRL", False).
+
+        Args:
+            inverter_sn: Inverter serial number
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Example:
+            >>> result = await client.control.disable_battery_backup_ctrl("1234567890")
+            >>> result.success
+            True
+        """
+        return await self.control_function(
+            inverter_sn, "FUNC_BATTERY_BACKUP_CTRL", False, client_type=client_type
+        )
+
     async def enable_normal_mode(
         self, inverter_sn: str, client_type: str = "WEB"
     ) -> SuccessResponse:

--- a/uv.lock
+++ b/uv.lock
@@ -1101,7 +1101,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.3.23"
+version = "0.3.25"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Added distinct methods for controlling `FUNC_BATTERY_BACKUP_CTRL` which is separate from `FUNC_EPS_EN` (EPS/off-grid mode).

## New Methods

### ControlEndpoint
- `enable_battery_backup_ctrl(inverter_sn)` - Enable battery backup control mode
- `disable_battery_backup_ctrl(inverter_sn)` - Disable battery backup control mode

### Inverter Device
- `enable_battery_backup_ctrl()` - Enable battery backup control mode
- `disable_battery_backup_ctrl()` - Disable battery backup control mode

## Background

There are two distinct battery backup related parameters:
- `FUNC_EPS_EN`: Controls EPS (Emergency Power Supply) off-grid mode
- `FUNC_BATTERY_BACKUP_CTRL`: Controls battery backup working mode

Previously only `FUNC_EPS_EN` had dedicated methods. This PR adds methods for `FUNC_BATTERY_BACKUP_CTRL`.

Related: joyfulhouse/eg4_web_monitor#50

🤖 Generated with [Claude Code](https://claude.com/claude-code)