### PR TITLE
feat: typed consumed-surface public API (0.9.29) for the integration seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.29] - 2026-05-30
+
+### Added
+
+- **Typed consumed-surface public API** (typed seam contract): export the device hierarchy
+  (`BaseInverter`, `Battery`, `BatteryBank`, `MIDDevice`, `ParallelGroup`, `Station`), transport
+  data classes (`InverterRuntimeData`, `InverterEnergyData`, `BatteryData`, `BatteryBankData`,
+  `MidboxRuntimeData`), and feature types (`InverterFeatures`, `InverterModelInfo`,
+  `InverterFamily`, `GridType`) from the package root so consumers import a stable, typed surface.
+- **Public transport accessors** on `BaseInverter` and `MIDDevice`: `transport`, `transport_runtime`,
+  `transport_energy`, `transport_battery` (read-only) — replacing private `_transport*` poking by
+  consumers.
+- **`BaseInverter.set_cache_ttls(*, runtime=, energy=, battery=)`**: public API to pin transport-data
+  cache TTLs to a consumer's polling interval (replaces writing private `_*_cache_ttl` attributes).
+- **`BaseInverter.has_runtime_data`** and **`BaseInverter.power_rating_text`** properties, and
+  **`BatteryBank.cycle_count`** property — close device-object seam gaps so the consumed property
+  surface resolves real values instead of None.
+
 ## [0.9.26] - 2026-03-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.28"
+version = "0.9.29"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -42,6 +42,20 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 
 from .client import LuxpowerClient
+from .devices import (
+    BaseInverter,
+    Battery,
+    BatteryBank,
+    MIDDevice,
+    ParallelGroup,
+    Station,
+)
+from .devices.inverters import (
+    GridType,
+    InverterFamily,
+    InverterFeatures,
+    InverterModelInfo,
+)
 from .endpoints import (
     AnalyticsEndpoints,
     ControlEndpoints,
@@ -65,6 +79,13 @@ from .models import (
     DongleStatus,
     FirmwareUpdateInfo,
     OperatingMode,
+)
+from .transports.data import (
+    BatteryBankData,
+    BatteryData,
+    InverterEnergyData,
+    InverterRuntimeData,
+    MidboxRuntimeData,
 )
 
 try:
@@ -94,4 +115,22 @@ __all__ = [
     "FirmwareUpdateInfo",
     # Enums
     "OperatingMode",
+    # Device hierarchy (consumed-surface public API)
+    "Station",
+    "ParallelGroup",
+    "BaseInverter",
+    "MIDDevice",
+    "Battery",
+    "BatteryBank",
+    # Transport data classes (consumed-surface public API)
+    "InverterRuntimeData",
+    "InverterEnergyData",
+    "BatteryData",
+    "BatteryBankData",
+    "MidboxRuntimeData",
+    # Feature detection (consumed-surface public API)
+    "InverterFeatures",
+    "InverterModelInfo",
+    "InverterFamily",
+    "GridType",
 ]

--- a/src/pylxpweb/devices/battery_bank.py
+++ b/src/pylxpweb/devices/battery_bank.py
@@ -248,6 +248,25 @@ class BatteryBank(BaseDevice):
         return max(b.cell_voltage_delta for b in self.batteries)
 
     @property
+    def cycle_count(self) -> int | None:
+        """Get the bank-level cycle count from transport BMS register data.
+
+        Sourced from the parent inverter's transport :class:`BatteryBankData`
+        (Modbus reg 106) — the same field the local data path consumes. Cloud
+        ``BatteryInfo`` carries no bank cycle count, so this is None in
+        cloud-only mode.
+
+        Returns:
+            Bank cycle count, or None if no transport bank data is available.
+        """
+        if self._inverter is None:
+            return None
+        transport_battery = self._inverter.transport_battery
+        if transport_battery is None:
+            return None
+        return transport_battery.cycle_count
+
+    @property
     def cycle_count_delta(self) -> int | None:
         """Get cycle count spread across batteries (max - min).
 

--- a/src/pylxpweb/devices/inverters/_runtime_properties.py
+++ b/src/pylxpweb/devices/inverters/_runtime_properties.py
@@ -605,3 +605,17 @@ class InverterRuntimePropertiesMixin:
         if self._runtime is None:
             return ""
         return self._runtime.powerRatingText
+
+    @property
+    def power_rating_text(self) -> str:
+        """Power rating text (alias of :attr:`power_rating`).
+
+        Mirrors the cloud ``powerRatingText`` field name so consumers mapping
+        the device by that attribute resolve a real value instead of None.
+        """
+        return self.power_rating
+
+    @property
+    def has_runtime_data(self) -> bool:
+        """Whether any runtime data (cloud or transport) is currently loaded."""
+        return self._runtime is not None or self._transport_runtime is not None

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -22,7 +22,11 @@ from pylxpweb.constants import (
 )
 from pylxpweb.exceptions import LuxpowerAPIError, LuxpowerConnectionError, LuxpowerDeviceError
 from pylxpweb.models import OperatingMode
-from pylxpweb.transports.data import InverterEnergyData
+from pylxpweb.transports.data import (
+    BatteryBankData,
+    InverterEnergyData,
+    InverterRuntimeData,
+)
 
 from .._firmware_update_mixin import FirmwareUpdateMixin
 from ..base import BaseDevice
@@ -94,16 +98,16 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         # Runtime data (refreshed frequently) - PRIVATE: use properties for access
         # HTTP API returns InverterRuntime, transport returns InverterRuntimeData
         self._runtime: InverterRuntime | None = None
-        self._transport_runtime: Any | None = None  # InverterRuntimeData when using transport
+        self._transport_runtime: InverterRuntimeData | None = None
 
         # Energy data (refreshed less frequently) - PRIVATE: use properties for access
         # HTTP API returns EnergyInfo, transport returns InverterEnergyData
         self._energy: EnergyInfo | None = None
-        self._transport_energy: Any | None = None  # InverterEnergyData when using transport
+        self._transport_energy: InverterEnergyData | None = None
 
         # Battery bank (aggregate data and individual batteries) - PRIVATE: use properties
         self._battery_bank: Any | None = None  # Will be BatteryBank object
-        self._transport_battery: Any | None = None  # BatteryBankData when using transport
+        self._transport_battery: BatteryBankData | None = None
 
         # Parameters (configuration registers, refreshed hourly)
         self.parameters: dict[str, Any] | None = None
@@ -191,6 +195,56 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             self.serial_number,
             transport_type,
         )
+
+    def set_cache_ttls(
+        self,
+        *,
+        runtime: timedelta | None = None,
+        energy: timedelta | None = None,
+        battery: timedelta | None = None,
+    ) -> None:
+        """Set explicit transport-data cache TTLs (public configuration API).
+
+        Consumers that poll on a custom interval (e.g. Home Assistant) can pin
+        the runtime/energy/battery caches to that interval instead of the
+        transport-type defaults applied by :meth:`set_transport_cache_ttls`.
+        Only the TTLs passed are changed; omitted ones keep their current value.
+
+        Args:
+            runtime: New TTL for runtime data, or None to leave unchanged.
+            energy: New TTL for energy data, or None to leave unchanged.
+            battery: New TTL for battery data, or None to leave unchanged.
+        """
+        if runtime is not None:
+            self._runtime_cache_ttl = runtime
+        if energy is not None:
+            self._energy_cache_ttl = energy
+        if battery is not None:
+            self._battery_cache_ttl = battery
+
+    # ============================================================================
+    # Transport Accessors (public, read-only)
+    # ============================================================================
+
+    @property
+    def transport(self) -> InverterTransport | None:
+        """Attached local transport, or None in cloud-only mode."""
+        return self._transport
+
+    @property
+    def transport_runtime(self) -> InverterRuntimeData | None:
+        """Runtime data from the local transport, or None when not transport-backed."""
+        return self._transport_runtime
+
+    @property
+    def transport_energy(self) -> InverterEnergyData | None:
+        """Energy data from the local transport, or None when not transport-backed."""
+        return self._transport_energy
+
+    @property
+    def transport_battery(self) -> BatteryBankData | None:
+        """Battery-bank data from the local transport, or None when not transport-backed."""
+        return self._transport_battery
 
     # ============================================================================
     # Factory Methods

--- a/src/pylxpweb/devices/mid_device.py
+++ b/src/pylxpweb/devices/mid_device.py
@@ -82,6 +82,16 @@ class MIDDevice(FirmwareUpdateMixin, MIDRuntimePropertiesMixin, BaseDevice):
         # Local transport for hybrid/local-only mode (optional)
         self._transport: InverterTransport | None = None
 
+    @property
+    def transport(self) -> InverterTransport | None:
+        """Attached local transport, or None in cloud-only mode."""
+        return self._transport
+
+    @property
+    def transport_runtime(self) -> MidboxRuntimeData | None:
+        """Runtime data from the local transport, or None when not transport-backed."""
+        return self._transport_runtime
+
     def set_max_system_power(self, total_kw: float) -> None:
         """Set the max system power behind this GridBOSS.
 

--- a/tests/unit/test_seam_public_api.py
+++ b/tests/unit/test_seam_public_api.py
@@ -1,0 +1,217 @@
+"""Unit tests for the typed pylxpweb<->consumer seam public API.
+
+These cover the public surface added for the typed-contract epic: the
+consumed-surface exports in ``pylxpweb.__all__``, the read-only transport
+accessors and ``set_cache_ttls`` on inverters, and the device properties that
+close the seam gaps (``power_rating_text`` / ``has_runtime_data`` on inverters,
+``cycle_count`` on the battery bank).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import Mock
+
+import pytest
+
+import pylxpweb
+from pylxpweb import (
+    BaseInverter,
+    Battery,
+    BatteryBank,
+    BatteryBankData,
+    GridType,
+    InverterEnergyData,
+    InverterFamily,
+    InverterFeatures,
+    InverterModelInfo,
+    InverterRuntimeData,
+    LuxpowerClient,
+    MidboxRuntimeData,
+    MIDDevice,
+    ParallelGroup,
+    Station,
+)
+from pylxpweb.devices.inverters.hybrid import HybridInverter
+from pylxpweb.models import BatteryInfo
+
+
+@pytest.fixture
+def mock_client() -> LuxpowerClient:
+    """Create a mock client for testing (only API calls touch it)."""
+    return Mock(spec=LuxpowerClient)
+
+
+def _make_inverter(mock_client: LuxpowerClient) -> HybridInverter:
+    return HybridInverter(client=mock_client, serial_number="1234567890", model="FlexBOSS21")
+
+
+def _make_battery_info() -> BatteryInfo:
+    return BatteryInfo(
+        success=True,
+        serialNum="1234567890",
+        batStatus="Idle",
+        soc=50,
+        vBat=520,
+        pCharge=0,
+        pDisCharge=0,
+    )
+
+
+class TestConsumedSurfaceExports:
+    """Every consumed-surface symbol is importable from the package root."""
+
+    @pytest.mark.parametrize(
+        "symbol",
+        [
+            Station,
+            ParallelGroup,
+            BaseInverter,
+            MIDDevice,
+            Battery,
+            BatteryBank,
+            InverterRuntimeData,
+            InverterEnergyData,
+            BatteryBankData,
+            MidboxRuntimeData,
+            InverterFeatures,
+            InverterModelInfo,
+            InverterFamily,
+            GridType,
+        ],
+    )
+    def test_symbol_is_a_type(self, symbol: type) -> None:
+        assert isinstance(symbol, type)
+
+    def test_symbols_listed_in_dunder_all(self) -> None:
+        for name in (
+            "Station",
+            "ParallelGroup",
+            "BaseInverter",
+            "MIDDevice",
+            "Battery",
+            "BatteryBank",
+            "InverterRuntimeData",
+            "InverterEnergyData",
+            "BatteryData",
+            "BatteryBankData",
+            "MidboxRuntimeData",
+            "InverterFeatures",
+            "InverterModelInfo",
+            "InverterFamily",
+            "GridType",
+        ):
+            assert name in pylxpweb.__all__, f"{name} missing from pylxpweb.__all__"
+
+
+class TestTransportAccessors:
+    """Read-only transport accessors mirror the private fields."""
+
+    def test_accessors_none_in_cloud_mode(self, mock_client: LuxpowerClient) -> None:
+        inv = _make_inverter(mock_client)
+        assert inv.transport is None
+        assert inv.transport_runtime is None
+        assert inv.transport_energy is None
+        assert inv.transport_battery is None
+
+    def test_accessors_reflect_injected_transport_data(self, mock_client: LuxpowerClient) -> None:
+        inv = _make_inverter(mock_client)
+        runtime = InverterRuntimeData()
+        energy = InverterEnergyData()
+        battery = BatteryBankData()
+        inv._transport_runtime = runtime
+        inv._transport_energy = energy
+        inv._transport_battery = battery
+        assert inv.transport_runtime is runtime
+        assert inv.transport_energy is energy
+        assert inv.transport_battery is battery
+
+
+class TestSetCacheTtls:
+    """Public cache-TTL setter replaces private-attr poking."""
+
+    def test_sets_only_provided_ttls(self, mock_client: LuxpowerClient) -> None:
+        inv = _make_inverter(mock_client)
+        original_energy = inv._energy_cache_ttl
+        original_battery = inv._battery_cache_ttl
+        inv.set_cache_ttls(runtime=timedelta(seconds=5))
+        assert inv._runtime_cache_ttl == timedelta(seconds=5)
+        assert inv._energy_cache_ttl == original_energy
+        assert inv._battery_cache_ttl == original_battery
+
+    def test_sets_all_three(self, mock_client: LuxpowerClient) -> None:
+        inv = _make_inverter(mock_client)
+        ttl = timedelta(seconds=15)
+        inv.set_cache_ttls(runtime=ttl, energy=ttl, battery=ttl)
+        assert inv._runtime_cache_ttl == ttl
+        assert inv._energy_cache_ttl == ttl
+        assert inv._battery_cache_ttl == ttl
+
+    def test_no_args_is_a_noop(self, mock_client: LuxpowerClient) -> None:
+        inv = _make_inverter(mock_client)
+        before = (
+            inv._runtime_cache_ttl,
+            inv._energy_cache_ttl,
+            inv._battery_cache_ttl,
+        )
+        inv.set_cache_ttls()
+        after = (
+            inv._runtime_cache_ttl,
+            inv._energy_cache_ttl,
+            inv._battery_cache_ttl,
+        )
+        assert before == after
+
+
+class TestSeamGapProperties:
+    """Properties that close the eg4-ohz device-map seam gaps."""
+
+    def test_power_rating_text_aliases_power_rating(self, mock_client: LuxpowerClient) -> None:
+        inv = _make_inverter(mock_client)
+        # No runtime loaded -> empty, identical to power_rating.
+        assert inv.power_rating_text == inv.power_rating == ""
+
+    def test_has_runtime_data_false_without_data(self, mock_client: LuxpowerClient) -> None:
+        inv = _make_inverter(mock_client)
+        assert inv.has_runtime_data is False
+
+    def test_has_runtime_data_true_with_transport_runtime(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        inv = _make_inverter(mock_client)
+        inv._transport_runtime = InverterRuntimeData()
+        assert inv.has_runtime_data is True
+
+    def test_bank_cycle_count_none_without_transport_battery(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        inv = _make_inverter(mock_client)
+        bank = BatteryBank(mock_client, "1234567890", _make_battery_info(), inverter=inv)
+        assert bank.cycle_count is None
+
+    def test_bank_cycle_count_reads_transport_battery(self, mock_client: LuxpowerClient) -> None:
+        inv = _make_inverter(mock_client)
+        inv._transport_battery = BatteryBankData(cycle_count=123)
+        bank = BatteryBank(mock_client, "1234567890", _make_battery_info(), inverter=inv)
+        assert bank.cycle_count == 123
+
+    def test_bank_cycle_count_none_without_parent_inverter(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        bank = BatteryBank(mock_client, "1234567890", _make_battery_info())
+        assert bank.cycle_count is None
+
+
+class TestMidTransportAccessors:
+    """MIDDevice exposes the same public transport accessors as inverters."""
+
+    def test_accessors_none_in_cloud_mode(self, mock_client: LuxpowerClient) -> None:
+        mid = MIDDevice(mock_client, "0987654321", "GridBOSS")
+        assert mid.transport is None
+        assert mid.transport_runtime is None
+
+    def test_transport_runtime_reflects_injected_data(self, mock_client: LuxpowerClient) -> None:
+        mid = MIDDevice(mock_client, "0987654321", "GridBOSS")
+        runtime = MidboxRuntimeData()
+        mid._transport_runtime = runtime
+        assert mid.transport_runtime is runtime

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.28"
+version = "0.9.29"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Publishes a stable, **typed** public surface for the eg4_web_monitor integration to consume, so the library↔integration seam is enforced by mypy --strict instead of duck-typing + private-attr poking. Part of the maintainability epic (eg4-2iw / eg4-ohz).

Design: a **concrete typed contract** (export the existing concrete classes + add public accessors) — not a parallel Protocol layer.

## Changes
- **Exports** (`__init__.py`): device hierarchy (`BaseInverter`, `Battery`, `BatteryBank`, `MIDDevice`, `ParallelGroup`, `Station`), transport data classes (`InverterRuntimeData`, `InverterEnergyData`, `BatteryData`, `BatteryBankData`, `MidboxRuntimeData`), feature types (`InverterFeatures`, `InverterModelInfo`, `InverterFamily`, `GridType`).
- **Public transport accessors** (read-only): `transport`, `transport_runtime`, `transport_energy`, `transport_battery` on `BaseInverter`; `transport`, `transport_runtime` on `MIDDevice`. The private `_transport*` fields are now typed concretely (no more `Any`).
- **`BaseInverter.set_cache_ttls(*, runtime=, energy=, battery=)`** — public API to pin transport-data cache TTLs (replaces consumers writing private `_*_cache_ttl`).
- **Seam-gap properties**: `BaseInverter.has_runtime_data`, `BaseInverter.power_rating_text` (alias of `power_rating`), `BatteryBank.cycle_count` (reads the parent inverter's transport bank data — the same reg-106 field the local path uses; None in cloud-only mode).
- Version `0.9.28` → `0.9.29` + CHANGELOG.

## Testing
- 2013 unit tests pass (incl. new `tests/unit/test_seam_public_api.py`, 28 tests).
- `mypy --strict` clean (94 source files).
- ruff clean.
- Adversarial review (Codex): **SHIP**, high confidence, 0 findings.
- Live-validated end-to-end in the integration (hybrid dev container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)