### PR TITLE
fix: keep HYBRID >4-battery cloud refresh alive + raw RR-page logging (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Raw round-robin battery page logging** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
+  the accumulator logs *virtual* slots and the merged register map hides which
+  battery occupies each *physical* Modbus slot, so firmware round-robin rotation
+  could not be characterized from debug logs. `_accumulate_battery_slots` now
+  emits an `RR raw page: 0=<id> 1=<id> 2=<id> 3=<id>` line each read (physical
+  slot → battery identity, before accumulation, with empty/truncated slots
+  marked). Diffing this line across reads reveals the rotation cadence and what
+  triggers a battery to enter/leave a physical slot — the signal needed to fix
+  non-rotating-firmware systems that have no cloud fallback.
+
 - **`.xls` data-export parser** — `parse_export(content: bytes) -> list[ExportDaySheet]`
   turns the bytes returned by `ExportEndpoints.export_data()` into per-day rows, and
   `ExportEndpoints.export_and_parse()` downloads and parses in one call (offloading the
@@ -20,6 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the optional `xlrd` dependency: `pip install pylxpweb[parse]`. (#181)
 
 ### Fixed
+
+- **HYBRID `>4`-battery cloud refresh no longer stalls after a battery briefly appears locally** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
+  the hybrid supplemental-battery gate (`_wants_hybrid_supplemental_battery`)
+  counted every non-ghost transport battery as "surfaced", including ones the
+  never-evict accumulator re-presents after the firmware stops rotating them into
+  a slot. On non-rotating firmware a battery that entered a Modbus slot even
+  *once* made `surfaced == cloud_count`, silencing the supplemental cloud fetch
+  that kept it live — so it froze at its last value (the #258 reporter's 5th
+  battery degraded from ~5-minute to hourly updates after midnight). A transport
+  battery now counts as surfaced only when its `last_seen` is within
+  `_SUPPLEMENTAL_BATTERY_STALE_AFTER` (2 min) of the freshest sibling — a
+  relative, poll-interval-agnostic comparison — so a frozen cached battery no
+  longer suppresses the cloud refresh. Pure-local and all-batteries-surfaced
+  systems are unchanged (still no extra cloud calls).
 
 - **Login no longer fails when the "last visited device" is a parallel group** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   on a parallel system the EG4 cloud may report the parallel GROUP (e.g.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.36b17"
+version = "0.9.36b18"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -42,6 +42,15 @@ from ._runtime_properties import InverterRuntimePropertiesMixin
 
 _LOGGER = logging.getLogger(__name__)
 
+# A never-evict battery accumulator (eg4_web_monitor#258) keeps re-presenting a
+# battery the firmware stopped surfacing locally, with its last_seen frozen.  In
+# the hybrid supplemental gate, a transport battery whose last_seen lags the
+# freshest sibling by more than this window is treated as not currently surfaced,
+# so the cloud supplement that keeps it live is not silenced.  Kept below the
+# integration's 5-minute transport-freshness overlay so the cloud value is
+# refreshed before the overlay switches to it.
+_SUPPLEMENTAL_BATTERY_STALE_AFTER = timedelta(minutes=2)
+
 
 if TYPE_CHECKING:
     from pylxpweb import LuxpowerClient
@@ -608,11 +617,37 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         # Count non-ghost slots: an empty 5002+ register slot reads 0V/0% SoC
         # (pylxpweb's canonical ghost definition), so it must not count as a
         # surfaced battery — otherwise the gate could never trip.
-        surfaced = sum(
-            1
+        candidates = [
+            batt
             for batt in (getattr(transport_battery, "batteries", None) or [])
             if not (batt.voltage == 0 and batt.soc == 0)
-        )
+        ]
+        if not candidates:
+            return True
+        # Exclude never-evict frozen batteries (eg4_web_monitor#258): on
+        # non-rotating firmware the accumulator re-presents a battery the
+        # firmware stopped surfacing locally, with its last_seen frozen.  If it
+        # counted as surfaced, surfaced would reach cloud_count and silence this
+        # very supplement — freezing that battery at its last value.  A battery
+        # read in step with the freshest sibling is genuinely surfaced; one
+        # materially older was not refreshed this cycle.  The comparison is
+        # relative (newest sibling, not wall-clock), so it is poll-interval
+        # agnostic and needs no clock read.
+        seen = [
+            batt.last_seen for batt in candidates if getattr(batt, "last_seen", None) is not None
+        ]
+        if not seen:
+            # No timestamps (legacy transport): keep the count-only gate rather
+            # than over-fetching cloud data.
+            surfaced = len(candidates)
+        else:
+            newest = max(seen)
+            surfaced = sum(
+                1
+                for batt in candidates
+                if getattr(batt, "last_seen", None) is not None
+                and newest - batt.last_seen <= _SUPPLEMENTAL_BATTERY_STALE_AFTER
+            )
         return cloud_count > surfaced
 
     async def refresh(self, force: bool = False, include_parameters: bool = False) -> None:

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -214,10 +214,18 @@ class RegisterDataMixin(_DataMixinBase):
         # interpret a naive datetime as its own local zone (eg4_web_monitor#258).
         now = datetime.now(UTC)
 
+        # Raw physical-slot -> identity page for rotation diagnostics
+        # (eg4_web_monitor#258): the accumulator log below reports VIRTUAL slots
+        # and the merged map hides which battery occupies each PHYSICAL slot, so
+        # firmware rotation cannot be characterized from logs.  Diffing this line
+        # across reads shows exactly when a battery rotates into/out of a slot.
+        raw_page: list[str] = []
+
         for phys_slot in range(BATTERY_MAX_COUNT):
             slot_base = BATTERY_BASE_ADDRESS + (phys_slot * BATTERY_REGISTER_COUNT)
             status = raw_registers.get(slot_base, 0)
             if not status:
+                raw_page.append(f"{phys_slot}=empty")
                 continue  # Empty physical slot — skip
 
             # Extract this slot's 30-register block (using slot-local offsets 0-29)
@@ -242,6 +250,7 @@ class RegisterDataMixin(_DataMixinBase):
             if serial and len(serial) >= _MIN_BATTERY_SERIAL_LEN:
                 identity = serial
             elif serial_reported:
+                raw_page.append(f"{phys_slot}={serial!r}~trunc")
                 _LOGGER.debug(
                     "[%s] slot %d: truncated serial %r — skipping this poll",
                     self._serial,
@@ -253,6 +262,7 @@ class RegisterDataMixin(_DataMixinBase):
                 pos = (raw_registers.get(slot_base + 24, 0) >> 8) & 0xFF
                 identity = f"pos:{pos}"
 
+            raw_page.append(f"{phys_slot}={identity}")
             if identity not in slot_index:
                 slot_index[identity] = len(slot_index)
             accumulator[identity] = slot_regs
@@ -261,6 +271,13 @@ class RegisterDataMixin(_DataMixinBase):
         self._battery_accumulator = accumulator
         self._battery_slot_index = slot_index
         self._battery_last_seen = last_seen
+
+        _LOGGER.debug(
+            "[%s] RR raw page: %s (reg96=%d)",
+            self._serial,
+            " ".join(raw_page),
+            battery_count,
+        )
 
         if not accumulator:
             return None
@@ -283,11 +300,15 @@ class RegisterDataMixin(_DataMixinBase):
         return merged
 
     def _stamp_battery_last_seen(self, battery: BatteryBankData | None) -> None:
-        """Stamp ``last_seen`` on each battery from accumulator timestamps.
+        """Stamp each battery's ``last_seen`` from the accumulator's per-slot clock.
 
-        For non-accumulated reads (battery_count <= 4), all batteries are
-        fresh — stamped with ``datetime.now(UTC)``.  For accumulated reads,
-        each battery gets the timestamp from ``_battery_last_seen[pos]``.
+        ``_battery_last_seen`` records, per virtual slot, when that slot's battery
+        was last actually read.  A battery the firmware has rotated out keeps its
+        OLD timestamp here — that staleness is exactly the signal the hybrid
+        supplemental gate and the integration's freshness overlay rely on
+        (eg4_web_monitor#258).  ``battery_index`` equals the virtual slot, so every
+        accumulated battery has an entry; the ``now`` fallback is a defensive
+        default for the unreachable case of a battery with no recorded read.
         """
         if battery is None or not battery.batteries:
             return

--- a/tests/unit/devices/test_transport_link_health.py
+++ b/tests/unit/devices/test_transport_link_health.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
@@ -554,8 +555,14 @@ class TestHybridSupplementalBattery:
         bank = Mock()
         bank.battery_count = cloud_count
         inverter._battery_bank = bank
+        # In-slot batteries are stamped together each read, so they share a
+        # fresh last_seen (the never-evict frozen-battery case is covered by its
+        # own test).
+        stamp = datetime(2026, 6, 23, 0, 0, 0, tzinfo=UTC)
         transport_battery = Mock(spec=BatteryBankData)
-        transport_battery.batteries = [Mock(voltage=53.0, soc=80) for _ in range(surfaced)]
+        transport_battery.batteries = [
+            Mock(voltage=53.0, soc=80, last_seen=stamp) for _ in range(surfaced)
+        ]
         inverter._transport_battery = transport_battery
 
     @pytest.mark.asyncio
@@ -617,6 +624,74 @@ class TestHybridSupplementalBattery:
         await inverter.refresh(force=True)
 
         inverter._fetch_battery_http.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_frozen_cached_battery_does_not_count_as_surfaced(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A never-evict frozen battery must not silence the supplement (#258 firestormo).
+
+        Non-rotating firmware places battery 5 into a Modbus slot exactly once,
+        then never again.  pylxpweb's accumulator never evicts, so it re-presents
+        that frozen block forever with its stale ``last_seen``.  If the frozen
+        block counted toward "surfaced", surfaced would equal cloud_count and the
+        supplemental cloud fetch — the only thing keeping battery 5 live — would
+        stop, freezing battery 5 at its last value (the observed regression).  A
+        battery materially older than its freshest sibling was not refreshed this
+        cycle and must not count as surfaced.
+        """
+        inverter = _make_inverter(client=mock_client)
+        self._healthy_transport(inverter)
+
+        bank = Mock()
+        bank.battery_count = 5
+        inverter._battery_bank = bank
+
+        fresh = datetime(2026, 6, 23, 0, 24, 39, tzinfo=UTC)
+        frozen = datetime(2026, 6, 23, 0, 19, 28, tzinfo=UTC)  # ~5 min stale
+        batteries = [Mock(voltage=53.0, soc=80, last_seen=fresh) for _ in range(4)]
+        batteries.append(Mock(voltage=53.0, soc=80, last_seen=frozen))
+        transport_battery = Mock(spec=BatteryBankData)
+        transport_battery.batteries = batteries
+        inverter._transport_battery = transport_battery
+        inverter._fetch_battery_http = AsyncMock()  # type: ignore[method-assign]
+
+        await inverter.refresh(force=True)
+
+        inverter._fetch_battery_http.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rotating_system_fetches_cloud_for_lagging_batteries(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """Rotating HYBRID >4-battery systems keep rotated-out batteries fresh via cloud.
+
+        Only the (up to 4) batteries in this read's physical slots are co-stamped
+        fresh; the rest lag by at least a rotation period.  In HYBRID those lagging
+        batteries would otherwise drift, so the gate fires the supplemental cloud
+        fetch whenever any battery lags the freshest sibling by more than the
+        window.  (Real cloud traffic is bounded by the client's battery_info
+        response cache; pure-LOCAL systems never reach here.)
+        """
+        inverter = _make_inverter(client=mock_client)
+        self._healthy_transport(inverter)
+
+        bank = Mock()
+        bank.battery_count = 8
+        inverter._battery_bank = bank
+
+        fresh = datetime(2026, 6, 23, 0, 24, 39, tzinfo=UTC)
+        lagging = datetime(2026, 6, 23, 0, 18, 0, tzinfo=UTC)  # > 2 min behind
+        batteries = [Mock(voltage=53.0, soc=80, last_seen=fresh) for _ in range(4)]
+        batteries += [Mock(voltage=53.0, soc=80, last_seen=lagging) for _ in range(4)]
+        transport_battery = Mock(spec=BatteryBankData)
+        transport_battery.batteries = batteries
+        inverter._transport_battery = transport_battery
+        inverter._fetch_battery_http = AsyncMock()  # type: ignore[method-assign]
+
+        await inverter.refresh(force=True)
+
+        inverter._fetch_battery_http.assert_awaited_once()
 
 
 class TestMIDDeviceLinkHealth:

--- a/tests/unit/transports/test_modbus.py
+++ b/tests/unit/transports/test_modbus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1008,6 +1009,31 @@ class TestBatteryRoundRobinAccumulator:
         # 4 distinct batteries accumulated, each with 30 registers
         assert len(result) == 120
         assert len(transport._battery_accumulator) == 4
+
+    @pytest.mark.asyncio
+    async def test_raw_physical_page_logged_for_rotation_diagnostics(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Each read logs the raw physical-slot -> identity page (eg4_web_monitor#258).
+
+        The accumulator log shows VIRTUAL slots and the merged map hides which
+        battery occupies each PHYSICAL slot, so firmware rotation cannot be
+        characterized from logs.  The raw page (physical slot -> identity, before
+        accumulation) is the missing signal: diffing it across reads shows exactly
+        when a battery rotates into/out of a physical slot.
+        """
+        transport = self._make_transport()
+        page_a = _build_battery_slot_values([0, 1, 2, 3])
+        _, mock_class = self._mock_client([page_a])
+
+        with patch("pymodbus.client.AsyncModbusTcpClient", mock_class):
+            await transport.connect()
+            with caplog.at_level(logging.DEBUG):
+                await transport._read_individual_battery_registers(4)
+
+        assert "RR raw page" in caplog.text
+        assert "0=pos:0" in caplog.text
+        assert "3=pos:3" in caplog.text
 
     @pytest.mark.asyncio
     async def test_accumulation_first_page(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.36b17"
+version = "0.9.36b18"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Follow-up to the #258 ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)) work. The beta.16 retest log from the reporter showed the 5th battery still degrading after midnight — and the cause turned out to be an interaction between two of our own mechanisms.

**Root cause (verified from the reporter's 13h debug log):** On non-rotating firmware the inverter exposed the 5th battery in a local Modbus slot **exactly once in 13h** (reg 5001 static at 0 → no rotation). The never-evict accumulator cached that single reading and re-presented the frozen block forever. `_wants_hybrid_supplemental_battery` counted that frozen battery as "surfaced", so `surfaced == cloud_count` and the supplemental cloud `getBatteryInfo` that had been keeping the 5th fresh every ~5 min **switched off** — the 5th dropped to hourly updates (only the unrelated hourly param refresh) and looked "stuck/dropped". Before the battery's single local appearance, the cloud was keeping it fresh.

## Changes

- **`_wants_hybrid_supplemental_battery`** (`devices/inverters/base.py`): count a transport battery as "surfaced" only when its `last_seen` is within `_SUPPLEMENTAL_BATTERY_STALE_AFTER` (2 min) of the **freshest sibling** — a relative, poll-interval-agnostic comparison (no clock read). A frozen never-evict battery (last_seen far behind) no longer counts, so the gate re-fires and the cloud refresh keeps the battery current. Falls back to count-only when no timestamps exist. Pure-local (`client=None`) and all-surfaced-≤4 systems are unchanged — no extra cloud calls.
- **Raw round-robin page logging** (`transports/_register_data.py`): new `RR raw page: 0=<id> 1=<id> 2=<id> 3=<id>` debug line per read (physical slot → identity, before accumulation, empty/truncated slots marked). The accumulator log shows *virtual* slots and the merged map hides *physical* ones, so firmware rotation couldn't be characterized from logs. Diffing this line reveals the rotation cadence/trigger — the signal needed for a true local-path fix.
- Corrected the `_stamp_battery_last_seen` docstring (it described a non-existent code path).
- Version → `0.9.36b18`.

## Tests

- `test_frozen_cached_battery_does_not_count_as_surfaced` (TDD red→green) — the reporter's exact case.
- `test_rotating_system_fetches_cloud_for_lagging_batteries` — documents/locks the intended behavior for rotating HYBRID >4-battery systems (gate fires for rotated-out batteries).
- `test_raw_physical_page_logged_for_rotation_diagnostics` — the new debug line.
- Full suite: **2444 passed**, mypy --strict clean, ruff clean.

Adversarially reviewed (pr-review-toolkit) before opening; the rotating-HYBRID behavior change (now fetches cloud for lagging batteries, bounded by the 60s client cache) is intentional and covered by a new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)