### PR TITLE
fix: local PV charge power targets reg 74 (HOLD_FORCED_CHG_POWER_CMD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.35b7] - 2026-06-05
+
+### Fixed
+
+- **PV/forced charge power register (reg 74) addressable locally** — added
+  `74: ["HOLD_FORCED_CHG_POWER_CMD"]` to `REGISTER_TO_PARAM_KEYS` so the local
+  Modbus path can read/write the forced/PV charge power command by name. It was
+  missing from the local map, which forced consumers onto the wrong register 64
+  (a 0-100% charge-power limit) with a lossy kW↔% conversion.
+- **Reg 74 unit metadata corrected** — `HOLD_FORCED_CHG_POWER_CMD` is **100W
+  units** (0-150 = 0-15 kW, same encoding as AC charge power reg 66), not a
+  percentage. Fixed the register comment, the `HoldingRegisterDefinition`
+  (`unit`/`max_value`/description), the scaling note, and the
+  `HybridInverter.set_forced_charge_power()` / `get_charge_discharge_power()`
+  docstrings; `set_forced_charge_power` now accepts 0-150 (was capped at 100).
+  Hardware-verified: FlexBOSS reg74=20→2.0 kW, 18kPV reg74=120→12.0 kW.
+- **Packaging** — moved `classifiers` back under `[project]` (it was misplaced
+  under `[project.urls]`, breaking `uv build`) and dropped the deprecated
+  License classifier in favor of the SPDX `license` field.
+
 ## [0.9.32] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.35b7] - 2026-06-05
+## [0.9.35] - 2026-06-05
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.35b7"
+version = "0.9.35"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.34"
+version = "0.9.35b7"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [
@@ -14,20 +14,19 @@ dependencies = [
 ]
 license = "MIT"
 keywords = ["luxpower", "eg4", "inverter", "solar", "api", "client"]
-
-[project.urls]
-Homepage = "https://github.com/joyfulhouse/pylxpweb"
-Repository = "https://github.com/joyfulhouse/pylxpweb"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Home Automation",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+
+[project.urls]
+Homepage = "https://github.com/joyfulhouse/pylxpweb"
+Repository = "https://github.com/joyfulhouse/pylxpweb"
 
 [project.optional-dependencies]
 dev = [

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -130,7 +130,7 @@ HOLD_AC_CHARGE_START_SOC = 160  # Battery SOC to start AC charging (0-90%)
 # Forced Charge (ChgFirst / PV Charge Priority) Parameters
 # Per EG4-18KPV-12LV Modbus PDF, regs 74-81 are "Charging Priority" (ChgFirst).
 # Cloud API names: HOLD_FORCED_CHG_POWER_CMD, HOLD_FORCED_CHG_SOC_LIMIT
-HOLD_FORCED_CHG_POWER_CMD = 74  # Forced charge power command (0-100%)
+HOLD_FORCED_CHG_POWER_CMD = 74  # Forced/PV charge power, 100W units (0-150 = 0-15kW)
 HOLD_FORCED_CHG_SOC_LIMIT = 75  # Forced charge SOC limit (0-100%)
 
 # Forced Charge Time Schedule (regs 76-81) - packed time format (Modbus)
@@ -507,6 +507,10 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
     71: ["HOLD_AC_CHARGE_END_MINUTE_1"],
     72: ["HOLD_AC_CHARGE_ENABLE_1"],
     73: ["HOLD_AC_CHARGE_ENABLE_2"],
+    # Forced/PV charge (ChgFirst) power command.
+    # 100W units (0-150 = 0.0-15.0 kW), same encoding as AC charge power (reg 66).
+    # Hardware-verified: FlexBOSS reg74=20 -> 2.0 kW, 18kPV reg74=120 -> 12.0 kW.
+    74: ["HOLD_FORCED_CHG_POWER_CMD"],
     # Battery protection
     100: ["HOLD_LEAD_ACID_DISCHARGE_CUT_OFF_VOLT"],
     # Battery charge/discharge current limits (A, confirmed 2026-02-18)

--- a/src/pylxpweb/constants/scaling.py
+++ b/src/pylxpweb/constants/scaling.py
@@ -311,7 +311,7 @@ PARAMETER_SCALING: dict[str, ScaleFactor] = {
     "HOLD_EPS_FREQ_SET": ScaleFactor.SCALE_100,
     # Power Parameters (direct Watts or percentage)
     "HOLD_AC_CHARGE_POWER_CMD": ScaleFactor.SCALE_NONE,  # Watts
-    "HOLD_FORCED_CHG_POWER_CMD": ScaleFactor.SCALE_NONE,  # Percentage (0-100)
+    "HOLD_FORCED_CHG_POWER_CMD": ScaleFactor.SCALE_NONE,  # 100W units (0-150=0-15kW); caller scales
     "HOLD_FORCED_DISCHG_POWER_CMD": ScaleFactor.SCALE_NONE,  # Percentage (0-100)
     "HOLD_FEED_IN_GRID_POWER_PERCENT": ScaleFactor.SCALE_NONE,  # Percentage
     # SOC Parameters (percentage, no scaling)

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -252,17 +252,22 @@ class HybridInverter(GenericInverter):
         return await self._set_register_bit(FUNC_EN_REGISTER, FUNC_EN_BIT_FORCED_DISCHG_EN, enabled)
 
     async def get_charge_discharge_power(self) -> dict[str, int]:
-        """Get charge and discharge power settings.
+        """Get AC charge and forced/PV charge power settings.
+
+        Both values are RAW 100W units (0-150 = 0-15 kW), not percentages.
+        The ``*_percent`` dict keys are a legacy misnomer kept for backward
+        compatibility; divide by 10 for kW.
 
         Returns:
             Dictionary with:
-            - charge_power_percent: AC charge power (0-100%)
-            - forced_charge_power_percent: Forced charge power (0-100%)
+            - charge_power_percent: AC charge power, raw 100W units (reg 66)
+            - forced_charge_power_percent: Forced/PV charge power, raw 100W
+              units (reg 74)
 
         Example:
             >>> settings = await inverter.get_charge_discharge_power()
             >>> settings
-            {'charge_power_percent': 50, 'forced_charge_power_percent': 100}
+            {'charge_power_percent': 120, 'forced_charge_power_percent': 20}
         """
         from pylxpweb.constants import HOLD_AC_CHARGE_POWER_CMD
 
@@ -273,25 +278,28 @@ class HybridInverter(GenericInverter):
             "forced_charge_power_percent": params.get("HOLD_FORCED_CHG_POWER_CMD", 0),
         }
 
-    async def set_forced_charge_power(self, power_percent: int) -> bool:
+    async def set_forced_charge_power(self, power_100w: int) -> bool:
         """Set forced charge (PV charge priority) power limit.
 
+        Register 74 stores RAW 100W units (0-150 = 0-15 kW), not a percentage
+        — same encoding as AC charge power (reg 66). e.g. ``20`` -> 2.0 kW.
+
         Args:
-            power_percent: Forced charge power percentage (0-100)
+            power_100w: Forced charge power in 100W units (0-150 = 0-15 kW).
 
         Returns:
             True if successful
 
         Example:
-            >>> await inverter.set_forced_charge_power(80)
+            >>> await inverter.set_forced_charge_power(20)  # 2.0 kW
             True
         """
         from pylxpweb.constants import HOLD_FORCED_CHG_POWER_CMD
 
-        if not 0 <= power_percent <= 100:
-            raise ValueError("power_percent must be between 0 and 100")
+        if not 0 <= power_100w <= 150:
+            raise ValueError("power_100w must be between 0 and 150 (0-15 kW)")
 
-        return await self.write_parameters({HOLD_FORCED_CHG_POWER_CMD: power_percent})
+        return await self.write_parameters({HOLD_FORCED_CHG_POWER_CMD: power_100w})
 
     # ============================================================================
     # Working Mode Time Schedule Operations (Generic + Type-Specific)

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -602,11 +602,14 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         address=74,
         canonical_name="forced_charge_power_command",
         api_param_key="HOLD_FORCED_CHG_POWER_CMD",
-        unit="%",
+        unit="W",
         min_value=0,
-        max_value=100,
+        max_value=15000,
         category=HoldingCategory.SCHEDULE,
-        description="Forced charge power command percentage.",
+        description=(
+            "Forced/PV charge (ChgFirst) power command. Raw value in 100W units "
+            "(0-150 = 0-15kW), same encoding as AC charge power (reg 66)."
+        ),
     ),
     HoldingRegisterDefinition(
         address=75,

--- a/tests/unit/devices/inverters/test_hybrid.py
+++ b/tests/unit/devices/inverters/test_hybrid.py
@@ -421,20 +421,20 @@ class TestChargeDischargePowerOperations:
             client=mock_client, serial_number="1234567890", model="FlexBOSS21"
         )
 
-        with pytest.raises(ValueError, match="power_percent must be between 0 and 100"):
+        with pytest.raises(ValueError, match="power_100w must be between 0 and 150"):
             await inverter.set_forced_charge_power(-5)
 
     @pytest.mark.asyncio
     async def test_set_forced_charge_power_validation_too_high(
         self, mock_client: LuxpowerClient
     ) -> None:
-        """Test forced charge power validation - too high."""
+        """Test forced charge power validation - too high (>150 = >15kW)."""
         inverter = HybridInverter(
             client=mock_client, serial_number="1234567890", model="FlexBOSS21"
         )
 
-        with pytest.raises(ValueError, match="power_percent must be between 0 and 100"):
-            await inverter.set_forced_charge_power(105)
+        with pytest.raises(ValueError, match="power_100w must be between 0 and 150"):
+            await inverter.set_forced_charge_power(151)
 
 
 class TestACChargeScheduleOperations:

--- a/tests/unit/transports/test_named_parameters.py
+++ b/tests/unit/transports/test_named_parameters.py
@@ -85,6 +85,22 @@ class TestReadNamedParametersModbus:
         assert result.get("HOLD_COM_ADDR") == 1
         assert result.get("HOLD_LANGUAGE") == 0
 
+    @pytest.mark.asyncio
+    async def test_read_named_parameters_forced_chg_power(
+        self, mock_modbus_transport: ModbusTransport
+    ) -> None:
+        """Register 74 (HOLD_FORCED_CHG_POWER_CMD) decodes to its named param.
+
+        Reg 74 is the forced/PV charge power command in 100W units
+        (0-150 = 0-15 kW), e.g. raw 120 -> 12.0 kW.
+        """
+        mock_modbus_transport.read_parameters = AsyncMock(return_value={74: 120})
+
+        result = await mock_modbus_transport.read_named_parameters(74, 1)
+
+        assert "HOLD_FORCED_CHG_POWER_CMD" in result
+        assert result["HOLD_FORCED_CHG_POWER_CMD"] == 120
+
 
 class TestWriteNamedParametersModbus:
     """Tests for Modbus transport write_named_parameters."""
@@ -112,6 +128,23 @@ class TestWriteNamedParametersModbus:
 
         assert result is True
         mock_modbus_transport.write_parameters.assert_called_once_with({66: 75})
+
+    @pytest.mark.asyncio
+    async def test_write_named_parameters_forced_chg_power(
+        self, mock_modbus_transport: ModbusTransport
+    ) -> None:
+        """Writing HOLD_FORCED_CHG_POWER_CMD resolves to register 74.
+
+        100W units: 1 kW -> raw 10. Local path must be able to address reg 74
+        by name (regression: it was missing from the local register map, which
+        forced the integration onto the wrong register 64).
+        """
+        result = await mock_modbus_transport.write_named_parameters(
+            {"HOLD_FORCED_CHG_POWER_CMD": 10}
+        )
+
+        assert result is True
+        mock_modbus_transport.write_parameters.assert_called_once_with({74: 10})
 
     @pytest.mark.asyncio
     async def test_write_named_parameters_bit_field_single(

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.34"
+version = "0.9.35b7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Adds register 74 to the local register map and corrects its unit metadata to 100W units (0-150 = 0-15 kW), matching AC charge power (reg 66). Fixes the 'set 1 kW reads 0' bounce on Modbus/hybrid inverters where the local path fell back to the wrong register 64 with a lossy kW↔% conversion.

Hardware-verified: FlexBOSS reg74=20→2.0 kW, 18kPV reg74=120→12.0 kW.

Also restores `classifiers` placement in `pyproject.toml` (was misplaced under `[project.urls]`, breaking `uv build`).

Pre-release `v0.9.35b7` cut from this branch for integration testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)