### PR TITLE
feat: Fast Zero Export controls + reg-103 kW pin (eg4_web_monitor#274)

### DIFF
--- a/src/pylxpweb/constants/scaling.py
+++ b/src/pylxpweb/constants/scaling.py
@@ -313,7 +313,9 @@ PARAMETER_SCALING: dict[str, ScaleFactor] = {
     "HOLD_AC_CHARGE_POWER_CMD": ScaleFactor.SCALE_NONE,  # Watts
     "HOLD_FORCED_CHG_POWER_CMD": ScaleFactor.SCALE_NONE,  # 100W units (0-150=0-15kW); caller scales
     "HOLD_FORCED_DISCHG_POWER_CMD": ScaleFactor.SCALE_NONE,  # 100W units like reg 74; caller scales
-    "HOLD_FEED_IN_GRID_POWER_PERCENT": ScaleFactor.SCALE_NONE,  # Percentage
+    # 100W units like regs 66/74/82 (NOT percent, GH eg4_web_monitor#274);
+    # cloud named reads return kW; caller scales the local raw value.
+    "HOLD_FEED_IN_GRID_POWER_PERCENT": ScaleFactor.SCALE_NONE,
     # SOC Parameters (percentage, no scaling)
     "HOLD_AC_CHARGE_SOC_LIMIT": ScaleFactor.SCALE_NONE,
     "HOLD_FORCED_CHG_SOC_LIMIT": ScaleFactor.SCALE_NONE,

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -2724,27 +2724,140 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         """
         return await self._client.api.control.get_pv_sell_to_grid_status(self.serial_number)
 
-    async def set_feed_in_grid_power_percent(self, percent: int) -> bool:
-        """Set the maximum sell-back (feed-in) power percentage (register 103).
+    async def enable_fast_zero_export(self) -> bool:
+        """Enable Fast Zero Export ("Fast Zero Export" in both web UIs).
 
-        "Grid Sell Back Power" in the EG4 web UI: caps export power as a
-        percentage of rated output.  Whole percent on both paths — the cloud
-        named reads return 0-100 and the raw register is documented 0-100
-        (no scale ambiguity), live-pinned via single-register named reads
-        on 18kPV + FlexBOSS21 (GH eg4_web_monitor#135).
+        Register 110 bit 1 (FUNC_RUN_WITHOUT_GRID) —
+        "FunctionEn1.ubFastZeroExport" in the LXP protocol PDF; the EG4 and
+        Luxpower web UIs both flip this cloud param from their Grid Sell
+        tab (GH eg4_web_monitor#135 + #274). Speeds up the zero-export
+        control loop (import control slows down); the vendors advise
+        selecting it as the opposite of Grid Sell Back.
+
+        Returns:
+            True if successful
+
+        Example:
+            >>> await inverter.enable_fast_zero_export()
+            True
+        """
+        result = await self._client.api.control.enable_fast_zero_export(self.serial_number)
+        return result.success
+
+    async def disable_fast_zero_export(self) -> bool:
+        """Disable Fast Zero Export.
+
+        See :meth:`enable_fast_zero_export` for the register 110 bit 1 pin.
+
+        Returns:
+            True if successful
+
+        Example:
+            >>> await inverter.disable_fast_zero_export()
+            True
+        """
+        result = await self._client.api.control.disable_fast_zero_export(self.serial_number)
+        return result.success
+
+    async def get_fast_zero_export_status(self) -> bool:
+        """Get current Fast Zero Export status (register 110 bit 1).
+
+        Returns:
+            True if Fast Zero Export is enabled, False otherwise
+
+        Example:
+            >>> is_enabled = await inverter.get_fast_zero_export_status()
+            >>> is_enabled
+            True
+        """
+        return await self._client.api.control.get_fast_zero_export_status(self.serial_number)
+
+    async def set_feed_in_grid_power_kw(self, power_kw: float) -> bool:
+        """Set the maximum sell-back (feed-in) power in kilowatts (register 103).
+
+        "Grid Sell Back Power(kW)" in BOTH the EG4 and Luxpower web UIs
+        (GH eg4_web_monitor#135 + #274 screenshots). The register stores
+        100 W units — the reg-66/74/82 encoding: the 2026-04-13 live local
+        probe read raw 160 on the 18kPV whose cloud named read returns
+        "16", and the #274 LXP-LB shows 12.1 kW (raw 121). The cloud
+        accepts kW floats directly (the server scales), like
+        :meth:`set_forced_discharge_power`.
 
         Args:
-            percent: Maximum sell-back power percentage (0 to 100)
+            power_kw: Maximum sell-back power in kilowatts (0.0 to 25.5)
 
         Returns:
             True if successful
 
         Raises:
-            ValueError: If percent is out of valid range (0-100)
+            ValueError: If power_kw is out of valid range (0-25.5)
 
         Example:
-            >>> await inverter.set_feed_in_grid_power_percent(50)
+            >>> await inverter.set_feed_in_grid_power_kw(12.1)
             True
+        """
+        if not 0.0 <= power_kw <= 25.5:
+            raise ValueError(f"Feed-in grid power must be between 0.0 and 25.5 kW, got {power_kw}")
+
+        # API accepts kW values directly; %g drops a trailing .0 (form value)
+        result = await self._client.api.control.write_parameter(
+            self.serial_number, "HOLD_FEED_IN_GRID_POWER_PERCENT", f"{power_kw:g}"
+        )
+
+        if result.success:
+            self._parameters_cache_time = None
+
+        return result.success
+
+    @property
+    def feed_in_grid_power_kw(self) -> float | None:
+        """Get current maximum sell-back (feed-in) power from cached parameters.
+
+        The value reflects however ``parameters`` was populated: the cloud
+        API returns kilowatts, while a local transport surfaces the raw
+        100 W register value (121 = 12.1 kW). Callers reading through a
+        local transport must scale by 0.1 themselves — the same caveat as
+        :attr:`forced_discharge_power`.
+
+        Returns:
+            Power cap in kilowatts when cloud-populated, or None if
+            parameters not loaded or parameter not found
+
+        Example:
+            >>> inverter.feed_in_grid_power_kw
+            12.1
+        """
+        if self.parameters is None:
+            return None
+        value = self.parameters.get("HOLD_FEED_IN_GRID_POWER_PERCENT")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None
+
+    async def set_feed_in_grid_power_percent(self, percent: int) -> bool:
+        """Set register 103 assuming percent semantics (DEPRECATED — it's kW).
+
+        .. deprecated:: 0.9.37
+            Register 103 is NOT a percent despite the cloud key name
+            (``HOLD_FEED_IN_GRID_POWER_PERCENT``): it stores 100 W units and
+            the cloud takes kilowatts (GH eg4_web_monitor#274 — live probe
+            raw 160 == cloud "16" == the web UIs' 16 kW field). A value
+            passed here is therefore interpreted by the server as
+            KILOWATTS: ``set_feed_in_grid_power_percent(50)`` sets a 50 kW
+            cap, not 50 %. Use :meth:`set_feed_in_grid_power_kw`.
+
+        Args:
+            percent: Historically documented as percent; the server treats
+                the number as kilowatts.
+
+        Returns:
+            True if successful
+
+        Raises:
+            ValueError: If the value is outside 0-100
         """
         if not 0 <= percent <= 100:
             raise ValueError(
@@ -2762,18 +2875,18 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
 
     @property
     def feed_in_grid_power_percent(self) -> int | None:
-        """Get current maximum sell-back (feed-in) power percentage.
+        """Get register 103 assuming percent semantics (DEPRECATED — it's kW).
 
-        Whole percent on both the cloud and local paths (register 103 stores
-        0-100 directly), so no transport-dependent scaling caveat applies.
+        .. deprecated:: 0.9.37
+            Register 103 stores 100 W units and the cloud returns
+            kilowatts (GH eg4_web_monitor#274), so this int-typed 0-100
+            getter mis-reads the value: a cloud "12.1" (kW) fails int()
+            and reads None, and a local raw 121 fails the 0-100 range
+            check. Use :attr:`feed_in_grid_power_kw`.
 
         Returns:
-            Maximum sell-back power percentage (0-100), or None if parameters
-            not loaded or parameter not found
-
-        Example:
-            >>> inverter.feed_in_grid_power_percent
-            16
+            The cached value coerced to int when it happens to fall in
+            0-100, or None otherwise
         """
         if self.parameters is None:
             return None

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -1080,6 +1080,79 @@ class ControlEndpoints(BaseEndpoint):
         """
         return await self._get_function_status(inverter_sn, 179, "FUNC_PV_SELL_TO_GRID_EN")
 
+    async def enable_fast_zero_export(
+        self, inverter_sn: str, client_type: str = "WEB"
+    ) -> SuccessResponse:
+        """Enable Fast Zero Export ("Fast Zero Export" in both web UIs).
+
+        Convenience wrapper for control_function(..., "FUNC_RUN_WITHOUT_GRID",
+        True). Register 110 bit 1 — "FunctionEn1.ubFastZeroExport" in the LXP
+        protocol PDF; the EG4 and Luxpower web UIs both toggle the
+        FUNC_RUN_WITHOUT_GRID cloud param for their Grid Sell tab button
+        (GH eg4_web_monitor#135 + #274 screenshots). Speeds up the
+        zero-export control loop (import control slows down); the vendors
+        advise selecting it as the opposite of Grid Sell Back.
+
+        Args:
+            inverter_sn: Inverter serial number
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Example:
+            >>> result = await client.control.enable_fast_zero_export("1234567890")
+            >>> result.success
+            True
+        """
+        return await self.control_function(
+            inverter_sn, "FUNC_RUN_WITHOUT_GRID", True, client_type=client_type
+        )
+
+    async def disable_fast_zero_export(
+        self, inverter_sn: str, client_type: str = "WEB"
+    ) -> SuccessResponse:
+        """Disable Fast Zero Export.
+
+        Convenience wrapper for control_function(..., "FUNC_RUN_WITHOUT_GRID",
+        False); see :meth:`enable_fast_zero_export` for the register pin.
+
+        Args:
+            inverter_sn: Inverter serial number
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Example:
+            >>> result = await client.control.disable_fast_zero_export("1234567890")
+            >>> result.success
+            True
+        """
+        return await self.control_function(
+            inverter_sn, "FUNC_RUN_WITHOUT_GRID", False, client_type=client_type
+        )
+
+    async def get_fast_zero_export_status(self, inverter_sn: str) -> bool:
+        """Get current Fast Zero Export status.
+
+        Reads register 110 (system function enable) and extracts
+        FUNC_RUN_WITHOUT_GRID (bit 1 — same position in the base and SNA
+        register-110 tables).
+
+        Args:
+            inverter_sn: Inverter serial number
+
+        Returns:
+            bool: True if Fast Zero Export is enabled, False otherwise
+
+        Example:
+            >>> enabled = await client.control.get_fast_zero_export_status("1234567890")
+            >>> if enabled:
+            >>>     print("Fast Zero Export is active")
+        """
+        return await self._get_function_status(inverter_sn, 110, "FUNC_RUN_WITHOUT_GRID")
+
     async def enable_peak_shaving_mode(
         self, inverter_sn: str, client_type: str = "WEB"
     ) -> SuccessResponse:

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -814,18 +814,25 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         address=103,
         canonical_name="max_backflow_power_percent",
         api_param_key="HOLD_FEED_IN_GRID_POWER_PERCENT",  # verified
-        unit="%",
+        unit="W",
         min_value=0,
-        max_value=100,
+        max_value=25500,
         category=HoldingCategory.POWER,
         description=(
-            "Maximum export (sell-back) power percentage — 'Grid Sell Back "
-            "Power' in the EG4 web UI.  The protocol spec calls reg 103 "
-            "'MaxBackflowPower', but live single-register named reads "
-            "(2026-06-12, 18kPV + FlexBOSS21, GH eg4_web_monitor#135) prove "
-            "the cloud API key is HOLD_FEED_IN_GRID_POWER_PERCENT; "
+            "Maximum export (sell-back) power — 'Grid Sell Back Power(kW)' "
+            "in BOTH the EG4 and Luxpower web UIs. Raw value in 100W units "
+            "(the reg-66/74/82 encoding), NOT the percent the protocol PDF "
+            "and the cloud key name claim: a 2026-04-13 live local probe "
+            "read raw 160 on the 18kPV whose cloud named read returns '16' "
+            "(= 16.0 kW), and the GH eg4_web_monitor#274 LXP-LB shows "
+            "12.1 kW (raw 121) — impossible as a 0-100 percent. The cloud "
+            "takes kW floats directly (server scales). The protocol spec "
+            "calls reg 103 'MaxBackflowPower'; live single-register named "
+            "reads (2026-06-12, 18kPV + FlexBOSS21, GH eg4_web_monitor#135) "
+            "prove the cloud API key is HOLD_FEED_IN_GRID_POWER_PERCENT — "
             "HOLD_MAX_BACKFLOW_POWER_PERCENT does not exist on this "
-            "hardware.  canonical_name retained for API stability."
+            "hardware. canonical_name retained for API stability despite "
+            "the misleading '_percent' suffix."
         ),
     ),
     # HOLD_EXPORT_LOCK_POWER is deliberately NOT mapped: its register is
@@ -916,7 +923,17 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         canonical_name="run_without_grid",
         api_param_key="FUNC_RUN_WITHOUT_GRID",  # verified
         category=HoldingCategory.FUNCTION,
-        description="Run without grid enable (off-grid capable).",
+        description=(
+            "Fast Zero Export — 'FunctionEn1.ubFastZeroExport' in the LXP "
+            "protocol PDF; the EG4 and Luxpower web UIs both toggle this "
+            "param from their Grid Sell tab's 'Fast Zero Export' button "
+            "(GH eg4_web_monitor#135 + #274 screenshots). Speeds up the "
+            "zero-export control loop (import control slows down); vendors "
+            "advise selecting it as the opposite of Grid Sell Back. The "
+            "canonical name mirrors the vendor param dictionary's literal "
+            "'run without grid' wording (kept for API stability) — the bit "
+            "does NOT make the inverter run without grid."
+        ),
     ),
     HoldingRegisterDefinition(
         address=110,

--- a/tests/unit/devices/inverters/test_hybrid.py
+++ b/tests/unit/devices/inverters/test_hybrid.py
@@ -1704,6 +1704,9 @@ class TestGridSellBackOperations:
         [
             ("enable_feed_in_grid", "enable_feed_in_grid"),
             ("disable_feed_in_grid", "disable_feed_in_grid"),
+            # Fast Zero Export (GH eg4_web_monitor#274, reg 110 bit 1)
+            ("enable_fast_zero_export", "enable_fast_zero_export"),
+            ("disable_fast_zero_export", "disable_fast_zero_export"),
         ],
     )
     async def test_toggle_delegates_to_control_endpoint(
@@ -1827,8 +1830,131 @@ class TestGridSellBackOperations:
         assert REGISTER_TO_PARAM_KEYS[103] == ["HOLD_FEED_IN_GRID_POWER_PERCENT"]
         canonical = BY_ADDRESS[103]
         assert canonical[0].api_param_key == "HOLD_FEED_IN_GRID_POWER_PERCENT"
+        # kW pin (GH eg4_web_monitor#274): raw 100 W units like regs
+        # 66/74/82 — live probe raw 160 == cloud named read "16" == the web
+        # UIs' 16 kW; NOT the 0-100 percent the PDF and the key name claim.
         assert canonical[0].min_value == 0
-        assert canonical[0].max_value == 100
+        assert canonical[0].max_value == 25500
+        assert canonical[0].unit == "W"
+
+    @pytest.mark.asyncio
+    async def test_fast_zero_export_status_delegates(self, mock_client: LuxpowerClient) -> None:
+        """Fast Zero Export status delegates to the control endpoint."""
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+        mock_client.api.control.get_fast_zero_export_status = AsyncMock(return_value=True)
+
+        assert await inverter.get_fast_zero_export_status() is True
+        mock_client.api.control.get_fast_zero_export_status.assert_called_once_with("1234567890")
+
+    @pytest.mark.asyncio
+    async def test_set_feed_in_grid_power_kw(self, mock_client: LuxpowerClient) -> None:
+        """kW setter writes HOLD_FEED_IN_GRID_POWER_PERCENT as a kW string.
+
+        The cloud takes kW floats for this register (server scales to the
+        raw 100 W units) — the GH eg4_web_monitor#274 LXP-LB shows 12.1 kW.
+        """
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+        inverter._parameters_cache_time = datetime.now()
+
+        mock_write_response = Mock()
+        mock_write_response.success = True
+        mock_client.api.control.write_parameter = AsyncMock(return_value=mock_write_response)
+
+        result = await inverter.set_feed_in_grid_power_kw(12.1)
+
+        mock_client.api.control.write_parameter.assert_called_once_with(
+            "1234567890", "HOLD_FEED_IN_GRID_POWER_PERCENT", "12.1"
+        )
+        assert result is True
+        assert inverter._parameters_cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_set_feed_in_grid_power_kw_whole_kw_string(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """Whole kilowatts serialize without a trailing .0 (cloud form value)."""
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+        mock_write_response = Mock()
+        mock_write_response.success = True
+        mock_client.api.control.write_parameter = AsyncMock(return_value=mock_write_response)
+
+        assert await inverter.set_feed_in_grid_power_kw(16.0) is True
+        mock_client.api.control.write_parameter.assert_called_once_with(
+            "1234567890", "HOLD_FEED_IN_GRID_POWER_PERCENT", "16"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_feed_in_grid_power_kw_out_of_range(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """kW outside 0-25.5 raises ValueError (both directions)."""
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+
+        with pytest.raises(ValueError, match="between 0.0 and 25.5"):
+            await inverter.set_feed_in_grid_power_kw(25.6)
+        with pytest.raises(ValueError, match="between 0.0 and 25.5"):
+            await inverter.set_feed_in_grid_power_kw(-0.1)
+
+    @pytest.mark.asyncio
+    async def test_set_feed_in_grid_power_kw_failure_keeps_cache(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A failed kW write returns False and does NOT invalidate the cache."""
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+        stamp = datetime.now()
+        inverter._parameters_cache_time = stamp
+
+        mock_write_response = Mock()
+        mock_write_response.success = False
+        mock_client.api.control.write_parameter = AsyncMock(return_value=mock_write_response)
+
+        assert await inverter.set_feed_in_grid_power_kw(4.0) is False
+        assert inverter._parameters_cache_time == stamp
+
+    def test_feed_in_grid_power_kw_property(self, mock_client: LuxpowerClient) -> None:
+        """kW getter mirrors forced_discharge_power: float of the cached
+        value (cloud kW float; local transports surface raw 100 W units —
+        callers scale by 0.1, same caveat as forced_discharge_power)."""
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+
+        assert inverter.parameters is None
+        assert inverter.feed_in_grid_power_kw is None
+
+        inverter.parameters = {"HOLD_FEED_IN_GRID_POWER_PERCENT": "12.1"}
+        assert inverter.feed_in_grid_power_kw == 12.1
+
+        inverter.parameters = {"HOLD_FEED_IN_GRID_POWER_PERCENT": "16"}
+        assert inverter.feed_in_grid_power_kw == 16.0
+
+        inverter.parameters = {"HOLD_FEED_IN_GRID_POWER_PERCENT": "garbage"}
+        assert inverter.feed_in_grid_power_kw is None
+
+        inverter.parameters = {}
+        assert inverter.feed_in_grid_power_kw is None
+
+    def test_run_without_grid_is_reg110_bit1_in_both_tables(self) -> None:
+        """FUNC_RUN_WITHOUT_GRID (Fast Zero Export, GH eg4_web_monitor#274)
+        sits at register 110 bit 1 in the base AND SNA tables, matching the
+        LXP protocol PDF's FunctionEn1.ubFastZeroExport."""
+        from pylxpweb.constants.registers import (
+            OFFGRID_REGISTER_110_PARAM_KEYS,
+            REGISTER_TO_PARAM_KEYS,
+        )
+
+        assert REGISTER_TO_PARAM_KEYS[110][1] == "FUNC_RUN_WITHOUT_GRID"
+        assert OFFGRID_REGISTER_110_PARAM_KEYS[1] == "FUNC_RUN_WITHOUT_GRID"
 
     def test_pv_sell_to_grid_bit_pinned_at_bit3(self) -> None:
         """FUNC_PV_SELL_TO_GRID_EN is register 179 bit 3.

--- a/tests/unit/endpoints/test_control_helpers.py
+++ b/tests/unit/endpoints/test_control_helpers.py
@@ -59,6 +59,10 @@ class TestFunctionToggleHelpers:
             ("disable_feed_in_grid", "FUNC_FEED_IN_GRID_EN", False),
             ("enable_pv_sell_to_grid", "FUNC_PV_SELL_TO_GRID_EN", True),
             ("disable_pv_sell_to_grid", "FUNC_PV_SELL_TO_GRID_EN", False),
+            # Fast Zero Export (GH eg4_web_monitor#274): reg 110 bit 1;
+            # both web UIs toggle FUNC_RUN_WITHOUT_GRID for the button.
+            ("enable_fast_zero_export", "FUNC_RUN_WITHOUT_GRID", True),
+            ("disable_fast_zero_export", "FUNC_RUN_WITHOUT_GRID", False),
         ],
     )
     async def test_toggle_delegates_to_control_function(
@@ -102,6 +106,7 @@ class TestFunctionStatusHelpers:
             ("get_sporadic_charge_status", 233, "FUNC_SPORADIC_CHARGE"),
             ("get_feed_in_grid_status", 21, "FUNC_FEED_IN_GRID_EN"),
             ("get_pv_sell_to_grid_status", 179, "FUNC_PV_SELL_TO_GRID_EN"),
+            ("get_fast_zero_export_status", 110, "FUNC_RUN_WITHOUT_GRID"),
         ],
     )
     async def test_status_enabled(
@@ -126,6 +131,7 @@ class TestFunctionStatusHelpers:
             ("get_sporadic_charge_status", 233, "FUNC_SPORADIC_CHARGE"),
             ("get_feed_in_grid_status", 21, "FUNC_FEED_IN_GRID_EN"),
             ("get_pv_sell_to_grid_status", 179, "FUNC_PV_SELL_TO_GRID_EN"),
+            ("get_fast_zero_export_status", 110, "FUNC_RUN_WITHOUT_GRID"),
         ],
     )
     async def test_status_disabled(


### PR DESCRIPTION
## Summary

Library support for [eg4_web_monitor#274](https://github.com/joyfulhouse/eg4_web_monitor/issues/274) (LXP-LB grid sell/export settings):

1. **Fast Zero Export cloud methods** — `enable_fast_zero_export()` / `disable_fast_zero_export()` / `get_fast_zero_export_status()` on the control endpoint and `BaseInverter`, wrapping `control_function(sn, "FUNC_RUN_WITHOUT_GRID", …)` — the exact call both vendor websites make.
2. **Register 103 corrected to kW** — canonical holding definition, new `set_feed_in_grid_power_kw()` / `feed_in_grid_power_kw`, and deprecation notes on the percent-named variants.

No behavior change to any existing method; the percent setter/getter keep their old (mis-scaled) behavior for compatibility and their docstrings now say exactly how they mis-read/mis-write.

## Register evidence

**HOLD 110 bit 1 = Fast Zero Export (`FUNC_RUN_WITHOUT_GRID`)**
- LXP protocol PDF (screenshot in eg4_web_monitor#274): `FunctionEn1.ubFastZeroExport` = Bit1 (the issue prose says "bit 2" — that is 1-based counting; the PDF row is Bit1).
- Reporter: toggling "Fast Zero Export" on na.luxpowertek.com flips `FUNC_RUN_WITHOUT_GRID`.
- EG4 monitor UI shows the same "Fast Zero Export" toggle on its Grid Sell tab (eg4_web_monitor#135 screenshot, FlexBOSS21).
- pylxpweb already had the bit at position 1 in BOTH the base and SNA reg-110 tables; only naming/docs and the cloud convenience wrappers were missing. `canonical_name="run_without_grid"` is retained for API stability (it is the vendor param dictionary's literal wording — the bit does **not** make the inverter run without grid; new description says so).

**HOLD 103 = kW with 100 W raw units (NOT percent)**
- 2026-04-13 live local Modbus probe (fw fAAB-2727): raw **160** on an 18kPV *and* a FlexBOSS21 (eg4_web_monitor `docs/reference/firmware_re/REGISTER_MAP_LIVE_PROBE.md`).
- The same 18kPV's cloud named read (2025-11-19 dump, `docs/claude/18KPV_4512670118.md`): `HOLD_FEED_IN_GRID_POWER_PERCENT = "16"` → the cloud returns **kW** (raw ÷ 10), like regs 66/74/82 (`set_forced_discharge_power` precedent, hardware-verified in eg4_web_monitor PR #249).
- Both web UIs label the field "Grid Sell Back Power(**kW**)" (eg4_web_monitor#135 + #274 screenshots).
- The #274 LXP-LB shows **12.1 kW** (raw 121) — impossible as a 0-100 percent, and `int("12.1")` is why the old percent property returned `None` on that hardware.
- The protocol PDF's "% 0-100" row is wrong for this register, the same way its percent claim for reg 82 was wrong.

## Changes

- `endpoints/control.py`: `enable_fast_zero_export` / `disable_fast_zero_export` (→ `control_function`), `get_fast_zero_export_status` (reads reg 110).
- `devices/inverters/base.py`: BaseInverter wrappers for the three methods; `set_feed_in_grid_power_kw(power_kw)` (0–25.5, writes the kW string like `set_forced_discharge_power`); `feed_in_grid_power_kw` property (float; local-raw caveat documented); percent setter/getter docstrings rewritten as deprecated mis-reads pointing at the kW variants.
- `registers/inverter_holding.py`: reg 103 definition → `unit="W"`, `max_value=25500`, evidence in description; reg 110 bit 1 description → Fast Zero Export.
- `constants/scaling.py`: comment for `HOLD_FEED_IN_GRID_POWER_PERCENT` corrected (stays `SCALE_NONE`; callers scale local raw).

## Testing

- New: control-endpoint toggle/status parametrize rows (`FUNC_RUN_WITHOUT_GRID`, reg 110); BaseInverter delegation tests; `set_feed_in_grid_power_kw` round-trip ("12.1"), whole-kW serialization ("16"), range validation, failed-write cache retention; `feed_in_grid_power_kw` property table; reg-110 bit-1 dual-table pin; reg-103 metadata pin.
- Full suite: **2453 passed, 4 skipped**; `ruff check` + `ruff format --check` clean; `mypy --strict src/pylxpweb/` clean.

## Open questions for the reporter (tracked in the integration PR)

- Live-verify on the LXP-LB that toggling the new switch flips the website's Fast Zero Export button (and vice versa), and that the kW number round-trips with the website field (12.1 ↔ 12.1).
- HOLD 110 **bit 14** ("AbsoluteZeroExport" on 12K per the PDF; GreenMode per lxp_modbus) is deliberately NOT implemented — the sources conflict and there is no live toggle evidence. Follow-up documented in the integration PR.

No version bump / release in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)