### PR TITLE
fix: Remove misleading default values from SOC/power limit properties

### DIFF
--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -1159,15 +1159,24 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         Universal control: All inverters support AC charge SOC limits.
 
         Returns:
-            Current SOC limit percentage, or None if parameters not loaded
+            Current SOC limit percentage (0-100), or None if parameters not loaded
+            or parameter not found
 
         Example:
             >>> limit = inverter.ac_charge_soc_limit
             >>> limit
             90
         """
-        value = self._get_parameter("HOLD_AC_CHARGE_SOC_LIMIT", 100, int)
-        return int(value) if value is not None else None
+        if self.parameters is None:
+            return None
+        value = self.parameters.get("HOLD_AC_CHARGE_SOC_LIMIT")
+        if value is None:
+            return None
+        try:
+            int_value = int(value)
+            return int_value if 0 <= int_value <= 100 else None
+        except (ValueError, TypeError):
+            return None
 
     @property
     def system_charge_soc_limit(self) -> int | None:
@@ -1181,14 +1190,23 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
 
         Returns:
             Current SOC limit percentage (0-101), or None if parameters not loaded
+            or parameter not found
 
         Example:
             >>> limit = inverter.system_charge_soc_limit
             >>> limit
             80
         """
-        value = self._get_parameter("HOLD_SYSTEM_CHARGE_SOC_LIMIT", 100, int)
-        return int(value) if value is not None else None
+        if self.parameters is None:
+            return None
+        value = self.parameters.get("HOLD_SYSTEM_CHARGE_SOC_LIMIT")
+        if value is None:
+            return None
+        try:
+            int_value = int(value)
+            return int_value if 0 <= int_value <= 101 else None
+        except (ValueError, TypeError):
+            return None
 
     # ============================================================================
     # Battery Current Control (Issue #13)
@@ -1296,14 +1314,23 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
 
         Returns:
             Discharge power limit as percentage (0-100%), or None if not loaded
+            or parameter not found
 
         Example:
             >>> power = inverter.discharge_power_limit
             >>> power
             100
         """
-        value = self._get_parameter("HOLD_DISCHG_POWER_PERCENT_CMD", 100, int)
-        return int(value) if value is not None else None
+        if self.parameters is None:
+            return None
+        value = self.parameters.get("HOLD_DISCHG_POWER_PERCENT_CMD")
+        if value is None:
+            return None
+        try:
+            int_value = int(value)
+            return int_value if 0 <= int_value <= 100 else None
+        except (ValueError, TypeError):
+            return None
 
     # ============================================================================
     # Battery Voltage Limits

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -90,7 +90,7 @@ class HybridInverter(GenericInverter):
         return {
             "enabled": ac_charge_enabled,
             "power_percent": ac_params.get("HOLD_AC_CHARGE_POWER_CMD", 0),
-            "soc_limit": ac_params.get("HOLD_AC_CHARGE_SOC_LIMIT", 100),
+            "soc_limit": ac_params.get("HOLD_AC_CHARGE_SOC_LIMIT"),
             "schedule1_enabled": bool(ac_params.get("HOLD_AC_CHARGE_ENABLE_1", 0)),
             "schedule2_enabled": bool(ac_params.get("HOLD_AC_CHARGE_ENABLE_2", 0)),
         }
@@ -250,7 +250,7 @@ class HybridInverter(GenericInverter):
 
         return {
             "charge_power_percent": params.get("HOLD_AC_CHARGE_POWER_CMD", 0),
-            "discharge_power_percent": params.get("HOLD_DISCHG_POWER_CMD", 100),
+            "discharge_power_percent": params.get("HOLD_DISCHG_POWER_CMD"),
         }
 
     async def set_discharge_power(self, power_percent: int) -> bool:

--- a/tests/unit/devices/inverters/test_parameter_initialization.py
+++ b/tests/unit/devices/inverters/test_parameter_initialization.py
@@ -238,9 +238,9 @@ class TestParameterInitialization:
         inverter.parameters = {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 100}
         assert inverter.system_charge_soc_limit == 100
 
-        # Case 5: Parameters loaded but key missing - should return default (100)
+        # Case 5: Parameters loaded but key missing - should return None (no default)
         inverter.parameters = {"OTHER_PARAM": 50}
-        assert inverter.system_charge_soc_limit == 100  # Default value
+        assert inverter.system_charge_soc_limit is None  # No default, returns None
 
     def test_discharge_power_limit_property(self, mock_client: LuxpowerClient) -> None:
         """Test discharge_power_limit property returns correct values.
@@ -267,9 +267,9 @@ class TestParameterInitialization:
         inverter.parameters = {"HOLD_DISCHG_POWER_PERCENT_CMD": 0}
         assert inverter.discharge_power_limit == 0
 
-        # Case 5: Parameters loaded but key missing - should return default (100)
+        # Case 5: Parameters loaded but key missing - should return None (no default)
         inverter.parameters = {"OTHER_PARAM": 50}
-        assert inverter.discharge_power_limit == 100  # Default value
+        assert inverter.discharge_power_limit is None  # No default, returns None
 
     def test_battery_voltage_limits_property(self, mock_client: LuxpowerClient) -> None:
         """Test battery_voltage_limits property returns correct scaled values.


### PR DESCRIPTION
## Summary

- Remove 100 as default return value when SOC/power limit parameters are not found in cache
- Properties now return `None` instead of misleading defaults when parameters aren't loaded

## Problem

Properties like `ac_charge_soc_limit`, `system_charge_soc_limit`, and `discharge_power_limit` were returning `100` as a default when the parameter key was not found in the parameters cache. This caused:

1. **Incorrect values displayed in Home Assistant** - When parameters weren't fully loaded or cache was invalidated, sensors would show 100% instead of "Unknown"
2. **User confusion** - Users reported that toggling Battery Backup Mode caused AC Charge SOC Limit to appear as 100% (see joyfulhouse/eg4_web_monitor#61)

## Root Cause

The `_get_parameter()` calls used `100` as the default value:
```python
# Before
value = self._get_parameter("HOLD_AC_CHARGE_SOC_LIMIT", 100, int)
```

When `self.parameters` was not None but the key was missing, this returned `100` instead of `None`.

## Solution

Changed affected properties to explicitly check for the key and return `None` when not found:
```python
# After
if self.parameters is None:
    return None
value = self.parameters.get("HOLD_AC_CHARGE_SOC_LIMIT")
if value is None:
    return None
```

## Changes

| Property | Before | After |
|----------|--------|-------|
| `ac_charge_soc_limit` | Returns 100 if key missing | Returns None |
| `system_charge_soc_limit` | Returns 100 if key missing | Returns None |
| `discharge_power_limit` | Returns 100 if key missing | Returns None |
| `get_ac_charge_settings()` | soc_limit defaults to 100 | Returns None |
| `get_charge_discharge_power()` | discharge_power_percent defaults to 100 | Returns None |

## Test Plan

- [x] Updated unit tests to expect `None` instead of `100` for missing parameters
- [x] All 690 tests pass
- [x] Ruff linting passes

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)