### PR TITLE
feat(devices): Add dongle connection status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-12-24
+
+### Added
+
+- **Dongle connection status** - New endpoint to check if dongle (datalog) is online ([#59](https://github.com/joyfulhouse/pylxpweb/issues/59)):
+  - `DongleStatus` model with `is_online` and `status_text` properties
+  - `client.api.devices.get_dongle_status(datalog_serial)` - Check dongle connectivity
+  - API returns `msg: "current"` when online, empty when offline
+  - Enables detection of stale inverter data when dongle is disconnected
+
+### Example Usage
+
+```python
+# Get inverter info to find dongle serial
+info = await client.api.devices.get_inverter_info("4512670118")
+
+# Check dongle status
+status = await client.api.devices.get_dongle_status(info.datalogSn)
+if status.is_online:
+    print("Dongle is online - data is current")
+else:
+    print("Dongle is offline - inverter data may be stale")
+```
+
 ## [0.3.24] - 2025-12-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -57,9 +57,9 @@ from .exceptions import (
     LuxpowerDeviceOfflineError,
     LuxpowerError,
 )
-from .models import FirmwareUpdateInfo, OperatingMode
+from .models import DongleStatus, FirmwareUpdateInfo, OperatingMode
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __all__ = [
     "LuxpowerClient",
     "LuxpowerError",
@@ -77,6 +77,7 @@ __all__ = [
     "ExportEndpoints",
     "FirmwareEndpoints",
     # Models
+    "DongleStatus",
     "FirmwareUpdateInfo",
     # Enums
     "OperatingMode",

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -1290,3 +1290,49 @@ class FirmwareUpdateInfo(BaseModel):
             app_filename=details.lastV1FileName,
             param_filename=details.lastV2FileName,
         )
+
+
+# Dongle Connection Status Models
+
+
+class DongleStatus(BaseModel):
+    """Dongle connection status from findOnlineDatalog endpoint.
+
+    The dongle (datalog) is the communication module that connects
+    inverters to the cloud monitoring service. This model represents
+    its current online/offline status.
+
+    The API returns:
+    - msg: "current" when dongle is actively communicating
+    - msg: "" (empty) when dongle is offline/not communicating
+
+    Example:
+        ```python
+        status = await client.devices.get_dongle_status("BC34000380")
+        if status.is_online:
+            print("Dongle is online and communicating")
+        else:
+            print("Dongle is offline - inverter data may be stale")
+        ```
+    """
+
+    success: bool
+    msg: str = ""
+
+    @property
+    def is_online(self) -> bool:
+        """Check if the dongle is currently online.
+
+        Returns:
+            True if dongle is actively communicating, False otherwise.
+        """
+        return self.msg == "current"
+
+    @property
+    def status_text(self) -> str:
+        """Get human-readable status text.
+
+        Returns:
+            "Online" or "Offline" based on dongle status.
+        """
+        return "Online" if self.is_online else "Offline"


### PR DESCRIPTION
## Summary

- Add new endpoint to check if dongle (datalog) is online ([#59](https://github.com/joyfulhouse/pylxpweb/issues/59))
- `DongleStatus` model with `is_online` and `status_text` properties
- `get_dongle_status(datalog_serial)` method on DeviceEndpoints
- API returns `msg: "current"` when online, empty when offline

This enables detection of stale inverter data when the dongle is disconnected from the cloud monitoring service.

## Example Usage

```python
# Get inverter info to find dongle serial
info = await client.api.devices.get_inverter_info("4512670118")

# Check dongle status
status = await client.api.devices.get_dongle_status(info.datalogSn)
if status.is_online:
    print("Dongle is online - data is current")
else:
    print("Dongle is offline - inverter data may be stale")
```

## Test plan

- [x] Unit tests for `DongleStatus` model (5 tests)
- [x] All 695 existing tests pass
- [x] Linting passes (`ruff check --fix && ruff format`)
- [x] Type checking passes (`mypy --strict`)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)