### PR TITLE
fix: serve accumulator on failed battery block read + rotation-stall watchdog + co-frozen gate backstop (#258 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Battery rotation-stall watchdog** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
+  the 2026-06-28 report pinned the firmware's battery page for ~9 hours with
+  ZERO non-debug logs — every 120-register block read succeeded, so nothing
+  warned while half the accumulated batteries silently served frozen data.
+  `_log_battery_rotation_stall` now emits one latched WARNING when any
+  accumulated battery has not been surfaced by the firmware for over
+  `BATTERY_ROTATION_STALL_WARN_AFTER` (45 min — above the ~30 min worst-case
+  reappearance interval measured on the #170 12-battery system), and an INFO
+  (re-arming the latch) once rotation resumes. HYBRID compensates via the
+  supplemental cloud refresh; for LOCAL this warning is the only signal.
+
 - **Raw round-robin battery page logging** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   the accumulator logs *virtual* slots and the merged register map hides which
   battery occupies each *physical* Modbus slot, so firmware round-robin rotation
@@ -30,6 +41,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the optional `xlrd` dependency: `pip install pylxpweb[parse]`. (#181)
 
 ### Fixed
+
+- **A failed battery block read no longer wipes individual batteries for the cycle** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
+  when the atomic 5002-5121 read failed (`Failed to read battery registers
+  5002-5121, will retry next poll`) but the bms_data group succeeded,
+  `read_all_input_data`/`read_battery` built a bank with `batteries=[]` that
+  REPLACED the cached `_transport_battery` — every individual battery vanished
+  for that cycle (in the 2026-06-28 incident all battery entities flipped
+  unavailable at the exact second of the warning). The failure path now serves
+  the never-evict accumulator's last-known blocks instead, with their honest
+  stale `last_seen` stamps so the hybrid supplemental gate and the
+  integration's freshness overlay still see exactly how old each battery is.
+  A first-poll failure (nothing accumulated yet) still returns `None`.
+
+- **Hybrid supplemental battery gate: co-frozen batteries no longer silence the cloud refresh** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
+  `_wants_hybrid_supplemental_battery` compared each battery's `last_seen`
+  only *relative to the freshest sibling*, so when the WHOLE local battery
+  feed froze (prolonged block-read failures, or every page pinned), the
+  co-stamped batteries all sat within the window of each other and every one
+  counted as "surfaced" — switching off the supplemental cloud fetch during
+  exactly the outage it exists for. The gate now also checks the freshest
+  stamp against the wall clock: if even the newest is older than
+  `_SUPPLEMENTAL_BATTERY_STALE_AFTER` (2 min), nothing is surfaced and the
+  cloud refresh keeps all batteries live.
 
 - **HYBRID `>4`-battery cloud refresh no longer stalls after a battery briefly appears locally** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   the hybrid supplemental-battery gate (`_wants_hybrid_supplemental_battery`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the 2026-06-28 report pinned the firmware's battery page for ~9 hours with
   ZERO non-debug logs — every 120-register block read succeeded, so nothing
   warned while half the accumulated batteries silently served frozen data.
-  `_log_battery_rotation_stall` now emits one latched WARNING when any
-  accumulated battery has not been surfaced by the firmware for over
-  `BATTERY_ROTATION_STALL_WARN_AFTER` (45 min — above the ~30 min worst-case
-  reappearance interval measured on the #170 12-battery system), and an INFO
-  (re-arming the latch) once rotation resumes. HYBRID compensates via the
-  supplemental cloud refresh; for LOCAL this warning is the only signal.
+  `_log_battery_rotation_stall` now emits a WARNING when an accumulated
+  battery has not been surfaced by the firmware past a page-count-scaled
+  threshold — `max(45 min, pages x 15 min)`, calibrated on the #170
+  12-battery/3-page system's ~30 min worst-case reappearance (so a 24-battery
+  array warns at 90 min instead of spamming at 45) — and an INFO when that
+  battery is surfaced again. Latching is **per battery per stall episode**
+  (not one global latch): a permanent straggler, e.g. a physically removed
+  battery that the never-evict accumulator keeps by design, cannot mask a
+  later unrelated battery's stall. Covers only the success path (pinned page
+  with successful reads); persistent block-read failures are surfaced by the
+  per-cycle "Failed to read battery registers ... serving N accumulated"
+  warning instead. HYBRID compensates via the supplemental cloud refresh; for
+  LOCAL this warning is the only signal.
 
 - **Raw round-robin battery page logging** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   the accumulator logs *virtual* slots and the merged register map hides which
@@ -61,9 +68,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   co-stamped batteries all sat within the window of each other and every one
   counted as "surfaced" — switching off the supplemental cloud fetch during
   exactly the outage it exists for. The gate now also checks the freshest
-  stamp against the wall clock: if even the newest is older than
-  `_SUPPLEMENTAL_BATTERY_STALE_AFTER` (2 min), nothing is surfaced and the
-  cloud refresh keeps all batteries live.
+  stamp against the wall clock. The backstop threshold **scales with the
+  battery cache TTL** — `max(2 min, TTL x 2.5)` — because the gate runs
+  before each cycle's read (the newest stamp is always ~one poll interval
+  old) and consumers pin the TTL to their poll interval, which is
+  UI-configurable up to 300 s: a fixed 2-minute cutoff would have fired on
+  every healthy slow-poll cycle, silently turning the supplement into an
+  every-poll cloud fetch. Default installs (30 s TTL) keep the 2-minute
+  floor, so a genuinely co-frozen feed still trips promptly.
 
 - **HYBRID `>4`-battery cloud refresh no longer stalls after a battery briefly appears locally** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   the hybrid supplemental-battery gate (`_wants_hybrid_supplemental_battery`)

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -11,7 +11,7 @@ import logging
 from abc import abstractmethod
 from collections.abc import Awaitable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from pylxpweb.constants import (
@@ -640,6 +640,15 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             # No timestamps (legacy transport): keep the count-only gate rather
             # than over-fetching cloud data.
             surfaced = len(candidates)
+        elif datetime.now(UTC) - max(seen) > _SUPPLEMENTAL_BATTERY_STALE_AFTER:
+            # The WHOLE local battery feed is stale — block reads failing for a
+            # stretch, or every page pinned/frozen.  The relative check below
+            # cannot see this: co-frozen batteries all sit within the window of
+            # each other (the newest stamp IS a frozen stamp), so they would all
+            # count as "surfaced" and silence the cloud supplement during
+            # exactly the outage it exists for (eg4_web_monitor#258, the
+            # 2026-06-28 9-hour stall).  Nothing locally fresh, nothing surfaced.
+            surfaced = 0
         else:
             newest = max(seen)
             surfaced = sum(

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -49,7 +49,20 @@ _LOGGER = logging.getLogger(__name__)
 # so the cloud supplement that keeps it live is not silenced.  Kept below the
 # integration's 5-minute transport-freshness overlay so the cloud value is
 # refreshed before the overlay switches to it.
+#
+# The same constant is the FLOOR of the whole-feed staleness backstop: the
+# effective threshold there scales with the battery cache TTL (see
+# _SUPPLEMENTAL_FEED_STALE_TTL_FACTOR) because consumers pin that TTL to their
+# poll interval, which can legitimately exceed this window.
 _SUPPLEMENTAL_BATTERY_STALE_AFTER = timedelta(minutes=2)
+
+# Whole-feed staleness backstop scale factor.  The gate is evaluated while
+# refresh() builds its task list — BEFORE this cycle's transport read — so the
+# newest last_seen is always ~one poll interval old at evaluation time.  The
+# backstop threshold is therefore max(floor, TTL x this factor): 2.5 intervals
+# tolerates scheduling jitter and one missed poll on any configured interval,
+# while a feed older than that is genuinely frozen.
+_SUPPLEMENTAL_FEED_STALE_TTL_FACTOR = 2.5
 
 
 if TYPE_CHECKING:
@@ -640,7 +653,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             # No timestamps (legacy transport): keep the count-only gate rather
             # than over-fetching cloud data.
             surfaced = len(candidates)
-        elif datetime.now(UTC) - max(seen) > _SUPPLEMENTAL_BATTERY_STALE_AFTER:
+        elif datetime.now(UTC) - max(seen) > self._supplemental_feed_stale_after():
             # The WHOLE local battery feed is stale — block reads failing for a
             # stretch, or every page pinned/frozen.  The relative check below
             # cannot see this: co-frozen batteries all sit within the window of
@@ -648,6 +661,13 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             # count as "surfaced" and silence the cloud supplement during
             # exactly the outage it exists for (eg4_web_monitor#258, the
             # 2026-06-28 9-hour stall).  Nothing locally fresh, nothing surfaced.
+            #
+            # The threshold scales with the battery cache TTL (the consumer's
+            # poll interval): this property runs BEFORE this cycle's read, so
+            # the newest stamp is always ~one interval old — a fixed 2-minute
+            # cutoff would fire on EVERY healthy cycle for the UI-supported
+            # intervals above 2 minutes, silently turning the supplement into
+            # an every-poll cloud fetch.
             surfaced = 0
         else:
             newest = max(seen)
@@ -658,6 +678,23 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                 and newest - batt.last_seen <= _SUPPLEMENTAL_BATTERY_STALE_AFTER
             )
         return cloud_count > surfaced
+
+    def _supplemental_feed_stale_after(self) -> timedelta:
+        """Whole-feed staleness threshold for the supplemental battery gate.
+
+        ``max(floor, battery cache TTL x 2.5)``: default installs (30 s TTL)
+        keep the 2-minute floor so a co-frozen feed still trips promptly; a
+        user polling every 300 s gets a ~750 s threshold that a healthy
+        cycle's one-interval-old stamps never cross.  Falls back to the bare
+        floor if the TTL is unavailable.
+        """
+        ttl = getattr(self, "_battery_cache_ttl", None)
+        if isinstance(ttl, timedelta):
+            return max(
+                _SUPPLEMENTAL_BATTERY_STALE_AFTER,
+                ttl * _SUPPLEMENTAL_FEED_STALE_TTL_FACTOR,
+            )
+        return _SUPPLEMENTAL_BATTERY_STALE_AFTER
 
     async def refresh(self, force: bool = False, include_parameters: bool = False) -> None:
         """Refresh runtime, energy, battery, and optionally parameters from API.

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -58,14 +58,21 @@ _LOGGER = logging.getLogger(__name__)
 _MIN_BATTERY_SERIAL_LEN = 10
 
 # Rotation-stall watchdog (eg4_web_monitor#258).  Firmware rotates >4 batteries
-# through the 4 physical slots; on the #170 12-battery system every battery
-# reappears within ~30 minutes worst-case.  A battery not surfaced for longer
-# than this means rotation has stalled/pinned — the 2026-06-28 incident pinned
-# one page for ~9 HOURS with zero non-debug logs (every block read succeeded;
-# the data was just frozen).  One latched WARNING per stall episode makes that
-# state visible; HYBRID compensates via the supplemental cloud refresh, LOCAL
-# has no compensation so the warning is the only signal.
+# through the 4 physical slots; a battery not surfaced for the effective
+# threshold means rotation has stalled/pinned for it — the 2026-06-28 incident
+# pinned one page for ~9 HOURS with zero non-debug logs (every block read
+# succeeded; the data was just frozen).  One latched WARNING per battery per
+# stall episode makes that state visible; HYBRID compensates via the
+# supplemental cloud refresh, LOCAL has no compensation so the warning is the
+# only signal.
+#
+# Calibration (#170): a 12-battery system (3 pages of 4) surfaces every battery
+# within ~30 minutes worst-case, i.e. ~10 min/page.  The effective threshold is
+# max(this 45-minute floor, pages x 15 min) — 15 min/page carries a 50% margin
+# over the measured cadence, and the floor keeps small arrays quiet, so a
+# 24-battery (6-page) array warns at 90 min instead of spamming at 45.
 BATTERY_ROTATION_STALL_WARN_AFTER = timedelta(minutes=45)
+_BATTERY_STALL_PER_PAGE = timedelta(minutes=15)
 
 # ---------------------------------------------------------------------------
 # Register group constants (unified across Modbus and Dongle transports)
@@ -342,27 +349,47 @@ class RegisterDataMixin(_DataMixinBase):
         return merged
 
     def _log_battery_rotation_stall(self, now: datetime) -> None:
-        """Latched WARNING when accumulated batteries stop being surfaced (#258).
+        """Per-battery latched WARNING when accumulation stops being surfaced (#258).
 
         The 2026-06-28 incident pinned the firmware's battery page for ~9 hours:
         every 120-register block read SUCCEEDED, so no warning ever fired while
         half the accumulated batteries silently served frozen data.  This
-        watchdog warns once when any accumulated battery has not appeared in a
-        physical slot for :data:`BATTERY_ROTATION_STALL_WARN_AFTER`, and logs an
-        INFO (re-arming the latch) once every battery is fresh again.
+        watchdog warns once per battery per stall episode when it has not
+        appeared in a physical slot for the effective threshold
+        (``max(BATTERY_ROTATION_STALL_WARN_AFTER, pages x 15 min)``), and logs
+        an INFO — re-arming that battery's latch — when it is surfaced again.
+
+        Latching is per identity, not global: a permanent straggler (e.g. a
+        physically removed battery, never evicted by design) must not hold a
+        global latch armed and mask a later, unrelated battery's stall — that
+        would silently reproduce the exact blind spot this watchdog closes.
+
+        This only covers the SUCCESS path — block reads succeeding while the
+        firmware pins the page.  Persistent block-read FAILURES never reach
+        this method; they are surfaced by the per-cycle "Failed to read
+        battery registers ... serving N accumulated batteries" warning in
+        :meth:`_read_individual_battery_registers` instead.
         """
         slot_index: dict[str, int] = getattr(self, "_battery_slot_index", {})
         last_seen: dict[int, datetime] = getattr(self, "_battery_last_seen", {})
 
-        stale: list[str] = []
+        # Threshold scales with the rotation cycle length (see the constants'
+        # calibration note): more accumulated batteries means more pages to
+        # cycle through before a battery legitimately reappears.
+        pages = max(1, -(-len(slot_index) // BATTERY_MAX_COUNT))
+        threshold = max(BATTERY_ROTATION_STALL_WARN_AFTER, pages * _BATTERY_STALL_PER_PAGE)
+
+        stale: dict[str, str] = {}
         for identity, slot in sorted(slot_index.items(), key=lambda kv: kv[1]):
             seen = last_seen.get(slot)
-            if seen is not None and now - seen > BATTERY_ROTATION_STALL_WARN_AFTER:
-                stale.append(f"{identity} ({int((now - seen).total_seconds() // 60)} min)")
+            if seen is not None and now - seen > threshold:
+                stale[identity] = f"{identity} ({int((now - seen).total_seconds() // 60)} min)"
 
-        already_logged = bool(getattr(self, "_battery_rotation_stall_logged", False))
-        if stale and not already_logged:
-            self._battery_rotation_stall_logged = True
+        warned: set[str] = getattr(self, "_battery_stall_warned", set())
+        newly_stale = [identity for identity in stale if identity not in warned]
+        recovered = sorted(warned - stale.keys())
+
+        if newly_stale:
             _LOGGER.warning(
                 "[%s] Battery rotation stalled: %d of %d accumulated batteries "
                 "not surfaced by the firmware for over %d minutes (%s); their "
@@ -371,16 +398,19 @@ class RegisterDataMixin(_DataMixinBase):
                 self._serial,
                 len(stale),
                 len(slot_index),
-                int(BATTERY_ROTATION_STALL_WARN_AFTER.total_seconds() // 60),
-                ", ".join(stale),
+                int(threshold.total_seconds() // 60),
+                ", ".join(stale.values()),
             )
-        elif not stale and already_logged:
-            self._battery_rotation_stall_logged = False
+        if recovered:
             _LOGGER.info(
-                "[%s] Battery rotation resumed: all %d accumulated batteries are fresh again",
+                "[%s] Battery rotation resumed for %d of %d accumulated batteries (%s)",
                 self._serial,
+                len(recovered),
                 len(slot_index),
+                ", ".join(recovered),
             )
+
+        self._battery_stall_warned = (warned | set(newly_stale)) - set(recovered)
 
     def _stamp_battery_last_seen(self, battery: BatteryBankData | None) -> None:
         """Stamp each battery's ``last_seen`` from the accumulator's per-slot clock.

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from pylxpweb.registers import (
@@ -56,6 +56,16 @@ _LOGGER = logging.getLogger(__name__)
 # back to position-based identity until its full serial appears.  Mirrors the
 # integration's round-robin merge threshold (coordinator_local._MIN_SERIAL_LENGTH).
 _MIN_BATTERY_SERIAL_LEN = 10
+
+# Rotation-stall watchdog (eg4_web_monitor#258).  Firmware rotates >4 batteries
+# through the 4 physical slots; on the #170 12-battery system every battery
+# reappears within ~30 minutes worst-case.  A battery not surfaced for longer
+# than this means rotation has stalled/pinned — the 2026-06-28 incident pinned
+# one page for ~9 HOURS with zero non-debug logs (every block read succeeded;
+# the data was just frozen).  One latched WARNING per stall episode makes that
+# state visible; HYBRID compensates via the supplemental cloud refresh, LOCAL
+# has no compensation so the warning is the only signal.
+BATTERY_ROTATION_STALL_WARN_AFTER = timedelta(minutes=45)
 
 # ---------------------------------------------------------------------------
 # Register group constants (unified across Modbus and Dongle transports)
@@ -188,13 +198,33 @@ class RegisterDataMixin(_DataMixinBase):
         try:
             values = await self._read_input_registers(BATTERY_BASE_ADDRESS, total_registers)
         except Exception:
+            # eg4_web_monitor#258 (2026-06-28): returning None here while the
+            # bms_data group succeeded made the caller build a bank with
+            # batteries=[] that REPLACED the cached one — every individual
+            # battery vanished for the cycle even though the accumulator still
+            # held them all.  Serve the accumulator's last-known blocks instead;
+            # their last_seen stamps stay old (not re-stamped), so the hybrid
+            # supplemental gate and the integration's freshness overlay see the
+            # staleness honestly.  Only a first-poll failure (nothing
+            # accumulated yet) still returns None.
+            cached = self._merged_accumulator_registers()
+            if cached is None:
+                _LOGGER.warning(
+                    "[%s] Failed to read battery registers %d-%d, will retry next poll",
+                    self._serial,
+                    BATTERY_BASE_ADDRESS,
+                    BATTERY_BASE_ADDRESS + total_registers - 1,
+                )
+                return None
             _LOGGER.warning(
-                "[%s] Failed to read battery registers %d-%d, will retry next poll",
+                "[%s] Failed to read battery registers %d-%d; serving %d "
+                "accumulated batteries from the last good read, will retry next poll",
                 self._serial,
                 BATTERY_BASE_ADDRESS,
                 BATTERY_BASE_ADDRESS + total_registers - 1,
+                len(getattr(self, "_battery_accumulator", {})),
             )
-            return None
+            return cached
 
         raw_registers = self._registers_from_values(BATTERY_BASE_ADDRESS, values)
 
@@ -290,14 +320,67 @@ class RegisterDataMixin(_DataMixinBase):
             battery_count,
         )
 
-        # Build merged register map: each identity at its stable virtual slot.
+        self._log_battery_rotation_stall(now)
+
+        return self._merged_accumulator_registers()
+
+    def _merged_accumulator_registers(self) -> dict[int, int] | None:
+        """Merged register map of every accumulated battery at its virtual slot.
+
+        Returns *None* when nothing has been accumulated yet.
+        """
+        accumulator: dict[str, dict[int, int]] = getattr(self, "_battery_accumulator", {})
+        slot_index: dict[str, int] = getattr(self, "_battery_slot_index", {})
+        if not accumulator:
+            return None
+
         merged: dict[int, int] = {}
         for identity, regs in accumulator.items():
             virtual_base = BATTERY_BASE_ADDRESS + (slot_index[identity] * BATTERY_REGISTER_COUNT)
             for offset, value in regs.items():
                 merged[virtual_base + offset] = value
-
         return merged
+
+    def _log_battery_rotation_stall(self, now: datetime) -> None:
+        """Latched WARNING when accumulated batteries stop being surfaced (#258).
+
+        The 2026-06-28 incident pinned the firmware's battery page for ~9 hours:
+        every 120-register block read SUCCEEDED, so no warning ever fired while
+        half the accumulated batteries silently served frozen data.  This
+        watchdog warns once when any accumulated battery has not appeared in a
+        physical slot for :data:`BATTERY_ROTATION_STALL_WARN_AFTER`, and logs an
+        INFO (re-arming the latch) once every battery is fresh again.
+        """
+        slot_index: dict[str, int] = getattr(self, "_battery_slot_index", {})
+        last_seen: dict[int, datetime] = getattr(self, "_battery_last_seen", {})
+
+        stale: list[str] = []
+        for identity, slot in sorted(slot_index.items(), key=lambda kv: kv[1]):
+            seen = last_seen.get(slot)
+            if seen is not None and now - seen > BATTERY_ROTATION_STALL_WARN_AFTER:
+                stale.append(f"{identity} ({int((now - seen).total_seconds() // 60)} min)")
+
+        already_logged = bool(getattr(self, "_battery_rotation_stall_logged", False))
+        if stale and not already_logged:
+            self._battery_rotation_stall_logged = True
+            _LOGGER.warning(
+                "[%s] Battery rotation stalled: %d of %d accumulated batteries "
+                "not surfaced by the firmware for over %d minutes (%s); their "
+                "local data is frozen at the last read (HYBRID keeps them fresh "
+                "from the cloud; LOCAL has no fallback)",
+                self._serial,
+                len(stale),
+                len(slot_index),
+                int(BATTERY_ROTATION_STALL_WARN_AFTER.total_seconds() // 60),
+                ", ".join(stale),
+            )
+        elif not stale and already_logged:
+            self._battery_rotation_stall_logged = False
+            _LOGGER.info(
+                "[%s] Battery rotation resumed: all %d accumulated batteries are fresh again",
+                self._serial,
+                len(slot_index),
+            )
 
     def _stamp_battery_last_seen(self, battery: BatteryBankData | None) -> None:
         """Stamp each battery's ``last_seen`` from the accumulator's per-slot clock.

--- a/tests/unit/devices/test_transport_link_health.py
+++ b/tests/unit/devices/test_transport_link_health.py
@@ -10,6 +10,7 @@ MIDDevice.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -714,7 +715,8 @@ class TestHybridSupplementalBattery:
         inverter._battery_bank = bank
 
         # All 8 co-stamped (within the relative window of each other) but the
-        # whole feed is stale: newest stamp is ~10 minutes old.
+        # whole feed is stale: newest stamp is ~10 minutes old — far past the
+        # scaled backstop for the default 30 s TTL (max(2 min, 75 s) = 2 min).
         frozen = datetime.now(UTC) - timedelta(minutes=10)
         batteries = [Mock(voltage=53.0, soc=80, last_seen=frozen) for _ in range(8)]
         transport_battery = Mock(spec=BatteryBankData)
@@ -722,6 +724,110 @@ class TestHybridSupplementalBattery:
         inverter._transport_battery = transport_battery
         inverter._fetch_battery_http = AsyncMock()  # type: ignore[method-assign]
 
+        await inverter.refresh(force=True)
+
+        inverter._fetch_battery_http.assert_awaited_once()
+
+    @staticmethod
+    def _stamped_transport(
+        inverter: GenericInverter, *, count: int, frozen_stamp: datetime | None
+    ) -> AsyncMock:
+        """Attach a combined-read transport with controllable battery stamps.
+
+        ``frozen_stamp=None`` re-stamps every battery ``now`` on each read (a
+        healthy feed, as the real transport stamps in-page batteries); a fixed
+        stamp models a frozen feed (pinned page / block reads served from the
+        accumulator), where ``last_seen`` never advances.
+        """
+
+        def _combined(*_args: object, **_kwargs: object) -> tuple[Mock, Mock, Mock]:
+            runtime, energy, battery = _make_combined_data()
+            stamp = frozen_stamp if frozen_stamp is not None else datetime.now(UTC)
+            battery.batteries = [Mock(voltage=53.0, soc=80, last_seen=stamp) for _ in range(count)]
+            return runtime, energy, battery
+
+        transport = AsyncMock()
+        transport.read_all_input_data = AsyncMock(side_effect=_combined)
+        inverter._transport = transport
+        return transport
+
+    def _seed_costamped_bank(
+        self, inverter: GenericInverter, *, count: int, stamp: datetime
+    ) -> None:
+        """Seed the cloud bank and a previous-cycle transport battery snapshot."""
+        bank = Mock()
+        bank.battery_count = count
+        inverter._battery_bank = bank
+        seed = Mock(spec=BatteryBankData)
+        seed.batteries = [Mock(voltage=53.0, soc=80, last_seen=stamp) for _ in range(count)]
+        inverter._transport_battery = seed
+
+    @pytest.mark.asyncio
+    async def test_slow_poll_healthy_cycles_do_not_fire_supplemental(
+        self, mock_client: LuxpowerClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A poll interval above the 2-min floor must NOT fire the supplement.
+
+        The gate is evaluated while refresh() BUILDS its task list — BEFORE
+        this cycle's transport read — so the newest ``last_seen`` is always
+        ~one poll interval old at evaluation time.  A fixed absolute cutoff
+        below the poll interval would therefore fire on EVERY healthy cycle
+        (intervals are UI-configurable up to 300 s and the integration pins
+        the battery cache TTL to them via set_cache_ttls) — a permanent,
+        silent every-poll cloud fetch.  The backstop must scale with the TTL.
+
+        Scaled-down clock: floor 0.2 s, TTL 0.4 s → threshold max(0.2 s,
+        2.5 x 0.4 s) = 1.0 s.  The 0.5 s inter-cycle gap is one healthy
+        "poll interval" that the unscaled floor (0.5 > 0.2) mistook for a
+        frozen feed.  Two REAL refresh cycles across real elapsed gaps.
+        """
+        from pylxpweb.devices.inverters import base as base_module
+
+        monkeypatch.setattr(
+            base_module,
+            "_SUPPLEMENTAL_BATTERY_STALE_AFTER",
+            timedelta(seconds=0.2),
+        )
+        inverter = _make_inverter(client=mock_client)
+        inverter.set_cache_ttls(battery=timedelta(seconds=0.4))
+        self._stamped_transport(inverter, count=2, frozen_stamp=None)
+        self._seed_costamped_bank(inverter, count=2, stamp=datetime.now(UTC))
+        inverter._fetch_battery_http = AsyncMock()  # type: ignore[method-assign]
+
+        await asyncio.sleep(0.5)  # one healthy poll interval elapses
+        await inverter.refresh(force=True)
+        await asyncio.sleep(0.5)  # next healthy interval
+        await inverter.refresh(force=True)
+
+        assert inverter._fetch_battery_http.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_slow_poll_co_frozen_feed_still_fires(
+        self, mock_client: LuxpowerClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A feed frozen past the scaled threshold still fires the supplement.
+
+        Same scaled clock as the healthy test (threshold 1.0 s), but the
+        transport keeps serving batteries whose ``last_seen`` never advances
+        (pinned page / accumulator-served failed reads).  Once the elapsed
+        gap exceeds the scaled threshold, nothing counts as surfaced and the
+        cloud supplement fires.
+        """
+        from pylxpweb.devices.inverters import base as base_module
+
+        monkeypatch.setattr(
+            base_module,
+            "_SUPPLEMENTAL_BATTERY_STALE_AFTER",
+            timedelta(seconds=0.2),
+        )
+        inverter = _make_inverter(client=mock_client)
+        inverter.set_cache_ttls(battery=timedelta(seconds=0.4))
+        frozen_stamp = datetime.now(UTC)
+        self._stamped_transport(inverter, count=2, frozen_stamp=frozen_stamp)
+        self._seed_costamped_bank(inverter, count=2, stamp=frozen_stamp)
+        inverter._fetch_battery_http = AsyncMock()  # type: ignore[method-assign]
+
+        await asyncio.sleep(1.1)  # beyond the 1.0 s scaled threshold
         await inverter.refresh(force=True)
 
         inverter._fetch_battery_http.assert_awaited_once()

--- a/tests/unit/devices/test_transport_link_health.py
+++ b/tests/unit/devices/test_transport_link_health.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
@@ -557,8 +557,9 @@ class TestHybridSupplementalBattery:
         inverter._battery_bank = bank
         # In-slot batteries are stamped together each read, so they share a
         # fresh last_seen (the never-evict frozen-battery case is covered by its
-        # own test).
-        stamp = datetime(2026, 6, 23, 0, 0, 0, tzinfo=UTC)
+        # own test).  Relative to now: the gate also has an absolute-staleness
+        # backstop that must not trip for genuinely fresh batteries.
+        stamp = datetime.now(UTC)
         transport_battery = Mock(spec=BatteryBankData)
         transport_battery.batteries = [
             Mock(voltage=53.0, soc=80, last_seen=stamp) for _ in range(surfaced)
@@ -647,8 +648,8 @@ class TestHybridSupplementalBattery:
         bank.battery_count = 5
         inverter._battery_bank = bank
 
-        fresh = datetime(2026, 6, 23, 0, 24, 39, tzinfo=UTC)
-        frozen = datetime(2026, 6, 23, 0, 19, 28, tzinfo=UTC)  # ~5 min stale
+        fresh = datetime.now(UTC)
+        frozen = fresh - timedelta(minutes=5, seconds=11)  # ~5 min stale
         batteries = [Mock(voltage=53.0, soc=80, last_seen=fresh) for _ in range(4)]
         batteries.append(Mock(voltage=53.0, soc=80, last_seen=frozen))
         transport_battery = Mock(spec=BatteryBankData)
@@ -680,10 +681,42 @@ class TestHybridSupplementalBattery:
         bank.battery_count = 8
         inverter._battery_bank = bank
 
-        fresh = datetime(2026, 6, 23, 0, 24, 39, tzinfo=UTC)
-        lagging = datetime(2026, 6, 23, 0, 18, 0, tzinfo=UTC)  # > 2 min behind
+        fresh = datetime.now(UTC)
+        lagging = fresh - timedelta(minutes=6, seconds=39)  # > 2 min behind
         batteries = [Mock(voltage=53.0, soc=80, last_seen=fresh) for _ in range(4)]
         batteries += [Mock(voltage=53.0, soc=80, last_seen=lagging) for _ in range(4)]
+        transport_battery = Mock(spec=BatteryBankData)
+        transport_battery.batteries = batteries
+        inverter._transport_battery = transport_battery
+        inverter._fetch_battery_http = AsyncMock()  # type: ignore[method-assign]
+
+        await inverter.refresh(force=True)
+
+        inverter._fetch_battery_http.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_all_batteries_co_frozen_still_fires_cloud_refresh(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A fully frozen local battery feed must not silence the supplement (#258).
+
+        When block reads fail for a stretch (or every page is pinned), ALL
+        transport batteries share old, co-stamped ``last_seen`` values.  The
+        relative check alone would call them all "surfaced" — the newest stamp
+        IS the frozen stamp — silencing the cloud supplement during exactly the
+        outage it exists for.  Nothing locally fresh means nothing is surfaced.
+        """
+        inverter = _make_inverter(client=mock_client)
+        self._healthy_transport(inverter)
+
+        bank = Mock()
+        bank.battery_count = 8
+        inverter._battery_bank = bank
+
+        # All 8 co-stamped (within the relative window of each other) but the
+        # whole feed is stale: newest stamp is ~10 minutes old.
+        frozen = datetime.now(UTC) - timedelta(minutes=10)
+        batteries = [Mock(voltage=53.0, soc=80, last_seen=frozen) for _ in range(8)]
         transport_battery = Mock(spec=BatteryBankData)
         transport_battery.batteries = batteries
         inverter._transport_battery = transport_battery

--- a/tests/unit/transports/test_battery_block_drop_serves_accumulator.py
+++ b/tests/unit/transports/test_battery_block_drop_serves_accumulator.py
@@ -26,7 +26,7 @@ when rotation resumes.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -295,3 +295,73 @@ class TestBatteryRotationStallWarning:
                 await transport._read_individual_battery_registers(8)
 
         assert "Battery rotation stalled" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_straggler_does_not_mask_new_stall(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A permanent straggler must not latch away warnings for NEW stalls.
+
+        A physically removed/replaced battery is never evicted by design, so it
+        stays stale forever.  With a single global latch its one warning would
+        stick (re-arming required ALL identities fresh), and a later, unrelated
+        battery stall would log NOTHING — silently reproducing the exact blind
+        spot the watchdog exists to close.  Latching is per identity: each
+        battery warns once per ITS OWN stall episode.
+        """
+        transport = _transport()
+        pages: list[list[int] | Exception] = [
+            _page([0, 1, 2, 3]),  # accumulate page A
+            _page([4, 5, 6, 7]),  # accumulate page B
+            _page([0, 1, 2, 3]),  # pos:7 backdated below -> warn #1
+            _page([0, 1, 3]),  # pos:2 not refreshed; backdated below -> warn #2
+        ]
+        fake = _make_fake_read(pages)
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            caplog.at_level(logging.INFO),
+        ):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            self._backdate(transport, [7])  # straggler (e.g. removed battery)
+            await transport._read_individual_battery_registers(8)
+            self._backdate(transport, [2])  # NEW, unrelated stall
+            await transport._read_individual_battery_registers(8)
+
+        warnings = [r for r in caplog.records if "Battery rotation stalled" in r.message]
+        assert len(warnings) == 2
+        assert "pos:7" in warnings[0].message
+        assert "pos:2" in warnings[1].message
+
+    @pytest.mark.asyncio
+    async def test_threshold_scales_with_battery_count(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Large arrays get a proportionally longer stall threshold.
+
+        The 45-min floor is calibrated on #170's 12-battery (3-page) system
+        (~30 min worst-case reappearance).  A 24-battery array rotates 6
+        pages, so a fixed 45-min cutoff would warn on perfectly healthy
+        rotation lag.  The threshold scales at 15 min/page: 6 pages → 90 min.
+        """
+        transport = _transport()
+        pages: list[list[int] | Exception] = [
+            _page(list(range(p * 4, p * 4 + 4))) for p in range(6)
+        ]
+        fake = _make_fake_read(pages + [_page([0, 1, 2, 3])] * 2, battery_count=24)
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            caplog.at_level(logging.WARNING),
+        ):
+            for _ in range(6):
+                await transport._read_individual_battery_registers(24)
+            # 60 min behind: past the 45-min floor but inside the scaled
+            # 90-min threshold -> healthy rotation lag on a big array, silent.
+            transport._battery_last_seen[23] = datetime.now(UTC) - timedelta(minutes=60)
+            await transport._read_individual_battery_registers(24)
+            assert "Battery rotation stalled" not in caplog.text
+            # 100 min behind: beyond the scaled threshold -> stalled, warns.
+            transport._battery_last_seen[23] = datetime.now(UTC) - timedelta(minutes=100)
+            await transport._read_individual_battery_registers(24)
+
+        assert "Battery rotation stalled" in caplog.text

--- a/tests/unit/transports/test_battery_block_drop_serves_accumulator.py
+++ b/tests/unit/transports/test_battery_block_drop_serves_accumulator.py
@@ -1,0 +1,297 @@
+"""A failed 5002+ battery block read must serve the accumulator, not wipe batteries.
+
+Regression for eg4_web_monitor#258 (ivanfmartinez, 2026-06-28, beta.16 +
+pylxpweb 0.9.36b17): a WiFi-dongle glitch failed ONE battery block read
+(``Failed to read battery registers 5002-5121, will retry next poll``).
+``_read_individual_battery_registers`` returned ``None``, but the bms_data
+group had succeeded, so ``read_all_input_data`` built a bank with
+``batteries=[]`` that REPLACED the cached ``_transport_battery`` — wiping
+every individual battery for the cycle even though the never-evict
+accumulator still held all of them. Downstream, every individual battery
+entity flipped unavailable at that exact second.
+
+The fix: on a failed block read, serve the accumulator's last-known blocks
+(with their honest, stale ``last_seen`` stamps — the signal the hybrid
+supplemental gate and the integration's freshness overlay key off) instead
+of dropping the batteries. Only a failure with an EMPTY accumulator (first
+poll after startup) still returns ``None``.
+
+The same incident exposed a 9-hour silently-pinned rotation (the firmware
+kept serving one page; reads succeeded, so no warnings fired while half the
+accumulated batteries froze). ``_log_battery_rotation_stall`` now emits one
+latched WARNING when accumulated batteries stop being surfaced, and an INFO
+when rotation resumes.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from pylxpweb.registers import (
+    BATTERY_BASE_ADDRESS,
+    BATTERY_MAX_COUNT,
+    BATTERY_REGISTER_COUNT,
+)
+from pylxpweb.transports._register_data import BATTERY_ROTATION_STALL_WARN_AFTER
+from pylxpweb.transports.modbus import ModbusTransport
+
+_VOLTAGE_RAW = 534  # reg 4, DIV_10 -> 53.4 V (above the 1.0 V no-battery gate)
+_SOC_SOH_PACKED = (100 << 8) | 82  # reg 5: SOC=82, SOH=100
+_POWER_GROUP_START = 0
+_BMS_GROUP_START = 80
+_BATTERY_COUNT_OFFSET = 16  # reg 96 within the bms_data group (80 + 16)
+
+
+def _page(positions: list[int]) -> list[int]:
+    """Build a 120-register battery block with batteries at ``positions``.
+
+    Each of the 4 physical slots gets status=0xC003, a voltage, packed
+    SOC/SOH, and its position index in offset 24's high byte (the identity
+    fallback used when the BMS reports no serial).
+    """
+    vals = [0] * (BATTERY_MAX_COUNT * BATTERY_REGISTER_COUNT)
+    for slot_idx, pos in enumerate(positions):
+        base = slot_idx * BATTERY_REGISTER_COUNT
+        vals[base] = 0xC003
+        vals[base + 6] = 5246  # 52.46 V after DIV_100
+        vals[base + 8] = _SOC_SOH_PACKED
+        vals[base + 24] = pos << 8
+    return vals
+
+
+def _transport() -> ModbusTransport:
+    t = ModbusTransport(host="192.168.1.100", serial="CE12345678")
+    t.pv_string_count = 3  # skip the pv4-6 extended read
+    return t
+
+
+def _make_fake_read(block_pages: list[list[int] | Exception], battery_count: int = 8):
+    """Fake ``_read_input_registers`` with scripted 5002+ block responses.
+
+    Register groups succeed with zeros, except the power group (valid battery
+    voltage + SOC) and the bms group (reg 96 = ``battery_count``). Each read of
+    the 120-register block at 5002 consumes the next entry of ``block_pages``;
+    an Exception entry raises (a dropped request), a list entry is returned.
+    The last entry repeats once the script is exhausted.
+    """
+    call_idx = [0]
+
+    async def fake_read(start: int, count: int) -> list[int]:
+        if start == BATTERY_BASE_ADDRESS:
+            idx = min(call_idx[0], len(block_pages) - 1)
+            call_idx[0] += 1
+            entry = block_pages[idx]
+            if isinstance(entry, Exception):
+                raise entry
+            return entry
+        vals = [0] * count
+        if start == _POWER_GROUP_START:
+            vals[4] = _VOLTAGE_RAW
+            vals[5] = _SOC_SOH_PACKED
+        if start == _BMS_GROUP_START:
+            vals[_BATTERY_COUNT_OFFSET] = battery_count
+        return vals
+
+    return fake_read
+
+
+class TestFailedBlockReadServesAccumulator:
+    """A dropped 5002+ read serves last-known batteries instead of none."""
+
+    @pytest.mark.asyncio
+    async def test_failed_block_read_returns_accumulated_batteries(self) -> None:
+        """Fail after two-page accumulation -> all 8 blocks still returned."""
+        transport = _transport()
+        fake = _make_fake_read(
+            [
+                _page([0, 1, 2, 3]),
+                _page([4, 5, 6, 7]),
+                OSError("simulated dropped block read"),
+            ]
+        )
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            result = await transport._read_individual_battery_registers(8)
+
+        assert result is not None
+        assert len(result) == 8 * BATTERY_REGISTER_COUNT
+        for virtual_slot in range(8):
+            base = BATTERY_BASE_ADDRESS + virtual_slot * BATTERY_REGISTER_COUNT
+            assert result.get(base) == 0xC003, f"virtual slot {virtual_slot} lost"
+
+    @pytest.mark.asyncio
+    async def test_failed_block_read_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The failure still warns every time (no silent retry loop)."""
+        transport = _transport()
+        fake = _make_fake_read([_page([0, 1, 2, 3]), OSError("boom"), OSError("boom")])
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            caplog.at_level(logging.WARNING),
+        ):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+
+        warnings = [r for r in caplog.records if "Failed to read battery registers" in r.message]
+        assert len(warnings) == 2  # one per actual failure — never deduplicated
+
+    @pytest.mark.asyncio
+    async def test_failed_block_read_with_empty_accumulator_returns_none(self) -> None:
+        """First-poll failure (nothing accumulated yet) keeps returning None."""
+        transport = _transport()
+        fake = _make_fake_read([OSError("boom")])
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            result = await transport._read_individual_battery_registers(8)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_failed_block_read_preserves_stale_last_seen(self) -> None:
+        """The served blocks keep their old stamps — staleness stays honest.
+
+        ``last_seen`` is the signal the hybrid supplemental gate (pylxpweb) and
+        the integration's HYBRID freshness overlay use to prefer cloud data, so
+        a failed read must NOT refresh it.
+        """
+        transport = _transport()
+        fake = _make_fake_read([_page([0, 1, 2, 3]), OSError("boom")])
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport._read_individual_battery_registers(8)
+            stamps_before = dict(transport._battery_last_seen)
+            result = await transport._read_individual_battery_registers(8)
+
+        assert result is not None
+        assert transport._battery_last_seen == stamps_before
+
+
+class TestCombinedReadKeepsBatteriesOnBlockDrop:
+    """read_all_input_data: block drop -> bank keeps accumulated batteries.
+
+    This is the exact 2026-06-28 incident shape: the bms group (reg 96 = 8)
+    succeeded, only the 5002-5121 block read failed. Before the fix the
+    returned bank had ``batteries=[]`` and replaced the last-good cache.
+    """
+
+    @pytest.mark.asyncio
+    async def test_block_drop_after_accumulation_keeps_batteries(self) -> None:
+        transport = _transport()
+        fake = _make_fake_read(
+            [
+                _page([0, 1, 2, 3]),
+                _page([4, 5, 6, 7]),
+                OSError("simulated dropped block read"),
+            ]
+        )
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            _, _, battery_ok = await transport.read_all_input_data()
+            _, _, battery_full = await transport.read_all_input_data()
+            runtime, _, battery_dropped = await transport.read_all_input_data()
+
+        assert battery_ok is not None and len(battery_ok.batteries) == 4
+        assert battery_full is not None and len(battery_full.batteries) == 8
+        # The failed cycle still presents every accumulated battery...
+        assert runtime is not None
+        assert battery_dropped is not None
+        assert len(battery_dropped.batteries) == 8
+        # ...with fresh bank-level data (the bms group succeeded)
+        assert battery_dropped.soc == 82
+
+    @pytest.mark.asyncio
+    async def test_first_poll_block_drop_yields_bank_without_individuals(self) -> None:
+        """Startup edge: nothing accumulated yet -> bank-level only (as before)."""
+        transport = _transport()
+        fake = _make_fake_read([OSError("boom")])
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            _, _, battery = await transport.read_all_input_data()
+
+        assert battery is not None  # bms group OK -> bank-level data valid
+        assert battery.batteries == []
+
+
+class TestBatteryRotationStallWarning:
+    """One latched WARNING per stall episode; INFO + re-arm on recovery.
+
+    The 2026-06-28 incident produced ZERO non-debug logs for ~9 hours while
+    the firmware kept serving one pinned page and half the accumulated
+    batteries silently froze.
+    """
+
+    @staticmethod
+    def _backdate(transport: ModbusTransport, slots: list[int]) -> None:
+        stale_stamp = datetime.now(UTC) - BATTERY_ROTATION_STALL_WARN_AFTER * 2
+        for slot in slots:
+            transport._battery_last_seen[slot] = stale_stamp
+
+    @pytest.mark.asyncio
+    async def test_pinned_page_warns_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        transport = _transport()
+        fake = _make_fake_read(
+            [_page([0, 1, 2, 3]), _page([4, 5, 6, 7])] + [_page([0, 1, 2, 3])] * 3
+        )
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            caplog.at_level(logging.INFO),
+        ):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            self._backdate(transport, [4, 5, 6, 7])  # page B never comes back
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+
+        warnings = [r for r in caplog.records if "Battery rotation stalled" in r.message]
+        assert len(warnings) == 1
+        assert "4 of 8" in warnings[0].message
+
+    @pytest.mark.asyncio
+    async def test_recovery_logs_info_and_rearms(self, caplog: pytest.LogCaptureFixture) -> None:
+        transport = _transport()
+        pages: list[list[int] | Exception] = [
+            _page([0, 1, 2, 3]),  # accumulate page A
+            _page([4, 5, 6, 7]),  # accumulate page B
+            _page([0, 1, 2, 3]),  # stall detected (B backdated below)
+            _page([4, 5, 6, 7]),  # rotation resumes -> recovery INFO
+            _page([0, 1, 2, 3]),  # second stall episode (B backdated again)
+        ]
+        fake = _make_fake_read(pages)
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            caplog.at_level(logging.INFO),
+        ):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            self._backdate(transport, [4, 5, 6, 7])
+            await transport._read_individual_battery_registers(8)  # warn #1
+            await transport._read_individual_battery_registers(8)  # recovery
+            self._backdate(transport, [4, 5, 6, 7])
+            await transport._read_individual_battery_registers(8)  # warn #2
+
+        warnings = [r for r in caplog.records if "Battery rotation stalled" in r.message]
+        infos = [r for r in caplog.records if "Battery rotation resumed" in r.message]
+        assert len(warnings) == 2
+        assert len(infos) == 1
+
+    @pytest.mark.asyncio
+    async def test_healthy_rotation_never_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Normal alternation (all stamps fresh) stays silent."""
+        transport = _transport()
+        fake = _make_fake_read(
+            [
+                _page([0, 1, 2, 3]),
+                _page([4, 5, 6, 7]),
+                _page([0, 1, 2, 3]),
+                _page([4, 5, 6, 7]),
+            ]
+        )
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            caplog.at_level(logging.WARNING),
+        ):
+            for _ in range(4):
+                await transport._read_individual_battery_registers(8)
+
+        assert "Battery rotation stalled" not in caplog.text


### PR DESCRIPTION
## Summary

Follow-up to the 2026-06-28 report on eg4_web_monitor#258 (ivanfmartinez: LXP-LB, 8 batteries on one inverter, DG WiFi dongles, HYBRID, integration beta.16 + pylxpweb 0.9.36b17): one failed `5002-5121` battery block read at 00:05:43 → all battery entities unavailable that second → 4 of 8 batteries frozen for ~9 hours with **zero** non-debug logs → recovery at the exact moment of the *second* failed-read warning at 09:01:56.

## Root cause

The 9-hour window was **not** failed reads and **not** a suppressed warning (the warning is never deduplicated — the two log lines are the only two actual failures). Verified against the reporter's log statistics: the ~3037 `Battery header` debug lines over ~19 h (one per poll) only print after a *successful* 120-register block read, so reads succeeded all night. What stalled was the **data**: register 5001 (page selector) stayed pinned at `0x2000` for the whole window, i.e. the firmware/dongle kept serving the same 4-battery page. Both stall boundaries coincide with dongle resets (00:04:26 cloud `DATAFRAME_TIMEOUT` + 00:05:43 local read failure with TCP teardown/reconnect; 09:01:56 identical) — the pinning is device-side state the client cannot prevent, but the client made it invisible and much worse:

1. **00:05:43, entities unavailable:** the failed block read returned `None` while the bms group (reg 96 = 8) had succeeded, so `read_all_input_data()` built a bank with `batteries=[]` that *replaced* the cached `_transport_battery`. The integration's per-cycle battery dict lost every battery key for that cycle → every individual battery entity flipped unavailable at 00:05:44 (availability = key present in the published dict).
2. **00:06 → 09:01, four batteries frozen:** the never-evict accumulator (correct for rotation) kept re-presenting the 4 off-page batteries with frozen `last_seen`. The integration's `HYBRID_TRANSPORT_FRESHNESS` overlay correctly refused those stale local blocks — but the cloud baseline it fell back to was itself frozen at setup time, because the b17 supplemental-battery gate was **count-only**: all 8 accumulated batteries counted as "surfaced", `surfaced == cloud_count`, so the supplemental cloud `getBatteryInfo` never fired. (b18 already fixed this specific gate for the *partially*-stale case via the relative `last_seen` check.)
3. **09:01:56, recovery on the second warning:** the second dongle glitch tore down and re-dialed the dongle session; rotation resumed immediately after, refreshing the stale accumulator entries. The client did nothing differently — the warning is simply the visible marker of the dongle reset that also unpinned the page.

## Changes

- **`transports/_register_data.py` — failed block read serves the accumulator:** `_read_individual_battery_registers()` now returns the accumulator's merged last-known blocks (honest stale `last_seen` preserved) instead of `None`, so a dropped read never wipes individual batteries mid-flight. First-poll failure (empty accumulator) still returns `None`. The per-failure warning is kept (never deduplicated).
- **`transports/_register_data.py` — rotation-stall watchdog:** `_log_battery_rotation_stall()` emits one latched WARNING when any accumulated battery has not been surfaced for `BATTERY_ROTATION_STALL_WARN_AFTER` (45 min, above the ~30 min worst-case reappearance measured on the #170 12-battery system) and an INFO (re-arming) on recovery — a 9-hour stall can never again be log-silent. HYBRID self-heals via the cloud supplement; for LOCAL this warning is the only signal.
- **`devices/inverters/base.py` — co-frozen gate backstop:** `_wants_hybrid_supplemental_battery` now also compares the *freshest* `last_seen` against the wall clock. Without this, a fully frozen local feed (all batteries co-stamped, e.g. prolonged block-read failures — including the cache-preserving behavior this PR introduces — or every page pinned) would count everything as "surfaced" under the b18 relative-only check and silence the cloud supplement during exactly the outage it exists for.

## Testing

- New `tests/unit/transports/test_battery_block_drop_serves_accumulator.py` (9 tests): failure-serves-accumulator (merged blocks, per-failure warning, empty-accumulator `None`, `last_seen` preserved), combined-path regression reproducing the exact incident shape (bms OK + block drop → bank keeps all 8 batteries, fresh bank-level SOC), and the stall watchdog (warn-once per episode, INFO + re-arm on recovery, silent on healthy rotation).
- New `test_all_batteries_co_frozen_still_fires_cloud_refresh` in `tests/unit/devices/test_transport_link_health.py`; existing gate tests converted from fixed historical stamps to relative-to-now stamps so each keeps exercising its intended branch under the new absolute backstop.
- Full suite: **2450 passed, 4 skipped**. `ruff check` / `ruff format --check` clean, `mypy --strict src/pylxpweb/` clean.

No version bump (release handled separately).

Refs joyfulhouse/eg4_web_monitor#258

🤖 Generated with [Claude Code](https://claude.com/claude-code)