### PR TITLE
fix: keep a known-healthy 0 fault/warning code through a dropped bms_data read (eg4_web_monitor#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`Fault Code` / `Warning Code` no longer flicker to "unknown" on a dropped `bms_data` read** ([eg4_web_monitor#261](https://github.com/joyfulhouse/eg4_web_monitor/issues/261)):
+  the inverter fault/warning registers (60-63, in the always-read `status_energy`
+  group) are merged with their BMS fallback codes (regs 99-100, in the droppable
+  `bms_data` group) "prefer the non-zero code". The merge was
+  `inverter_code if inverter_code else bms_code`, which collapsed a **known-healthy
+  `0`** (the inverter reporting no fault) into `None` whenever the `bms_data` group
+  read dropped — `read_all_input_data` still rebuilds the runtime from the surviving
+  snapshot, so the BMS code is `None` while the inverter code reads `0`, and
+  `0 if 0 else None` is `None`. A `None` code is omitted from the sensor payload, so
+  Home Assistant's `Fault Code` sensor went *unknown* on those polls in both HYBRID
+  and LOCAL mode. (The integration's earlier carry-forward only covered a full
+  link-down where `transport_runtime` is `None`, not this present-but-`None` case.)
+  The merge now returns `0` when **either** register was actually read and `None`
+  only when **both** are genuinely absent, so a healthy `0` survives a dropped BMS
+  read; an active code from either source is still preferred and preserved.
 - **A dropped `bms_data` read no longer publishes a degraded battery bank** ([eg4_web_monitor#261](https://github.com/joyfulhouse/eg4_web_monitor/issues/261)):
   the combined (`read_all_input_data`) and chunked (`read_battery`) reads fetch
   register groups as separate Modbus requests. Register 96 (`battery_parallel_count`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.36b15"
+version = "0.9.36b16"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/transports/data.py
+++ b/src/pylxpweb/transports/data.py
@@ -92,6 +92,31 @@ _RUNTIME_INT_FIELDS: frozenset[str] = frozenset(
 # _sum_optional = sum_optional
 
 
+def _merge_status_code(inverter_code: int | None, bms_code: int | None) -> int | None:
+    """Merge an inverter fault/warning code with its BMS fallback.
+
+    The inverter code (regs 60-63) and the BMS fallback (regs 99-100) are read
+    from different input-register groups — ``status_energy`` (32-63, always
+    read) and ``bms_data`` (80-112, the one group allowed to fail non-fatally).
+    A transient bms_data-group drop therefore leaves ``bms_code`` None while the
+    inverter code still reads a healthy 0.
+
+    Prefer an active (non-zero) code from either source, inverter first.  When
+    neither is active, return 0 if *either* register was actually read (a
+    known-healthy 0) and None only when *both* are absent (genuinely unread), so
+    a dropped BMS read never turns a known-healthy 0 into None — which blanked
+    the Home Assistant Fault Code sensor to "unknown" even though the inverter
+    reported no fault (eg4_web_monitor#261).
+    """
+    if inverter_code:
+        return inverter_code
+    if bms_code:
+        return bms_code
+    if inverter_code is not None or bms_code is not None:
+        return 0
+    return None
+
+
 @dataclass
 class InverterRuntimeData:
     """Real-time inverter operating data.
@@ -625,11 +650,11 @@ class InverterRuntimeData:
             else:
                 kwargs[field_name] = read_scaled(input_registers, reg)
 
-        # Combine fault/warning codes (inverter + BMS) — prefer non-zero
-        kwargs["fault_code"] = inverter_fault_code if inverter_fault_code else bms_fault_code
-        kwargs["warning_code"] = (
-            inverter_warning_code if inverter_warning_code else bms_warning_code
-        )
+        # Combine fault/warning codes (inverter + BMS).  Prefer an active
+        # (non-zero) code; preserve a known-healthy 0 when only the BMS read
+        # dropped instead of collapsing it to None (eg4_web_monitor#261).
+        kwargs["fault_code"] = _merge_status_code(inverter_fault_code, bms_fault_code)
+        kwargs["warning_code"] = _merge_status_code(inverter_warning_code, bms_warning_code)
 
         # Compute derived fields.  Sum all non-None pvN_power across pv1..pv6
         # so the total is count-agnostic: a 3-string inverter has pv4-6=None

--- a/tests/unit/transports/test_data.py
+++ b/tests/unit/transports/test_data.py
@@ -881,3 +881,65 @@ class TestPv456Parity:
         assert data.pv4_power is None
         assert data.pv5_power is None
         assert data.pv6_power is None
+
+
+class TestFaultWarningCodeMerge:
+    """Merge of the inverter fault/warning code (regs 60-63) with the BMS
+    fallback (regs 99-100) in ``from_modbus_registers``.
+
+    The two sources live in different input-register groups — the inverter
+    code in ``status_energy`` (regs 32-63, always read) and the BMS fallback in
+    ``bms_data`` (regs 80-112, the one group whose read is allowed to fail
+    non-fatally).  When the bms_data read drops (a common flaky-dongle case),
+    ``read_all_input_data`` still rebuilds the runtime from the surviving
+    snapshot, so the BMS code is None while the inverter code still reads a
+    healthy 0.  The merge must surface that known-healthy 0 rather than None:
+    collapsing it to None blanked the Home Assistant ``Fault Code`` sensor to
+    "unknown" on every such drop, even though the inverter reported no fault
+    (eg4_web_monitor#261).  A genuinely unread code (both sources absent) must
+    still be None, and an active code from either source must be preserved.
+    """
+
+    def test_healthy_inverter_survives_bms_data_drop(self) -> None:
+        """Inverter code 0 + bms_data group dropped → 0, not None (#261).
+
+        regs 60-63 = 0 (the always-read inverter fault/warning, healthy) with
+        the bms_data group (incl. regs 99-100) absent — exactly the snapshot
+        ``read_all_input_data`` rebuilds on a bms_data drop.
+        """
+        regs: dict[int, int] = {60: 0, 61: 0, 62: 0, 63: 0}  # bms regs 99/100 absent
+        data = InverterRuntimeData.from_modbus_registers(regs)
+        assert data.fault_code == 0
+        assert data.warning_code == 0
+
+    def test_both_sources_absent_yields_none(self) -> None:
+        """Neither inverter nor BMS code present → genuinely unknown (None)."""
+        regs: dict[int, int] = {0: 0}  # no fault/warning registers at all
+        data = InverterRuntimeData.from_modbus_registers(regs)
+        assert data.fault_code is None
+        assert data.warning_code is None
+
+    def test_real_inverter_fault_survives_bms_drop(self) -> None:
+        """An active inverter code is preserved when the bms_data group drops."""
+        regs: dict[int, int] = {60: 0x10, 61: 0, 62: 0x01, 63: 0}  # bms absent
+        data = InverterRuntimeData.from_modbus_registers(regs)
+        assert data.fault_code == 0x10
+        assert data.warning_code == 0x01
+
+    def test_bms_code_used_when_inverter_zero(self) -> None:
+        """BMS fallback unchanged: inverter code 0, BMS code active → BMS code."""
+        regs: dict[int, int] = {60: 0, 61: 0, 62: 0, 63: 0, 99: 0x04, 100: 0x08}
+        data = InverterRuntimeData.from_modbus_registers(regs)
+        assert data.fault_code == 0x04
+        assert data.warning_code == 0x08
+
+    def test_fault_and_warning_merge_independently_on_bms_drop(self) -> None:
+        """Healthy fault + active warning, bms_data dropped → 0 and the warning.
+
+        Fault and warning are merged independently, so a healthy-0 fault must
+        survive (not None) while an active warning on the same poll is preserved.
+        """
+        regs: dict[int, int] = {60: 0, 61: 0, 62: 0x02, 63: 0}  # bms regs absent
+        data = InverterRuntimeData.from_modbus_registers(regs)
+        assert data.fault_code == 0
+        assert data.warning_code == 0x02

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.36b14"
+version = "0.9.36b16"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Resolves the residual **Fault Code / Warning Code → "unknown"** flicker reported in [eg4_web_monitor#261](https://github.com/joyfulhouse/eg4_web_monitor/issues/261), which persisted on `3.4.0-beta.14` / `0.9.36b15` even after the battery-bank cloud-fallback and link-down carry-forward fixes.

## Root cause

`InverterRuntimeData.from_modbus_registers` merges the inverter fault/warning code (regs 60-63, in the **always-read** `status_energy` group 32-63) with the BMS fallback code (regs 99-100, in the `bms_data` group 80-112 — the only input-register group whose read is allowed to fail non-fatally):

```python
kwargs["fault_code"] = inverter_fault_code if inverter_fault_code else bms_fault_code
```

On a `bms_data`-group drop (common on a flaky WiFi-dongle link), `read_all_input_data` still rebuilds the runtime from the surviving snapshot, so `bms_fault_code` is `None` while `inverter_fault_code` reads `0` (healthy). `0 if 0 else None` evaluates to **`None`**, and a `None` code is omitted from the Home Assistant sensor payload → the sensor goes **unknown**. This breaks **both HYBRID and LOCAL** mode, and is *not* covered by the integration's prior carry-forward (which only fires when `transport_runtime is None`, a full link-down — here the runtime is present).

The reporter confirmed the drop is rare and **uncorrelated** with the frequent dongle-mismatch count, matching this "a full `bms_data` read-failure happening to land on a runtime rebuild" trigger.

## Fix

`_merge_status_code(inverter_code, bms_code)` prefers a non-zero (active) code from either source (inverter first), returns `0` when **either** register was actually read (a known-healthy 0), and `None` only when **both** are genuinely absent — so a dropped BMS read never turns a known-healthy `0` into `None`. Applied to both `fault_code` and `warning_code`, covering both `from_modbus_registers` call sites (combined `read_all_input_data` + individual `read_runtime`). Pure CLOUD is unaffected — `from_http_response` never sets these keys (the cloud API has no fault field).

The only behavior change vs. before is the single bug cell `(inverter=0, bms=None) → 0` (was `None`); every other `(inverter, bms)` combination is byte-identical.

### Tradeoff (intentional)

A *BMS-only* fault (inverter reg `0`, an active BMS fault) during a `bms_data` drop now briefly reads `0` instead of `unknown`. Both old and new lose the un-readable BMS fault for that one poll; the new behavior shows the inverter's genuine `0` (consistent with "inverter primary, BMS fallback"), and the BMS fault resurfaces on the next successful read.

## Tests

`TestFaultWarningCodeMerge` (5 tests): healthy-survives-bms-drop (the regression that failed before the fix), both-absent → `None`, active-inverter-fault preserved, BMS-fallback unchanged, independent fault/warning merge. **Full suite: 2421 passed.**

Bumps to **0.9.36b16**. The matching `eg4_web_monitor` manifest bump (require `>=0.9.36b16`, release `3.4.0-beta.15`) is in joyfulhouse/eg4_web_monitor `fix/261-followup-require-b16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)