### PR TITLE
fix: tolerate parallel-group userVisitRecord at login; UTC battery last_seen (eg4_web_monitor#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Login no longer fails when the "last visited device" is a parallel group** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
+  on a parallel system the EG4 cloud may report the parallel GROUP (e.g.
+  `serialNum="Parallel_A"`) as the account's `userVisitRecord`, which carries only
+  `plantId` + `serialNum` and omits every device-specific field (`phase`,
+  `deviceType`, `batteryType`, …). Those fields were declared required, so
+  `LoginResponse.model_validate()` raised and **every** authenticated call failed
+  (the consumer saw a hard login error and lost all cloud data). The
+  `UserVisitRecord` fields — and `LoginResponse.userVisitRecord` itself — are now
+  optional; the record is informational only and is not read anywhere, so
+  tolerating the parallel-group shape cannot affect any caller.
+- **Battery `last_seen` is now timezone-aware UTC** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
+  the round-robin accumulator stamped each battery's `last_seen` with a naive
+  `datetime.now()` (OS-local). Consumers that interpret a naive datetime as their
+  *own* timezone (e.g. Home Assistant) mis-computed battery freshness when the
+  container timezone differed from theirs. `last_seen` is now stamped with
+  `datetime.now(UTC)` so the value is unambiguous across process boundaries.
 - **`Fault Code` / `Warning Code` no longer flicker to "unknown" on a dropped `bms_data` read** ([eg4_web_monitor#261](https://github.com/joyfulhouse/eg4_web_monitor/issues/261)):
   the inverter fault/warning registers (60-63, in the always-read `status_energy`
   group) are merged with their BMS fallback codes (regs 99-100, in the droppable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.36b16"
+version = "0.9.36b17"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -119,20 +119,28 @@ class CountryInfo(BaseModel):
 
 
 class UserVisitRecord(BaseModel):
-    """User visit record."""
+    """User visit record (the last device the user opened in the portal).
+
+    Only ``plantId`` and ``serialNum`` are guaranteed. When the last-visited
+    entity is a parallel GROUP (``serialNum`` like ``"Parallel_A"``) rather than
+    an individual inverter, the cloud omits every device-specific field. They
+    are therefore all optional. This record is informational only and is not
+    consumed anywhere — keeping login parsing tolerant avoids breaking the whole
+    cloud session over unused metadata (GitHub issue #258).
+    """
 
     plantId: int
     serialNum: str
-    phase: int
-    phaseValue: int
-    deviceType: int
-    deviceTypeValue: int
-    subDeviceTypeValue: int
-    dtc: int
-    dtcValue: int
-    powerRating: int
-    batteryType: BatteryType
-    protocolVersion: int
+    phase: int | None = None
+    phaseValue: int | None = None
+    deviceType: int | None = None
+    deviceTypeValue: int | None = None
+    subDeviceTypeValue: int | None = None
+    dtc: int | None = None
+    dtcValue: int | None = None
+    powerRating: int | None = None
+    batteryType: BatteryType | None = None
+    protocolVersion: int | None = None
 
     @field_serializer("serialNum")
     def serialize_serial(self, value: str) -> str:
@@ -235,7 +243,7 @@ class LoginResponse(BaseModel):
     telNumber: str
     address: str
     platform: str
-    userVisitRecord: UserVisitRecord
+    userVisitRecord: UserVisitRecord | None = None
     plants: list[PlantBasic]
     clusterId: int
     needHideDisChgEnergy: bool

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from pylxpweb.registers import (
@@ -210,7 +210,9 @@ class RegisterDataMixin(_DataMixinBase):
         accumulator: dict[str, dict[int, int]] = getattr(self, "_battery_accumulator", {})
         slot_index: dict[str, int] = getattr(self, "_battery_slot_index", {})
         last_seen: dict[int, datetime] = getattr(self, "_battery_last_seen", {})
-        now = datetime.now()
+        # tz-aware UTC: last_seen crosses into Home Assistant, which would
+        # interpret a naive datetime as its own local zone (eg4_web_monitor#258).
+        now = datetime.now(UTC)
 
         for phys_slot in range(BATTERY_MAX_COUNT):
             slot_base = BATTERY_BASE_ADDRESS + (phys_slot * BATTERY_REGISTER_COUNT)
@@ -284,14 +286,16 @@ class RegisterDataMixin(_DataMixinBase):
         """Stamp ``last_seen`` on each battery from accumulator timestamps.
 
         For non-accumulated reads (battery_count <= 4), all batteries are
-        fresh — stamped with ``datetime.now()``.  For accumulated reads,
+        fresh — stamped with ``datetime.now(UTC)``.  For accumulated reads,
         each battery gets the timestamp from ``_battery_last_seen[pos]``.
         """
         if battery is None or not battery.batteries:
             return
 
         last_seen: dict[int, datetime] = getattr(self, "_battery_last_seen", {})
-        now = datetime.now()
+        # tz-aware UTC: last_seen crosses into Home Assistant, which would
+        # interpret a naive datetime as its own local zone (eg4_web_monitor#258).
+        now = datetime.now(UTC)
 
         for b in battery.batteries:
             b.last_seen = last_seen.get(b.battery_index, now)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -117,6 +117,49 @@ class TestLoginResponse:
         assert model.techInfo.techInfoType2 == "Email"
         assert model.techInfo.techInfo2 == "support@example.com"
 
+    def test_parse_parallel_group_user_visit_record(self) -> None:
+        """Test login when userVisitRecord is a parallel-group stub.
+
+        On parallel systems the EG4 cloud may report the parallel GROUP as the
+        "last visited device". In that case userVisitRecord carries only
+        plantId + serialNum (e.g. serialNum='Parallel_A') and omits every
+        device-specific field (phase, phaseValue, deviceType, deviceTypeValue,
+        subDeviceTypeValue, dtc, dtcValue, powerRating, batteryType,
+        protocolVersion).
+
+        Regression test for GitHub issue #258: these fields were required, so
+        login() raised 10 validation errors -> _ensure_authenticated() raised
+        -> every cloud call failed (ConfigEntryNotReady on setup, frozen
+        cloud battery backfill, log spam).
+        """
+        data = load_sample("login.json")
+        data["userVisitRecord"] = {"plantId": 42921, "serialNum": "Parallel_A"}
+
+        model = LoginResponse.model_validate(data)
+
+        assert model.userVisitRecord is not None
+        assert model.userVisitRecord.plantId == 42921
+        assert model.userVisitRecord.serialNum == "Parallel_A"
+        # Device-specific fields are absent for a parallel group.
+        assert model.userVisitRecord.phase is None
+        assert model.userVisitRecord.deviceType is None
+        assert model.userVisitRecord.batteryType is None
+        assert model.userVisitRecord.protocolVersion is None
+
+    def test_parse_login_without_user_visit_record(self) -> None:
+        """Test login response that omits userVisitRecord entirely.
+
+        Defensive: a brand-new account that has never opened a device in the
+        EG4 portal has no "last visit", so the cloud may omit the field. Login
+        must still succeed.
+        """
+        data = load_sample("login.json")
+        data.pop("userVisitRecord", None)
+
+        model = LoginResponse.model_validate(data)
+
+        assert model.userVisitRecord is None
+
 
 class TestPlantInfo:
     """Test PlantInfo model."""

--- a/tests/unit/transports/test_modbus.py
+++ b/tests/unit/transports/test_modbus.py
@@ -1210,6 +1210,31 @@ class TestBatteryRoundRobinAccumulator:
         # Accumulation always runs: all 4 batteries get a last_seen timestamp.
         assert set(transport._battery_last_seen.keys()) == {0, 1, 2, 3}
 
+    @pytest.mark.asyncio
+    async def test_last_seen_is_timezone_aware_utc(self) -> None:
+        """last_seen must be tz-aware UTC, not naive local (eg4_web_monitor#258).
+
+        last_seen crosses into Home Assistant, which interprets a *naive*
+        datetime as HA's configured timezone. When the container/OS timezone
+        differs from HA's, a naive-local stamp is mis-converted, skewing the
+        battery-freshness decision (a fresh battery looked stale, or a frozen
+        one looked fresh). A tz-aware UTC stamp is unambiguous everywhere.
+        """
+        transport = self._make_transport()
+        page = _build_battery_slot_values([0, 1, 2, 3])
+        _, mock_class = self._mock_client([page])
+
+        with patch("pymodbus.client.AsyncModbusTcpClient", mock_class):
+            await transport.connect()
+            await transport._read_individual_battery_registers(4)
+
+        # The accumulator timestamps feed BatteryData.last_seen, which crosses
+        # into Home Assistant. They must be timezone-aware and in UTC.
+        assert transport._battery_last_seen
+        for ts in transport._battery_last_seen.values():
+            assert ts.tzinfo is not None, "last_seen must be timezone-aware"
+            assert ts.utcoffset().total_seconds() == 0, "last_seen must be UTC"
+
 
 class TestBatteryAccumulatorReg96Unreliable:
     """Round-robin accumulation must not depend on reg 96 (#170, #258).

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.36b16"
+version = "0.9.36b17"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes the cloud-login failure behind [eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258) ("more than 4 batteries don't pull data reliably"), plus a timezone bug in the battery-freshness timestamp.

### 1. Login tolerates a parallel-group `userVisitRecord`
On a parallel system the EG4 cloud may report the parallel **group** (`serialNum="Parallel_A"`) as the account's "last visited device". That record carries only `plantId` + `serialNum` and omits the 10 device-specific fields `UserVisitRecord` declared **required**, so `LoginResponse.model_validate()` raised and **every** authenticated call failed — the HA integration hit `ConfigEntryNotReady` on restart, the HYBRID cloud battery backfill froze, and the log filled with validation errors (the reporter's 24 h log: **838 validation errors vs 32 successful logins**).

`userVisitRecord` is informational only and read nowhere in the library, so its fields — and `LoginResponse.userVisitRecord` itself — are now `Optional`. Mirrors the #256 "cloud-omittable fields" pattern.

### 2. Battery `last_seen` stamped in UTC
The round-robin accumulator stamped `last_seen` with a naive `datetime.now()` (OS-local). Home Assistant interprets a naive datetime as *its* configured timezone, so the HYBRID battery-freshness check skewed by the UTC offset when the container TZ differed from HA's. Now stamped `datetime.now(UTC)` — unambiguous across process boundaries.

## Tests
- `test_models.py`: parallel-group stub + fully-omitted `userVisitRecord` cases.
- `test_modbus.py`: `last_seen` is tz-aware UTC.
- Full suite: **2441 passed**, ruff + mypy clean.

Bumps `0.9.36b16` → `0.9.36b17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
