### PR TITLE
feat(control): Add green mode (off-grid) convenience methods

### DIFF
--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -872,6 +872,91 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         return result.success
 
     # ============================================================================
+    # Green Mode Control (Off-Grid Mode in Web Monitor)
+    # ============================================================================
+
+    async def enable_green_mode(self) -> bool:
+        """Enable green mode (off-grid mode in the web monitoring display).
+
+        Green Mode controls the off-grid operating mode toggle visible in the
+        EG4 web monitoring interface. When enabled, the inverter operates in
+        an off-grid optimized configuration.
+
+        Note: This is FUNC_GREEN_EN in register 110, distinct from FUNC_EPS_EN
+        (battery backup/EPS mode) in register 21.
+
+        Universal control: All inverters support green mode.
+
+        Returns:
+            True if successful
+
+        Example:
+            >>> await inverter.enable_green_mode()
+            True
+        """
+        result = await self._client.api.control.enable_green_mode(self.serial_number)
+        return result.success
+
+    async def disable_green_mode(self) -> bool:
+        """Disable green mode (off-grid mode in the web monitoring display).
+
+        Green Mode controls the off-grid operating mode toggle visible in the
+        EG4 web monitoring interface. When disabled, the inverter operates in
+        standard grid-tied configuration.
+
+        Note: This is FUNC_GREEN_EN in register 110, distinct from FUNC_EPS_EN
+        (battery backup/EPS mode) in register 21.
+
+        Universal control: All inverters support green mode.
+
+        Returns:
+            True if successful
+
+        Example:
+            >>> await inverter.disable_green_mode()
+            True
+        """
+        result = await self._client.api.control.disable_green_mode(self.serial_number)
+        return result.success
+
+    async def get_green_mode_status(self) -> bool:
+        """Get current green mode (off-grid mode) status.
+
+        Green Mode controls the off-grid operating mode toggle visible in the
+        EG4 web monitoring interface.
+
+        Universal control: All inverters support green mode.
+
+        Returns:
+            True if green mode is enabled, False otherwise
+
+        Example:
+            >>> is_enabled = await inverter.get_green_mode_status()
+            >>> is_enabled
+            True
+        """
+        return await self._client.api.control.get_green_mode_status(self.serial_number)
+
+    @property
+    def green_mode_enabled(self) -> bool | None:
+        """Get green mode status from cached parameters.
+
+        Green Mode controls the off-grid operating mode toggle visible in the
+        EG4 web monitoring interface.
+
+        Returns:
+            True if green mode is enabled, False if disabled,
+            or None if parameters not loaded
+
+        Example:
+            >>> enabled = inverter.green_mode_enabled
+            >>> enabled
+            True
+        """
+        value = self._get_parameter("FUNC_GREEN_EN", False, bool)
+        return bool(value) if value is not None else None
+
+    # ============================================================================
     # AC Charge Power Control (Issue #9)
     # ============================================================================
 

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -925,6 +925,93 @@ class ControlEndpoints(BaseEndpoint):
         value = response.parameters.get("FUNC_GRID_PEAK_SHAVING", False)
         return bool(value)
 
+    # ============================================================================
+    # Green Mode Controls (Off-Grid Mode in Web Monitor)
+    # ============================================================================
+
+    async def enable_green_mode(
+        self, inverter_sn: str, client_type: str = "WEB"
+    ) -> SuccessResponse:
+        """Enable green mode (off-grid mode in the web monitoring display).
+
+        Green Mode controls the off-grid operating mode toggle visible in the
+        EG4 web monitoring interface. When enabled, the inverter operates in
+        an off-grid optimized configuration.
+
+        Note: This is FUNC_GREEN_EN in register 110, distinct from FUNC_EPS_EN
+        (battery backup/EPS mode) in register 21.
+
+        Convenience wrapper for control_function(..., "FUNC_GREEN_EN", True).
+
+        Args:
+            inverter_sn: Inverter serial number
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Example:
+            >>> result = await client.control.enable_green_mode("1234567890")
+            >>> result.success
+            True
+        """
+        return await self.control_function(
+            inverter_sn, "FUNC_GREEN_EN", True, client_type=client_type
+        )
+
+    async def disable_green_mode(
+        self, inverter_sn: str, client_type: str = "WEB"
+    ) -> SuccessResponse:
+        """Disable green mode (off-grid mode in the web monitoring display).
+
+        Green Mode controls the off-grid operating mode toggle visible in the
+        EG4 web monitoring interface. When disabled, the inverter operates in
+        standard grid-tied configuration.
+
+        Note: This is FUNC_GREEN_EN in register 110, distinct from FUNC_EPS_EN
+        (battery backup/EPS mode) in register 21.
+
+        Convenience wrapper for control_function(..., "FUNC_GREEN_EN", False).
+
+        Args:
+            inverter_sn: Inverter serial number
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Example:
+            >>> result = await client.control.disable_green_mode("1234567890")
+            >>> result.success
+            True
+        """
+        return await self.control_function(
+            inverter_sn, "FUNC_GREEN_EN", False, client_type=client_type
+        )
+
+    async def get_green_mode_status(self, inverter_sn: str) -> bool:
+        """Get current green mode (off-grid mode) status.
+
+        Green Mode controls the off-grid operating mode toggle visible in the
+        EG4 web monitoring interface.
+
+        Reads register 110 (system functions) and extracts FUNC_GREEN_EN bit.
+
+        Args:
+            inverter_sn: Inverter serial number
+
+        Returns:
+            bool: True if green mode is enabled, False otherwise
+
+        Example:
+            >>> enabled = await client.control.get_green_mode_status("1234567890")
+            >>> if enabled:
+            >>>     print("Green mode (off-grid) is active")
+        """
+        response = await self.read_parameters(inverter_sn, 110, 1)
+        value = response.parameters.get("FUNC_GREEN_EN", False)
+        return bool(value)
+
     async def read_device_parameters_ranges(self, inverter_sn: str) -> dict[str, int | bool]:
         """Read all device parameters across three common register ranges.
 


### PR DESCRIPTION
## Summary

- Add dedicated convenience methods for controlling Green Mode (`FUNC_GREEN_EN`), which is the off-grid mode toggle in the EG4 web monitoring display
- Add `enable_green_mode()`, `disable_green_mode()`, `get_green_mode_status()` to ControlEndpoints
- Add corresponding methods and `green_mode_enabled` property to BaseInverter class
- Add unit tests for all green mode functionality

## Details

Green Mode is located in Register 110 (system functions bit field), distinct from `FUNC_EPS_EN` (battery backup/EPS mode) in Register 21.

## Test plan

- [x] All 5 new unit tests pass
- [x] Ruff linting passes
- [ ] Integration test with real inverter (manual)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)