### PR TITLE
fix(ci): restore green CI — aiohttp 3.14 aioresponses shim + register control marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ addopts = [
 ]
 markers = [
     "integration: Integration tests that require real API access (run with: pytest -m integration)",
+    "control: Tests that write to or control real hardware (run with: pytest -m \"integration and control\")",
 ]
 timeout = 60  # Per-test timeout in seconds (prevents hanging)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 from collections.abc import AsyncGenerator, Generator
@@ -9,9 +10,45 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from aiohttp import web
+from aiohttp import ClientResponse, web
 from aiohttp.test_utils import TestClient, TestServer
 from aioresponses import aioresponses
+from aioresponses import core as aioresponses_core
+
+# aioresponses 0.7.8 (its latest release) builds mock ClientResponse objects
+# without the `stream_writer` keyword argument that aiohttp 3.14.0 made required,
+# so every aioresponses-mocked test would raise
+# "ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'".
+# Home Assistant pins aiohttp==3.14.1, so pylxpweb must keep working (and testing)
+# against aiohttp >= 3.14 rather than cap it. Supply the kwarg here — mirroring
+# aioresponses' own `writer=None` — by reassigning the ClientResponse class that
+# aioresponses.core instantiates for mocked responses. The guard makes this a
+# no-op on aiohttp < 3.14. Remove once aioresponses ships native aiohttp 3.14 support.
+if "stream_writer" in inspect.signature(ClientResponse.__init__).parameters:
+
+    class _NoopStreamWriter:
+        """Minimal stand-in for the request body writer aiohttp>=3.14 expects.
+
+        aioresponses always passes ``writer=None`` ("request already sent"), so
+        aiohttp only reads ``stream_writer.output_size`` and never writes through
+        it — a bare object carrying that one attribute is enough.
+        """
+
+        output_size = 0
+
+    class _StreamWriterCompatResponse(ClientResponse):
+        """ClientResponse that defaults the aiohttp>=3.14 `stream_writer` kwarg."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs.setdefault("stream_writer", _NoopStreamWriter())
+            super().__init__(*args, **kwargs)
+
+    # Patch via __dict__ to satisfy both linters without a suppression:
+    # aioresponses.core re-imports ClientResponse without re-exporting it, so a
+    # plain `core.ClientResponse = ...` trips mypy attr-defined (whole-tree check)
+    # while `setattr(core, "ClientResponse", ...)` trips ruff B010. A __dict__ write
+    # patches the same name and is clean under both.
+    aioresponses_core.__dict__["ClientResponse"] = _StreamWriterCompatResponse
 
 
 def is_ci_environment() -> bool:


### PR DESCRIPTION
## Summary

CI is **red across `main` and every PR** due to **two independent, pre-existing breakages** that only fully surface on non-fork PRs (where the unit + integration jobs both run). Each is on a different CI job, so a PR fixing only one would still show red on the other — this PR fixes both so CI goes green again.

Both were discovered while validating PR #181 and proven pre-existing on a clean `origin/main` worktree.

### 1. Unit Tests — aioresponses vs aiohttp 3.14 (`tests/conftest.py`)
aiohttp **3.14.0** made `stream_writer` a required `ClientResponse` kwarg; `aioresponses 0.7.8` (its latest release) builds mock responses without it, so every aioresponses-mocked test fails:
```
ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
```
**Why fix the test harness, not cap aiohttp:** pylxpweb's own code works on aiohttp 3.14+ (it never constructs `ClientResponse`), and **Home Assistant pins `aiohttp==3.14.1`** — the eg4_web_monitor integration is the primary consumer, so the library must run and be tested on 3.14.1. Capping dev/CI would test a version HA doesn't run; capping the runtime dep would make pylxpweb un-installable next to HA.

Fix: an import-time conftest shim (guarded on `stream_writer` being in the signature → no-op on aiohttp < 3.14) subclasses `ClientResponse` to default the kwarg and patches `aioresponses.core.ClientResponse`. `_NoopStreamWriter` exposes only `output_size = 0` (aioresponses passes `writer=None`, so aiohttp only reads that one attribute). Patched via `__dict__` to stay clean under ruff (`B010`) and `mypy --strict` (`attr-defined`) with no `# noqa`/`# type: ignore`. Removable once aioresponses supports aiohttp 3.14.

### 2. Integration Tests — unregistered `control` marker (`pyproject.toml`)
`tests/integration/test_control_operations.py` sets `pytestmark = [..., pytest.mark.control]`, but `control` was never registered in `[tool.pytest.ini_options] markers`. With `--strict-markers`, that's a hard collection error:
```
'control' not found in `markers` configuration option
```
Fix: register the `control` marker. Collection now succeeds (80 integration tests collected).

## Test plan
- Full unit suite: **2046 passed / 0 failed** on aiohttp 3.14.1 (was 21 failed).
- Integration collection succeeds (was a hard error).
- `ruff check` + `ruff format` clean; `mypy --strict src/pylxpweb/` clean (94 files); `mypy --strict tests/conftest.py` clean; `uv build` + `twine check` pass.
- No runtime/packaging change: published wheel metadata unchanged (`Requires-Dist: aiohttp>=3.13.2`); aiohttp stays locked at 3.14.1.

## Tri-vendor adversarial review
Claude + Codex (GPT-5.5 @ xhigh) + Gemini 3.1 Pro — all **NO BLOCKING ISSUES** on the conftest shim (Gemini had flagged an earlier aiohttp-cap approach as a BLOCKER for version skew; this approach eliminates it). The `control` marker registration is a trivial config fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)