### PR TITLE
feat(features): add InverterFeatures.from_family (eg4-xi8); release 0.9.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.29"
+version = "0.9.30"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/devices/inverters/_features.py
+++ b/src/pylxpweb/devices/inverters/_features.py
@@ -154,6 +154,19 @@ DEVICE_TYPE_CODE_TO_FAMILY: dict[int, InverterFamily] = {
 }
 
 
+# Representative device type code per family, used by ``InverterFeatures.from_family``
+# when a caller has only a family name (for example a stored configuration that
+# predates device-type-code capture).  Only families whose capabilities are
+# unambiguous from the family alone are listed here.  Families that require the
+# device type code to disambiguate — notably ``LXP`` (EU is three-phase, LB is
+# split-phase) — are intentionally absent, so ``from_family`` returns ``None`` for
+# them and the caller applies a conservative fallback.
+_FAMILY_REPRESENTATIVE_DEVICE_TYPE_CODE: dict[InverterFamily, int] = {
+    InverterFamily.EG4_OFFGRID: DEVICE_TYPE_CODE_SNA,
+    InverterFamily.EG4_HYBRID: DEVICE_TYPE_CODE_PV_SERIES,
+}
+
+
 # Known feature sets by model family
 # These represent the default capabilities for each family
 FAMILY_DEFAULT_FEATURES: dict[InverterFamily, dict[str, bool]] = {
@@ -596,6 +609,64 @@ class InverterFeatures:
                 features.grid_type = GridType.SINGLE_PHASE
 
         return features
+
+    @classmethod
+    def from_family(
+        cls,
+        family: InverterFamily,
+        device_type_code: int | None = None,
+    ) -> InverterFeatures | None:
+        """Create a features instance from a model family.
+
+        :meth:`from_device_type_code` is the authoritative entry point and should
+        be preferred whenever a device type code is known. This family-based
+        helper exists for callers that only have a family name (for example a
+        stored configuration that predates device-type-code capture) and need the
+        family-default capability set without reading registers.
+
+        Resolution order:
+
+        1. If ``device_type_code`` is provided and maps to ``family``, delegate to
+           :meth:`from_device_type_code` (fully authoritative).
+        2. Otherwise, for families whose capabilities are unambiguous from the
+           family alone (``EG4_OFFGRID``, ``EG4_HYBRID``), build from the
+           family-representative device type code so grid type, phase flags and
+           PV string count are correct.
+        3. Otherwise the family cannot be resolved to a definite capability set —
+           either it needs a device type code to disambiguate (``LXP``: EU is
+           three-phase, LB is split-phase) or it is ``UNKNOWN`` — and ``None`` is
+           returned so the caller can apply a conservative fallback.
+
+        Args:
+            family: Inverter model family.
+            device_type_code: Optional device type code from
+                HOLD_DEVICE_TYPE_CODE. Used directly when it maps to ``family``;
+                a mismatched or absent code falls back to the family-representative
+                code.
+
+        Returns:
+            An :class:`InverterFeatures` instance, or ``None`` when the family
+            cannot be resolved without a device type code.
+
+        Example:
+            >>> InverterFeatures.from_family(InverterFamily.EG4_HYBRID).split_phase
+            True
+            >>> InverterFeatures.from_family(InverterFamily.LXP) is None  # needs code
+            True
+            >>> InverterFeatures.from_family(InverterFamily.LXP, 44).split_phase
+            True
+        """
+        if (
+            device_type_code is not None
+            and DEVICE_TYPE_CODE_TO_FAMILY.get(device_type_code) == family
+        ):
+            return cls.from_device_type_code(device_type_code)
+
+        representative = _FAMILY_REPRESENTATIVE_DEVICE_TYPE_CODE.get(family)
+        if representative is not None:
+            return cls.from_device_type_code(representative)
+
+        return None
 
 
 def get_inverter_family(device_type_code: int) -> InverterFamily:

--- a/tests/unit/devices/inverters/test_features.py
+++ b/tests/unit/devices/inverters/test_features.py
@@ -423,6 +423,85 @@ class TestInverterFeatures:
         assert features.off_grid_capable is True  # Most inverters have this
 
 
+class TestFromFamily:
+    """Tests for InverterFeatures.from_family (family-only feature resolution)."""
+
+    def test_eg4_offgrid_no_code(self) -> None:
+        """EG4_OFFGRID is unambiguous from the family alone (representative SNA)."""
+        features = InverterFeatures.from_family(InverterFamily.EG4_OFFGRID)
+        assert features is not None
+        assert features.model_family == InverterFamily.EG4_OFFGRID
+        assert features.grid_type == GridType.SPLIT_PHASE
+        assert features.split_phase is True
+        assert features.three_phase_capable is False
+        assert features.discharge_recovery_hysteresis is True
+        assert features.volt_watt_curve is False
+
+    def test_eg4_hybrid_no_code(self) -> None:
+        """EG4_HYBRID is unambiguous from the family alone (representative PV series)."""
+        features = InverterFeatures.from_family(InverterFamily.EG4_HYBRID)
+        assert features is not None
+        assert features.model_family == InverterFamily.EG4_HYBRID
+        assert features.grid_type == GridType.SPLIT_PHASE
+        assert features.split_phase is True
+        assert features.three_phase_capable is False
+        assert features.volt_watt_curve is True
+
+    def test_matching_code_is_authoritative(self) -> None:
+        """A device type code that maps to the family is used directly."""
+        # FlexBOSS (10284) maps to EG4_HYBRID and must be honoured.
+        features = InverterFeatures.from_family(InverterFamily.EG4_HYBRID, 10284)
+        assert features is not None
+        assert features.device_type_code == 10284
+        assert features.model_family == InverterFamily.EG4_HYBRID
+
+    def test_lxp_requires_code(self) -> None:
+        """LXP is ambiguous (EU three-phase vs LB split-phase) without a code."""
+        assert InverterFeatures.from_family(InverterFamily.LXP) is None
+        assert InverterFeatures.from_family(InverterFamily.LXP, None) is None
+
+    def test_lxp_eu_with_code(self) -> None:
+        """LXP + device_type_code 12 resolves to LXP-EU three-phase."""
+        features = InverterFeatures.from_family(InverterFamily.LXP, 12)
+        assert features is not None
+        assert features.grid_type == GridType.SINGLE_PHASE
+        assert features.split_phase is False
+        assert features.three_phase_capable is True
+
+    def test_lxp_lb_with_code(self) -> None:
+        """LXP + device_type_code 44 resolves to LXP-LB split-phase."""
+        features = InverterFeatures.from_family(InverterFamily.LXP, 44)
+        assert features is not None
+        assert features.grid_type == GridType.SPLIT_PHASE
+        assert features.split_phase is True
+        assert features.three_phase_capable is False
+
+    def test_lxp_unrecognized_code_returns_none(self) -> None:
+        """A code that does not map to LXP cannot disambiguate -> None."""
+        assert InverterFeatures.from_family(InverterFamily.LXP, 999) is None
+
+    def test_unknown_family_returns_none(self) -> None:
+        """UNKNOWN family has no representative code -> None."""
+        assert InverterFeatures.from_family(InverterFamily.UNKNOWN) is None
+
+    def test_mismatched_code_falls_back_to_family(self) -> None:
+        """A code mapping to a different family falls back to the family default."""
+        # 54 maps to EG4_OFFGRID; caller explicitly asked for EG4_HYBRID, so the
+        # family wins via its representative code.
+        features = InverterFeatures.from_family(InverterFamily.EG4_HYBRID, 54)
+        assert features is not None
+        assert features.model_family == InverterFamily.EG4_HYBRID
+
+    def test_agrees_with_from_device_type_code(self) -> None:
+        """For a matching code, from_family equals from_device_type_code."""
+        for code in (54, 2092, 10284, 12, 44):
+            family = DEVICE_TYPE_CODE_TO_FAMILY[code]
+            via_family = InverterFeatures.from_family(family, code)
+            via_code = InverterFeatures.from_device_type_code(code)
+            assert via_family is not None
+            assert via_family == via_code
+
+
 # =============================================================================
 # Helper Function Tests
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.29"
+version = "0.9.30"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Adds `InverterFeatures.from_family(family, device_type_code=None) -> InverterFeatures | None` — the library half of **eg4-xi8** (unify feature detection). Callers that only have a model family (e.g. an integration config stored without a device type code) can now obtain pylxpweb's canonical family-default capability set instead of re-encoding family→capability knowledge.

### Resolution rules
1. A `device_type_code` that maps to `family` → authoritative, delegates to `from_device_type_code`.
2. Families unambiguous from the family alone (`EG4_OFFGRID`, `EG4_HYBRID`) → built from a representative device type code (so grid type, phase flags, PV string count are correct).
3. Ambiguous `LXP` (EU three-phase vs LB split-phase) or `UNKNOWN` → returns `None` so the caller applies a conservative fallback.

### Release 0.9.30
Bundles the already-merged **E6** dead-code cleanup on `main` (shadowed `registers.py` removal + weekly-schedule documentation) with this E7 addition. The eg4_web_monitor integration's manifest will require `pylxpweb>=0.9.30`.

## Test plan
- `TestFromFamily` (10 cases): each family/code combination incl. None/ambiguous/mismatch + equivalence with `from_device_type_code`.
- Full suite: **2025 passed**. ruff + mypy --strict clean.
- Adversarial (Codex) review: no logic issues; all feature invariants preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)