### PR TITLE
feat: configurable Modbus input-register block coalescing (eg4_web_monitor#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configurable input-register block coalescing** ([eg4_web_monitor#254](https://github.com/joyfulhouse/eg4_web_monitor/issues/254)):
+  new `max_input_block_size` parameter (40..125, default 40) on
+  `ModbusTransport`, `ModbusSerialTransport`, `DongleTransport`,
+  `TransportConfig`, and the factory functions. At the default the read
+  pattern is byte-identical to previous releases (one read per
+  `INPUT_REGISTER_GROUPS` entry). Larger values (multiples of 40
+  recommended; 120 field-proven on DG dongle firmware 2.04–2.09) coalesce
+  *adjacent/overlapping* register groups into consolidated reads — at 120
+  the 8 inverter group reads become 4 (regs 0–112 in ONE transaction),
+  cutting ~4 Modbus round-trips per poll per inverter for faster local
+  polling. Safety: coalescing only merges spans already read today (the
+  154–169 / 174–192 gaps are never bridged); the first failed or short
+  coalesced read logs one WARNING, completes the same cycle via the plain
+  grouped reads, and latches the transport back to grouped mode permanently
+  (probe-once), so old dongle firmware that caps reads at ~40 registers
+  degrades gracefully instead of hard-failing polling. GridBOSS/MID reads
+  are deliberately not coalesced (>40-register midbox reads empirically
+  failed on real GridBOSS hardware); the atomic 120-register battery block,
+  PV4-6 extended reads, and input-register 210 are unchanged.
+
 - **Battery rotation-stall watchdog** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   the 2026-06-28 report pinned the firmware's battery page for ~9 hours with
   ZERO non-debug logs — every 120-register block read succeeded, so nothing

--- a/src/pylxpweb/devices/station.py
+++ b/src/pylxpweb/devices/station.py
@@ -806,6 +806,7 @@ class Station(BaseDevice):
                 serial=config.serial,
                 inverter_family=config.inverter_family,
                 timeout=config.timeout,
+                max_input_block_size=config.max_input_block_size,
             )
 
         if config.transport_type == TransportType.WIFI_DONGLE:
@@ -822,6 +823,7 @@ class Station(BaseDevice):
                 port=config.port,
                 inverter_family=config.inverter_family,
                 timeout=config.timeout,
+                max_input_block_size=config.max_input_block_size,
             )
 
         _LOGGER.warning("Unknown transport type: %s", config.transport_type)

--- a/src/pylxpweb/devices/station.py
+++ b/src/pylxpweb/devices/station.py
@@ -1359,6 +1359,7 @@ class Station(BaseDevice):
                         serial=serial,
                         timeout=config.timeout,
                         inverter_family=config.inverter_family,
+                        max_input_block_size=config.max_input_block_size,
                     )
                 elif config.transport_type == TransportType.WIFI_DONGLE:
                     # dongle_serial is guaranteed by TransportConfig validation
@@ -1370,6 +1371,7 @@ class Station(BaseDevice):
                         inverter_serial=serial,
                         timeout=config.timeout,
                         inverter_family=config.inverter_family,
+                        max_input_block_size=config.max_input_block_size,
                     )
                 else:
                     _LOGGER.error("Unknown transport type: %s", config.transport_type)

--- a/src/pylxpweb/transports/_modbus_base.py
+++ b/src/pylxpweb/transports/_modbus_base.py
@@ -21,7 +21,12 @@ from typing import TYPE_CHECKING, Any
 
 from pymodbus.exceptions import ModbusException
 
-from ._register_data import INPUT_REGISTER_GROUPS, RegisterDataMixin
+from ._register_data import (
+    DEFAULT_INPUT_BLOCK_SIZE,
+    INPUT_REGISTER_GROUPS,
+    RegisterDataMixin,
+    validate_input_block_size,
+)
 from .exceptions import (
     TransportConnectionError,
     TransportReadError,
@@ -67,6 +72,7 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
         retry_delay: float = 0.5,
         inter_register_delay: float = 0.05,
         pymodbus_retries: int = 3,
+        max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
     ) -> None:
         """Initialize base Modbus transport.
 
@@ -82,6 +88,13 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
                 (default 0.05)
             pymodbus_retries: Number of retries passed to pymodbus client
                 (default 3)
+            max_input_block_size: Maximum registers per coalesced input-register
+                read, 40..125 (default 40 = no coalescing, the plain per-group
+                reads).  Larger values (multiples of 40 recommended; 120 is
+                field-proven on newer dongles) consolidate adjacent register
+                groups into fewer reads for faster polling; hardware that
+                rejects large reads automatically falls back to the plain
+                grouped reads (eg4_web_monitor#254).
         """
         super().__init__(serial)
         self._unit_id = unit_id
@@ -93,6 +106,8 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
         self._retry_delay = retry_delay
         self._inter_register_delay = inter_register_delay
         self._pymodbus_retries = pymodbus_retries
+        self._max_input_block_size = validate_input_block_size(max_input_block_size)
+        self._input_coalescing_latched_off: bool = False
         self._client: Any = None
         self._lock = asyncio.Lock()
         self._consecutive_errors: int = 0
@@ -365,52 +380,15 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
     ) -> dict[int, int]:
         """Read register groups with adaptive delay and auto-reconnect.
 
-        Overrides ``RegisterDataMixin._read_register_groups`` to add:
-        - Auto-reconnect after consecutive errors
-        - Adaptive delay increase when retries have occurred
+        Overrides ``RegisterDataMixin._read_register_groups`` to add the
+        auto-reconnect gate.  The adaptive delay increase after low-level
+        retries lives in the shared ``_read_group_plan`` loop (keyed on
+        ``_last_read_retried``, which only Modbus transports track).
         """
-        if group_names is None:
-            groups = list(INPUT_REGISTER_GROUPS.items())
-        else:
-            groups = [
-                (name, INPUT_REGISTER_GROUPS[name])
-                for name in group_names
-                if name in INPUT_REGISTER_GROUPS
-            ]
-
         if self._consecutive_errors >= self._max_consecutive_errors:
             await self._reconnect()
 
-        registers: dict[int, int] = {}
-        current_delay = self._inter_register_delay
-
-        for i, (group_name, (start, count)) in enumerate(groups):
-            try:
-                values = await self._read_input_registers(start, count)
-                for offset, value in enumerate(values):
-                    registers[start + offset] = value
-            except Exception as e:
-                _LOGGER.error(
-                    "Failed to read register group '%s': %s",
-                    group_name,
-                    e,
-                )
-                raise TransportReadError(
-                    f"Failed to read register group '{group_name}': {e}"
-                ) from e
-
-            # Increase delay when retries occurred to give the device breathing room
-            if self._last_read_retried:
-                current_delay = min(current_delay * 2, 1.0)
-                _LOGGER.debug(
-                    "Increasing inter-group delay to %.3fs after retries",
-                    current_delay,
-                )
-
-            if i < len(groups) - 1:
-                await asyncio.sleep(current_delay)
-
-        return registers
+        return await super()._read_register_groups(group_names)
 
     # ------------------------------------------------------------------
     # Overrides: combined read + read_battery with reconnect check

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -104,6 +106,117 @@ MIDBOX_REGISTER_GROUPS: list[tuple[int, int]] = [
 ]
 
 # ---------------------------------------------------------------------------
+# Configurable input-register block coalescing (eg4_web_monitor#254)
+# ---------------------------------------------------------------------------
+# The vendor Modbus RTU doc (2025/6/13) specifies reads must not span
+# 40-register block boundaries on old firmware; newer dongles/firmware accept
+# up to the Modbus FC04 PDU cap (125 registers; DG dongle fw 2.04-2.09 field-
+# verified at 120).  ``max_input_block_size`` lets capable hardware coalesce
+# the adjacent INPUT_REGISTER_GROUPS into fewer transactions.  The default
+# keeps the plain per-group reads (byte-identical to previous releases).
+#
+# GridBOSS/MID reads are deliberately NOT coalesced: >40-register midbox
+# reads empirically failed on real GridBOSS hardware (see f050eb2, "fix
+# critical 40-register hardware limit bug ... for GridBOSS midbox runtime
+# reads"), so MIDBOX_REGISTER_GROUPS stays chunked at <=40 regardless of
+# this setting.
+
+DEFAULT_INPUT_BLOCK_SIZE = 40
+"""Conservative default: no coalescing — reads are exactly the group table.
+
+40 is the documented per-read cap of the oldest dongle firmware.  Multiples
+of 40 are recommended for larger values (the vendor doc's block convention);
+120 is the field-proven fast setting.
+"""
+
+MAX_INPUT_BLOCK_SIZE = 125
+"""Modbus FC04 PDU limit (the dongle frame's u8 byte count caps at 127)."""
+
+
+def validate_input_block_size(value: int) -> int:
+    """Validate a ``max_input_block_size`` setting.
+
+    Args:
+        value: Requested maximum registers per coalesced input read.
+
+    Returns:
+        The validated value.
+
+    Raises:
+        ValueError: If outside ``DEFAULT_INPUT_BLOCK_SIZE..MAX_INPUT_BLOCK_SIZE``.
+    """
+    if not DEFAULT_INPUT_BLOCK_SIZE <= value <= MAX_INPUT_BLOCK_SIZE:
+        raise ValueError(
+            f"max_input_block_size must be {DEFAULT_INPUT_BLOCK_SIZE}.."
+            f"{MAX_INPUT_BLOCK_SIZE} (40-multiples recommended; got {value})"
+        )
+    return int(value)
+
+
+@dataclass(frozen=True, slots=True)
+class _ReadBlock:
+    """One planned input-register read (a single Modbus transaction)."""
+
+    members: tuple[str, ...]
+    """Constituent group names (length 1 = plain, unmerged group read)."""
+
+    start: int
+    count: int
+
+    @property
+    def label(self) -> str:
+        """Human-readable name for logs ('power_energy+status_energy+...')."""
+        return "+".join(self.members)
+
+    @property
+    def coalesced(self) -> bool:
+        """Whether this block merges multiple groups (fallback-eligible)."""
+        return len(self.members) > 1
+
+
+class _CoalescedReadFallback(Exception):
+    """Internal: a coalesced block read failed; retry with plain group reads."""
+
+
+def coalesce_register_groups(
+    groups: Sequence[tuple[str, tuple[int, int]]],
+    max_block_size: int,
+) -> list[_ReadBlock]:
+    """Merge contiguous/overlapping register groups into larger read blocks.
+
+    Generic span coalescing: groups are merged only when the next group's
+    start lies within (or exactly at the end of) the running block, so a
+    merged block is always the exact union of its members' spans — it never
+    reads an address the plain grouped reads don't already read.  Registers
+    in the gaps *between* groups (which may misbehave or not exist on some
+    models) are never bridged, no matter the block size.
+
+    A single group larger than ``max_block_size`` is never split; it stays
+    one read, exactly as in the plain plan.
+
+    Args:
+        groups: ``(name, (start, count))`` pairs (e.g. INPUT_REGISTER_GROUPS
+            items, or a subset).
+        max_block_size: Maximum registers per merged read.
+
+    Returns:
+        Ordered read plan covering the same addresses as ``groups``.
+    """
+    merged: list[tuple[list[str], int, int]] = []  # (names, start, end)
+    for name, (start, count) in sorted(groups, key=lambda g: (g[1][0], g[1][0] + g[1][1])):
+        end = start + count
+        if merged:
+            names, run_start, run_end = merged[-1]
+            new_end = max(run_end, end)
+            if start <= run_end and new_end - run_start <= max_block_size:
+                names.append(name)
+                merged[-1] = (names, run_start, new_end)
+                continue
+        merged.append(([name], start, end))
+    return [_ReadBlock(tuple(names), start, end - start) for names, start, end in merged]
+
+
+# ---------------------------------------------------------------------------
 # TYPE_CHECKING-only base class for mixin attribute stubs
 # ---------------------------------------------------------------------------
 
@@ -117,6 +230,7 @@ if TYPE_CHECKING:
         _inverter_family: InverterFamily | None
         _split_phase: bool
         _pv_string_count: int
+        _max_input_block_size: int
 
         async def _read_input_registers(self, start: int, count: int) -> list[int]: ...
 
@@ -526,14 +640,95 @@ class RegisterDataMixin(_DataMixinBase):
     # Register group reading
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _resolve_input_groups(
+        group_names: list[str] | None,
+    ) -> list[tuple[str, tuple[int, int]]]:
+        """Resolve group names to ``(name, (start, count))`` pairs."""
+        if group_names is None:
+            return list(INPUT_REGISTER_GROUPS.items())
+        return [
+            (name, INPUT_REGISTER_GROUPS[name])
+            for name in group_names
+            if name in INPUT_REGISTER_GROUPS
+        ]
+
+    def _plan_input_reads(
+        self,
+        groups: list[tuple[str, tuple[int, int]]],
+    ) -> list[_ReadBlock]:
+        """Plan the input reads for ``groups``, coalescing when configured.
+
+        With the conservative default block size — or after a coalesced read
+        has failed and latched the transport back (``eg4_web_monitor#254``) —
+        the plan is exactly one read per group, byte-identical to the
+        pre-feature behavior.
+        """
+        max_size = getattr(self, "_max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE)
+        if max_size <= DEFAULT_INPUT_BLOCK_SIZE or getattr(
+            self, "_input_coalescing_latched_off", False
+        ):
+            return [_ReadBlock((name,), start, count) for name, (start, count) in groups]
+        return coalesce_register_groups(groups, max_size)
+
+    def _latch_input_coalescing_off(self, block: _ReadBlock, reason: object) -> None:
+        """Disable coalescing for this transport's lifetime (probe-once).
+
+        Old dongle firmware caps reads at ~40 registers; a large read on
+        such hardware fails (or times out) every time, so the first failure
+        latches the transport back to the plain grouped reads permanently
+        (until the transport is recreated, e.g. on reload) instead of
+        re-paying retries every poll cycle.
+        """
+        self._input_coalescing_latched_off = True
+        _LOGGER.warning(
+            "[%s] Coalesced input-register read %d-%d (%d registers; groups %s) "
+            "failed: %s — falling back to standard grouped reads for this "
+            "connection. Older dongle firmware only supports 40-register reads; "
+            "lower the configured block size to silence this probe.",
+            self._serial,
+            block.start,
+            block.start + block.count - 1,
+            block.count,
+            block.label,
+            reason,
+        )
+
+    async def _read_block(self, block: _ReadBlock) -> list[int]:
+        """Read one planned block.
+
+        A failed or short **coalesced** read latches coalescing off and
+        raises :class:`_CoalescedReadFallback` so the caller re-reads the
+        cycle with plain group reads.  Plain (single-group) reads propagate
+        errors unchanged, preserving the existing per-group semantics.
+        """
+        try:
+            values = await self._read_input_registers(block.start, block.count)
+        except Exception as err:
+            if block.coalesced:
+                self._latch_input_coalescing_off(block, err)
+                raise _CoalescedReadFallback() from err
+            raise
+        if block.coalesced and len(values) < block.count:
+            self._latch_input_coalescing_off(
+                block, f"short response ({len(values)}/{block.count} registers)"
+            )
+            raise _CoalescedReadFallback()
+        return values
+
     async def _read_register_groups(
         self,
         group_names: list[str] | None = None,
     ) -> dict[int, int]:
         """Read multiple register groups sequentially with inter-group delays.
 
+        When a larger ``max_input_block_size`` is configured, adjacent groups
+        are coalesced into fewer reads; the first failed coalesced read falls
+        back to the plain per-group reads for the cycle and latches the
+        transport back permanently (eg4_web_monitor#254).
+
         Subclasses (e.g. BaseModbusTransport) may override this to add
-        adaptive delay or auto-reconnect logic.
+        auto-reconnect logic around it.
 
         Args:
             group_names: Specific group names from ``INPUT_REGISTER_GROUPS``.
@@ -545,34 +740,51 @@ class RegisterDataMixin(_DataMixinBase):
         Raises:
             TransportReadError: If any group read fails.
         """
-        if group_names is None:
-            groups = list(INPUT_REGISTER_GROUPS.items())
-        else:
-            groups = [
-                (name, INPUT_REGISTER_GROUPS[name])
-                for name in group_names
-                if name in INPUT_REGISTER_GROUPS
-            ]
+        groups = self._resolve_input_groups(group_names)
+        try:
+            return await self._read_group_plan(self._plan_input_reads(groups))
+        except _CoalescedReadFallback:
+            # Latched off inside _read_block; the plan is now one read/group.
+            return await self._read_group_plan(self._plan_input_reads(groups))
 
+    async def _read_group_plan(self, plan: list[_ReadBlock]) -> dict[int, int]:
+        """Execute a read plan sequentially with inter-read delays.
+
+        The adaptive-delay backoff only applies to transports that track
+        ``_last_read_retried`` (the pymodbus-based ones); the dongle
+        transport has no such attribute and keeps its fixed delay.
+        """
         registers: dict[int, int] = {}
+        current_delay = self._inter_register_delay
 
-        for i, (group_name, (start, count)) in enumerate(groups):
+        for i, block in enumerate(plan):
             try:
-                values = await self._read_input_registers(start, count)
-                for offset, value in enumerate(values):
-                    registers[start + offset] = value
+                values = await self._read_block(block)
+            except _CoalescedReadFallback:
+                raise
             except Exception as e:
                 _LOGGER.error(
                     "Failed to read register group '%s': %s",
-                    group_name,
+                    block.label,
                     e,
                 )
                 raise TransportReadError(
-                    f"Failed to read register group '{group_name}': {e}"
+                    f"Failed to read register group '{block.label}': {e}"
                 ) from e
 
-            if i < len(groups) - 1:
-                await asyncio.sleep(self._inter_register_delay)
+            for offset, value in enumerate(values):
+                registers[block.start + offset] = value
+
+            # Increase delay when retries occurred to give the device breathing room
+            if getattr(self, "_last_read_retried", False):
+                current_delay = min(current_delay * 2, 1.0)
+                _LOGGER.debug(
+                    "Increasing inter-group delay to %.3fs after retries",
+                    current_delay,
+                )
+
+            if i < len(plan) - 1:
+                await asyncio.sleep(current_delay)
 
         return registers
 
@@ -793,6 +1005,62 @@ class RegisterDataMixin(_DataMixinBase):
 
         return result
 
+    async def _read_all_input_groups(
+        self,
+        plan: list[_ReadBlock],
+    ) -> tuple[dict[int, int], bool]:
+        """Execute the combined-read plan, tracking bms_data availability.
+
+        A plain ``bms_data`` read failing or coming back short is non-fatal
+        (#261): its registers stay absent and ``bms_ok`` turns False so the
+        caller suppresses the half-empty battery bank.  In a coalesced plan
+        the bms registers ride inside a merged block, whose failure raises
+        :class:`_CoalescedReadFallback` (via ``_read_block``) so the whole
+        cycle re-runs with plain group reads — restoring exactly these
+        per-group semantics.
+
+        Returns:
+            Tuple of (address→value map, bms_ok).
+        """
+        input_registers: dict[int, int] = {}
+        bms_ok = True
+
+        for i, block in enumerate(plan):
+            is_plain_bms = block.members == ("bms_data",)
+            try:
+                values = await self._read_block(block)
+                if is_plain_bms and len(values) < block.count:
+                    # A short BMS response (e.g. a misrouted/partial dongle
+                    # frame that didn't raise) would leave reg 96 / BMS fields
+                    # absent and rebuild the half-empty bank.  Treat it as
+                    # unavailable, like an outright failure (#261).
+                    _LOGGER.debug(
+                        "bms_data short read (%d/%d regs) for %s, treating as unavailable",
+                        len(values),
+                        block.count,
+                        self._serial,
+                    )
+                    bms_ok = False
+                    continue
+                for offset, value in enumerate(values):
+                    input_registers[block.start + offset] = value
+            except _CoalescedReadFallback:
+                raise
+            except Exception:
+                if is_plain_bms:
+                    _LOGGER.debug(
+                        "bms_data registers unavailable for %s, continuing",
+                        self._serial,
+                    )
+                    bms_ok = False
+                    continue
+                raise
+
+            if i < len(plan) - 1:
+                await asyncio.sleep(self._inter_register_delay)
+
+        return input_registers, bms_ok
+
     async def read_all_input_data(
         self,
     ) -> tuple[InverterRuntimeData, InverterEnergyData, BatteryBankData | None]:
@@ -806,39 +1074,17 @@ class RegisterDataMixin(_DataMixinBase):
         Returns:
             Tuple of (runtime_data, energy_data, battery_data_or_none).
         """
-        input_registers: dict[int, int] = {}
-        bms_ok = True
-
-        for i, (group_name, (start, count)) in enumerate(INPUT_REGISTER_GROUPS.items()):
-            try:
-                values = await self._read_input_registers(start, count)
-                if group_name == "bms_data" and len(values) < count:
-                    # A short BMS response (e.g. a misrouted/partial dongle
-                    # frame that didn't raise) would leave reg 96 / BMS fields
-                    # absent and rebuild the half-empty bank.  Treat it as
-                    # unavailable, like an outright failure (#261).
-                    _LOGGER.debug(
-                        "bms_data short read (%d/%d regs) for %s, treating as unavailable",
-                        len(values),
-                        count,
-                        self._serial,
-                    )
-                    bms_ok = False
-                    continue
-                for offset, value in enumerate(values):
-                    input_registers[start + offset] = value
-            except Exception:
-                if group_name == "bms_data":
-                    _LOGGER.debug(
-                        "bms_data registers unavailable for %s, continuing",
-                        self._serial,
-                    )
-                    bms_ok = False
-                    continue
-                raise
-
-            if i < len(INPUT_REGISTER_GROUPS) - 1:
-                await asyncio.sleep(self._inter_register_delay)
+        groups = self._resolve_input_groups(None)
+        try:
+            input_registers, bms_ok = await self._read_all_input_groups(
+                self._plan_input_reads(groups)
+            )
+        except _CoalescedReadFallback:
+            # Latched off inside _read_block; the plan is now one read/group,
+            # restoring the exact per-group (bms non-fatal) semantics.
+            input_registers, bms_ok = await self._read_all_input_groups(
+                self._plan_input_reads(groups)
+            )
 
         # V23-extended PV4-6 registers (only read for models with >=4 strings)
         input_registers.update(await self._read_pv4_6_registers())

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -678,14 +678,19 @@ class RegisterDataMixin(_DataMixinBase):
         such hardware fails (or times out) every time, so the first failure
         latches the transport back to the plain grouped reads permanently
         (until the transport is recreated, e.g. on reload) instead of
-        re-paying retries every poll cycle.
+        re-paying retries every poll cycle.  Transient link errors (a short
+        or misrouted frame) trip the same latch — the warning names both
+        causes rather than blaming firmware for a one-off flake.
         """
         self._input_coalescing_latched_off = True
         _LOGGER.warning(
             "[%s] Coalesced input-register read %d-%d (%d registers; groups %s) "
-            "failed: %s — falling back to standard grouped reads for this "
-            "connection. Older dongle firmware only supports 40-register reads; "
-            "lower the configured block size to silence this probe.",
+            "failed (%s) — falling back to the standard grouped reads for this "
+            "connection. Possible causes: older dongle firmware that only "
+            "supports ~40-register reads, or a transient link error (short or "
+            "misrouted frame). Coalescing re-arms when the transport is "
+            "recreated (e.g. on reload); lower the configured block size to "
+            "disable this probe.",
             self._serial,
             block.start,
             block.start + block.count - 1,

--- a/src/pylxpweb/transports/config.py
+++ b/src/pylxpweb/transports/config.py
@@ -144,6 +144,15 @@ class TransportConfig:
     inter_register_delay: float = field(default=0.05)
     """Delay between register group reads in seconds."""
 
+    max_input_block_size: int = field(default=40)
+    """Maximum registers per coalesced input-register read (40..125).
+
+    40 (default) keeps the plain per-group reads.  Larger values (multiples
+    of 40 recommended; 120 field-proven on newer dongles) coalesce adjacent
+    register groups into fewer reads for faster polling; hardware that
+    rejects large reads automatically falls back (eg4_web_monitor#254).
+    """
+
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
         self.validate()
@@ -157,6 +166,12 @@ class TransportConfig:
         Raises:
             ValueError: If configuration is invalid
         """
+        from ._register_data import validate_input_block_size
+
+        # Applies to every register-reading transport type (not HTTP, but
+        # harmless there: the field only matters for local transports).
+        validate_input_block_size(self.max_input_block_size)
+
         # HTTP transport has relaxed validation (used for hybrid mode reference only)
         if self.transport_type == TransportType.HTTP:
             if not self.serial:
@@ -210,6 +225,7 @@ class TransportConfig:
             "retries": self.retries,
             "retry_delay": self.retry_delay,
             "inter_register_delay": self.inter_register_delay,
+            "max_input_block_size": self.max_input_block_size,
         }
 
     @classmethod
@@ -251,6 +267,7 @@ class TransportConfig:
         instance.retries = data.get("retries", 2)
         instance.retry_delay = data.get("retry_delay", 0.5)
         instance.inter_register_delay = data.get("inter_register_delay", 0.05)
+        instance.max_input_block_size = data.get("max_input_block_size", 40)
 
         # Validate the restored config
         instance.validate()

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -31,7 +31,11 @@ import logging
 import struct
 from typing import TYPE_CHECKING, Any
 
-from ._register_data import RegisterDataMixin
+from ._register_data import (
+    DEFAULT_INPUT_BLOCK_SIZE,
+    RegisterDataMixin,
+    validate_input_block_size,
+)
 from .capabilities import MODBUS_CAPABILITIES, TransportCapabilities
 from .exceptions import (
     TransportConnectionError,
@@ -139,6 +143,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         write_retries: int = DEFAULT_WRITE_RETRIES,
         write_step_delay: float = DEFAULT_WRITE_STEP_DELAY,
         verify_writes: bool = True,
+        max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
     ) -> None:
         """Initialize WiFi Dongle transport.
 
@@ -160,6 +165,13 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                 that drop the TCP link on rapid function-code changes.
             verify_writes: Read back written registers to confirm the values
                 were applied (named parameter writes only, when cheap).
+            max_input_block_size: Maximum registers per coalesced input-register
+                read, 40..125 (default 40 = no coalescing, the plain per-group
+                reads).  Larger values (multiples of 40 recommended; 120 is
+                field-proven on DG dongle firmware 2.04-2.09) consolidate
+                adjacent register groups into fewer reads; dongles that reject
+                large reads automatically fall back to the plain grouped reads
+                (eg4_web_monitor#254).
         """
         super().__init__(inverter_serial)
         self._host = host
@@ -171,6 +183,8 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         self._pv_string_count: int = 3
         self._connection_retries = connection_retries
         self._inter_register_delay = 0.5  # Dongle needs slower pace than Modbus
+        self._max_input_block_size = validate_input_block_size(max_input_block_size)
+        self._input_coalescing_latched_off: bool = False
         self._write_retries = write_retries
         self._write_step_delay = write_step_delay
         self._verify_writes = verify_writes

--- a/src/pylxpweb/transports/factory.py
+++ b/src/pylxpweb/transports/factory.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, overload
 
+from ._register_data import DEFAULT_INPUT_BLOCK_SIZE
 from .config import TransportConfig, TransportType
 from .dongle import DongleTransport
 from .http import HTTPTransport
@@ -78,6 +79,7 @@ def create_transport(
     unit_id: int = ...,
     timeout: float = ...,
     inverter_family: InverterFamily | None = ...,
+    max_input_block_size: int = ...,
 ) -> ModbusTransport: ...
 
 
@@ -93,6 +95,7 @@ def create_transport(
     unit_id: int = ...,
     timeout: float = ...,
     inverter_family: InverterFamily | None = ...,
+    max_input_block_size: int = ...,
 ) -> ModbusSerialTransport: ...
 
 
@@ -106,6 +109,7 @@ def create_transport(
     port: int = ...,
     timeout: float = ...,
     inverter_family: InverterFamily | None = ...,
+    max_input_block_size: int = ...,
 ) -> DongleTransport: ...
 
 
@@ -123,6 +127,7 @@ def create_transport(
     timeout: float = ...,
     inverter_family: InverterFamily | None = ...,
     local_retry_interval: float = ...,
+    max_input_block_size: int = ...,
 ) -> HybridTransport: ...
 
 
@@ -218,6 +223,7 @@ def create_transport(
             unit_id=config.get("unit_id", 1),
             timeout=config.get("timeout", 10.0),
             inverter_family=config.get("inverter_family"),
+            max_input_block_size=config.get("max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE),
         )
 
     if connection_type == "serial":
@@ -236,6 +242,7 @@ def create_transport(
             unit_id=config.get("unit_id", 1),
             timeout=config.get("timeout", 10.0),
             inverter_family=config.get("inverter_family"),
+            max_input_block_size=config.get("max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE),
         )
 
     if connection_type == "dongle":
@@ -255,6 +262,7 @@ def create_transport(
             port=config.get("port", 8000),
             timeout=config.get("timeout", 10.0),
             inverter_family=config.get("inverter_family"),
+            max_input_block_size=config.get("max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE),
         )
 
     if connection_type == "hybrid":
@@ -272,6 +280,7 @@ def create_transport(
         inverter_family = config.get("inverter_family")
         timeout = config.get("timeout", 10.0)
         local_retry_interval = config.get("local_retry_interval", 60.0)
+        max_input_block_size = config.get("max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE)
 
         # Create HTTP transport
         http_transport = HTTPTransport(client, serial)
@@ -285,6 +294,7 @@ def create_transport(
                 unit_id=config.get("unit_id", 1),
                 timeout=timeout,
                 inverter_family=inverter_family,
+                max_input_block_size=max_input_block_size,
             )
         elif local_type == "dongle":
             dongle_serial = config.get("dongle_serial")
@@ -297,6 +307,7 @@ def create_transport(
                 port=config.get("local_port") or 8000,
                 timeout=timeout,
                 inverter_family=inverter_family,
+                max_input_block_size=max_input_block_size,
             )
         else:
             raise ValueError(f"Invalid local_type: {local_type}")
@@ -351,6 +362,7 @@ def create_modbus_transport(
     unit_id: int = 1,
     timeout: float = 10.0,
     inverter_family: InverterFamily | None = None,
+    max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
 ) -> ModbusTransport:
     """Create a Modbus TCP transport for local network communication.
 
@@ -417,6 +429,7 @@ def create_modbus_transport(
         unit_id=unit_id,
         timeout=timeout,
         inverter_family=inverter_family,
+        max_input_block_size=max_input_block_size,
     )
 
 
@@ -428,6 +441,7 @@ def create_dongle_transport(
     port: int = 8000,
     timeout: float = 10.0,
     inverter_family: InverterFamily | None = None,
+    max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
 ) -> DongleTransport:
     """Create a WiFi dongle transport for local network communication.
 
@@ -490,6 +504,7 @@ def create_dongle_transport(
         port=port,
         timeout=timeout,
         inverter_family=inverter_family,
+        max_input_block_size=max_input_block_size,
     )
 
 
@@ -503,6 +518,7 @@ def create_serial_transport(
     unit_id: int = 1,
     timeout: float = 10.0,
     inverter_family: InverterFamily | None = None,
+    max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
 ) -> ModbusSerialTransport:
     """Create a Modbus RTU serial transport for local communication.
 
@@ -558,6 +574,7 @@ def create_serial_transport(
         unit_id=unit_id,
         timeout=timeout,
         inverter_family=inverter_family,
+        max_input_block_size=max_input_block_size,
     )
 
 
@@ -604,6 +621,7 @@ def create_transport_from_config(config: TransportConfig) -> BaseTransport:
             retries=config.retries,
             retry_delay=config.retry_delay,
             inter_register_delay=config.inter_register_delay,
+            max_input_block_size=config.max_input_block_size,
         )
     elif config.transport_type == TransportType.MODBUS_SERIAL:
         # serial_port is guaranteed to be set after validate() for MODBUS_SERIAL
@@ -620,6 +638,7 @@ def create_transport_from_config(config: TransportConfig) -> BaseTransport:
             retries=config.retries,
             retry_delay=config.retry_delay,
             inter_register_delay=config.inter_register_delay,
+            max_input_block_size=config.max_input_block_size,
         )
     elif config.transport_type == TransportType.WIFI_DONGLE:
         # dongle_serial is guaranteed to be set after validate() for WIFI_DONGLE
@@ -631,6 +650,7 @@ def create_transport_from_config(config: TransportConfig) -> BaseTransport:
             inverter_serial=config.serial,
             timeout=config.timeout,
             inverter_family=config.inverter_family,
+            max_input_block_size=config.max_input_block_size,
         )
     elif config.transport_type == TransportType.HTTP:
         raise ValueError(

--- a/src/pylxpweb/transports/modbus.py
+++ b/src/pylxpweb/transports/modbus.py
@@ -22,6 +22,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from ._modbus_base import INPUT_REGISTER_GROUPS, BaseModbusTransport
+from ._register_data import DEFAULT_INPUT_BLOCK_SIZE
 from .capabilities import MODBUS_CAPABILITIES, TransportCapabilities
 from .exceptions import TransportConnectionError
 
@@ -83,6 +84,7 @@ class ModbusTransport(BaseModbusTransport):
         retry_delay: float = 0.5,
         inter_register_delay: float = 0.05,
         pymodbus_retries: int = 3,
+        max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
     ) -> None:
         """Initialize Modbus transport.
 
@@ -102,6 +104,12 @@ class ModbusTransport(BaseModbusTransport):
                 (default 0.05)
             pymodbus_retries: Number of retries passed to pymodbus client
                 (default 3)
+            max_input_block_size: Maximum registers per coalesced input-register
+                read, 40..125 (default 40 = no coalescing, the plain per-group
+                reads).  Larger values (multiples of 40 recommended; 120 is
+                field-proven) consolidate adjacent register groups into fewer
+                reads; hardware that rejects large reads automatically falls
+                back to the plain grouped reads (eg4_web_monitor#254).
         """
         super().__init__(
             serial,
@@ -112,6 +120,7 @@ class ModbusTransport(BaseModbusTransport):
             retry_delay=retry_delay,
             inter_register_delay=inter_register_delay,
             pymodbus_retries=pymodbus_retries,
+            max_input_block_size=max_input_block_size,
         )
         self._host = host
         self._port = port

--- a/src/pylxpweb/transports/modbus_serial.py
+++ b/src/pylxpweb/transports/modbus_serial.py
@@ -29,6 +29,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from ._modbus_base import BaseModbusTransport
+from ._register_data import DEFAULT_INPUT_BLOCK_SIZE
 from .capabilities import MODBUS_CAPABILITIES, TransportCapabilities
 from .exceptions import TransportConnectionError
 
@@ -86,6 +87,7 @@ class ModbusSerialTransport(BaseModbusTransport):
         retry_delay: float = 0.5,
         inter_register_delay: float = 0.05,
         pymodbus_retries: int = 3,
+        max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
     ) -> None:
         """Initialize Modbus serial transport.
 
@@ -108,6 +110,12 @@ class ModbusSerialTransport(BaseModbusTransport):
                 (default 0.05)
             pymodbus_retries: Number of retries passed to pymodbus client
                 (default 3)
+            max_input_block_size: Maximum registers per coalesced input-register
+                read, 40..125 (default 40 = no coalescing, the plain per-group
+                reads).  Larger values (multiples of 40 recommended; 120 is
+                field-proven) consolidate adjacent register groups into fewer
+                reads; hardware that rejects large reads automatically falls
+                back to the plain grouped reads (eg4_web_monitor#254).
         """
         super().__init__(
             serial,
@@ -118,6 +126,7 @@ class ModbusSerialTransport(BaseModbusTransport):
             retry_delay=retry_delay,
             inter_register_delay=inter_register_delay,
             pymodbus_retries=pymodbus_retries,
+            max_input_block_size=max_input_block_size,
         )
         self._port = port
         self._baudrate = baudrate

--- a/tests/unit/transports/test_input_block_coalescing.py
+++ b/tests/unit/transports/test_input_block_coalescing.py
@@ -467,3 +467,170 @@ class TestFactoryPlumbing:
 
         t = create_transport("modbus", host="h", serial="CE12345678")
         assert t._max_input_block_size == DEFAULT_INPUT_BLOCK_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Station local-discovery plumbing (the third construction path)
+# ---------------------------------------------------------------------------
+
+
+class TestLocalDiscoveryPlumbing:
+    """`Station.from_local_discovery` must propagate the block size.
+
+    Regression: `Station._create_transport_from_config()` (used by
+    `from_local_discovery` -> `_discover_devices_from_configs`) omitted
+    `max_input_block_size` at both its call sites, so a
+    `TransportConfig(..., max_input_block_size=120)` silently got the
+    default 40 and coalescing never activated on that public path — while
+    `attach_local_transports()` and the factory paths propagated correctly.
+    """
+
+    def _modbus_config(self) -> TransportConfig:
+        return TransportConfig(
+            host="192.168.1.100",
+            port=502,
+            serial="CE12345678",
+            transport_type=TransportType.MODBUS_TCP,
+            max_input_block_size=120,
+        )
+
+    def _dongle_config(self) -> TransportConfig:
+        return TransportConfig(
+            host="192.168.1.101",
+            port=8000,
+            serial="CE87654321",
+            transport_type=TransportType.WIFI_DONGLE,
+            dongle_serial="BA12345678",
+            max_input_block_size=120,
+        )
+
+    def test_create_transport_from_config_modbus_propagates(self) -> None:
+        from pylxpweb.devices.station import Station
+
+        transport = Station._create_transport_from_config(self._modbus_config())
+        assert transport is not None
+        assert transport._max_input_block_size == 120
+
+    def test_create_transport_from_config_dongle_propagates(self) -> None:
+        from pylxpweb.devices.station import Station
+
+        transport = Station._create_transport_from_config(self._dongle_config())
+        assert transport is not None
+        assert transport._max_input_block_size == 120
+
+    def test_create_transport_from_config_default_conservative(self) -> None:
+        from pylxpweb.devices.station import Station
+
+        config = TransportConfig(
+            host="192.168.1.100",
+            port=502,
+            serial="CE12345678",
+            transport_type=TransportType.MODBUS_TCP,
+        )
+        transport = Station._create_transport_from_config(config)
+        assert transport is not None
+        assert transport._max_input_block_size == DEFAULT_INPUT_BLOCK_SIZE
+
+    @pytest.mark.asyncio
+    async def test_discovery_pipeline_propagates_for_both_types(self) -> None:
+        """The from_local_discovery pipeline carries the size end-to-end."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from pylxpweb.devices.station import Station
+
+        with (
+            patch.object(ModbusTransport, "connect", new=AsyncMock()),
+            patch.object(DongleTransport, "connect", new=AsyncMock()),
+            patch(
+                "pylxpweb.transports.discover_device_info",
+                new=AsyncMock(side_effect=lambda t: MagicMock(serial=t._serial)),
+            ),
+        ):
+            discovered, failed = await Station._discover_devices_from_configs(
+                [self._modbus_config(), self._dongle_config()]
+            )
+
+        assert failed == []
+        assert len(discovered) == 2
+        for transport, _info in discovered:
+            assert transport._max_input_block_size == 120
+
+
+# ---------------------------------------------------------------------------
+# Merge-boundary sentinels (guard against off-by-one in the offset math)
+# ---------------------------------------------------------------------------
+
+# Distinct raw values planted at the registers that sit on every coalesced
+# merge boundary: 112|113 (mega-block end / extended_data start), 153
+# (extended_data end), 170|173 (output_power start/end), 193|204
+# (split_phase_grid start/end).  Expected parsed values are pinned against
+# the GROUPED (pre-feature) parser, which is ground truth by definition.
+_BOUNDARY_SENTINELS = {
+    112: 250,  # temperature_t5, DIV_10 -> 25.0
+    113: (7 << 8) | 0b0101,  # packed parallel config -> parallel_number 7
+    153: 1530,  # ac_couple_power -> 1530.0 W
+    170: 1700,  # output_power -> 1700.0 W
+    173: 2,  # load_energy_total high word (regs 172-173) -> 13107.2 kWh
+    193: 1201,  # grid_l1_voltage, DIV_10 -> 120.1 V
+    204: 2040,  # grid_import_power_l2 -> 2040 W
+}
+
+
+def _make_sentinel_read():
+    """Fake reader serving a register image with the boundary sentinels."""
+
+    async def fake_read(start: int, count: int) -> list[int]:
+        return [_BOUNDARY_SENTINELS.get(start + offset, 0) for offset in range(count)]
+
+    return fake_read
+
+
+class TestBoundarySentinels:
+    """Each boundary register lands in its exact field in BOTH modes.
+
+    The equivalence tests elsewhere plant values only around regs 4-5, so an
+    off-by-one at a merge boundary (e.g. block (0,113) mapping register 113's
+    value onto 112) could slip through while SOC still matched.  These
+    sentinels bracket every merge seam; any regression in the offset math
+    shifts at least one of them into the wrong field.
+    """
+
+    def _parse(self, transport: ModbusTransport):
+        return transport.read_all_input_data()
+
+    @pytest.mark.parametrize("block_size", [40, 120])
+    @pytest.mark.asyncio
+    async def test_sentinels_land_in_correct_fields(self, block_size: int) -> None:
+        transport = _transport(max_input_block_size=block_size)
+        with patch.object(transport, "_read_input_registers", side_effect=_make_sentinel_read()):
+            runtime, energy, _battery = await transport.read_all_input_data()
+
+        assert runtime.temperature_t5 == 25.0  # reg 112
+        assert runtime.parallel_number == 7  # reg 113 (bits 8-15)
+        assert runtime.ac_couple_power == 1530.0  # reg 153
+        assert runtime.output_power == 1700.0  # reg 170
+        assert energy.load_energy_total == 13107.2  # regs 172-173 high word
+        assert runtime.grid_l1_voltage == 120.1  # reg 193
+        assert runtime.grid_import_power_l2 == 2040  # reg 204
+
+    @pytest.mark.asyncio
+    async def test_modes_parse_identically(self) -> None:
+        """Full-dataclass equivalence between grouped and coalesced modes."""
+        import dataclasses
+
+        results = {}
+        for block_size in (40, 120):
+            transport = _transport(max_input_block_size=block_size)
+            with patch.object(
+                transport, "_read_input_registers", side_effect=_make_sentinel_read()
+            ):
+                runtime, energy, battery = await transport.read_all_input_data()
+            rt = dataclasses.asdict(runtime)
+            en = dataclasses.asdict(energy)
+            rt.pop("timestamp", None)
+            en.pop("timestamp", None)
+            results[block_size] = (rt, en, battery)
+
+        assert results[40][0] == results[120][0]  # runtime
+        assert results[40][1] == results[120][1]  # energy
+        assert results[40][2] == results[120][2]  # battery (None == None)

--- a/tests/unit/transports/test_input_block_coalescing.py
+++ b/tests/unit/transports/test_input_block_coalescing.py
@@ -1,0 +1,469 @@
+"""Configurable input-register block coalescing (eg4_web_monitor#254).
+
+``max_input_block_size`` lets capable hardware read the adjacent
+``INPUT_REGISTER_GROUPS`` in consolidated Modbus transactions (e.g. regs
+0-112 in ONE read instead of four), cutting round-trips per poll.
+
+Safety contract under test:
+
+- **Default unchanged**: the default (40) issues EXACTLY the same reads as
+  before the feature — byte-identical request sequence.
+- **No gap bridging**: coalescing only merges groups whose spans are
+  contiguous or overlapping.  A merged block never reads a register address
+  that the plain grouped reads don't already read (the 154-169 and 174-192
+  gaps stay unread).
+- **Graceful degradation**: the FIRST failed/short coalesced read latches the
+  transport back to plain grouped reads permanently (one WARNING), and the
+  same cycle completes via the grouped fallback — an old dongle that cannot
+  serve large reads must degrade, not hard-fail polling.
+- **Validation**: only 40..125 accepted (125 = Modbus FC04 PDU cap).
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from pylxpweb.transports._register_data import (
+    DEFAULT_INPUT_BLOCK_SIZE,
+    INPUT_REGISTER_GROUPS,
+    MAX_INPUT_BLOCK_SIZE,
+    coalesce_register_groups,
+)
+from pylxpweb.transports.config import TransportConfig, TransportType
+from pylxpweb.transports.dongle import DongleTransport
+from pylxpweb.transports.exceptions import TransportReadError
+from pylxpweb.transports.modbus import ModbusTransport
+from pylxpweb.transports.modbus_serial import ModbusSerialTransport
+
+_VOLTAGE_RAW = 534  # reg 4, DIV_10 -> 53.4 V (above the no-battery gate)
+_SOC_SOH_PACKED = (100 << 8) | 82  # reg 5: SOC=82, SOH=100
+
+# The reads issued today (and forever, by default) for read_all_input_data:
+# the 8 register groups.  Battery/PV4-6/reg-210 reads are out of scope.
+_GROUPED_READS = [(start, count) for start, count in INPUT_REGISTER_GROUPS.values()]
+
+# Expected plan for the current group table at max_input_block_size=120:
+# groups 0-31|32-63|64-79|80-112 are contiguous -> one 113-register read;
+# eps_split_phase (140-142) is a subset of extended_data (113-153) -> merged
+# (same span extended_data already reads today); the 154-169 / 174-192 gaps
+# are never bridged, so output_power and split_phase_grid stay separate.
+_COALESCED_READS_120 = [(0, 113), (113, 41), (170, 4), (193, 12)]
+
+
+def _make_fake_read(fail_starts: set[int] = frozenset(), short_starts: set[int] = frozenset()):
+    """Fake ``_read_input_registers`` recording each (start, count) request.
+
+    ``fail_starts`` raise; ``short_starts`` return a truncated list without
+    raising.  Register 4/5 carry a valid battery voltage + SOC whenever the
+    read covers them, so battery parsing exercises the real paths.
+    """
+    calls: list[tuple[int, int]] = []
+
+    async def fake_read(start: int, count: int) -> list[int]:
+        calls.append((start, count))
+        if start in fail_starts:
+            raise OSError("simulated dropped Modbus request")
+        n = 5 if start in short_starts else count
+        vals = [0] * n
+        for reg, value in ((4, _VOLTAGE_RAW), (5, _SOC_SOH_PACKED)):
+            if start <= reg < start + n:
+                vals[reg - start] = value
+        return vals
+
+    fake_read.calls = calls  # type: ignore[attr-defined]
+    return fake_read
+
+
+def _transport(**kwargs) -> ModbusTransport:
+    t = ModbusTransport(host="192.168.1.100", serial="CE12345678", **kwargs)
+    t.pv_string_count = 3  # skip the pv4-6 extended read
+    t._inter_register_delay = 0.0  # keep tests fast
+    return t
+
+
+# ---------------------------------------------------------------------------
+# coalesce_register_groups (pure planning function)
+# ---------------------------------------------------------------------------
+
+
+class TestCoalescePlanning:
+    def test_current_table_at_120(self) -> None:
+        """The live group table consolidates 8 reads into 4 at 120."""
+        plan = coalesce_register_groups(list(INPUT_REGISTER_GROUPS.items()), 120)
+        assert [(b.start, b.count) for b in plan] == _COALESCED_READS_120
+        assert plan[0].members == (
+            "power_energy",
+            "status_energy",
+            "temperatures",
+            "bms_data",
+        )
+        assert plan[1].members == ("extended_data", "eps_split_phase")
+        assert plan[2].members == ("output_power",)
+        assert plan[3].members == ("split_phase_grid",)
+
+    def test_current_table_at_125_same_as_120(self) -> None:
+        """The FC04 PDU cap (125) doesn't admit any further merge."""
+        plan = coalesce_register_groups(list(INPUT_REGISTER_GROUPS.items()), 125)
+        assert [(b.start, b.count) for b in plan] == _COALESCED_READS_120
+
+    def test_current_table_at_40_is_identity(self) -> None:
+        """At the conservative default no merge fits -> plain group reads."""
+        plan = coalesce_register_groups(list(INPUT_REGISTER_GROUPS.items()), 40)
+        assert [(b.start, b.count) for b in plan] == _GROUPED_READS
+        assert all(len(b.members) == 1 for b in plan)
+
+    def test_never_bridges_gaps(self) -> None:
+        """Groups separated by unread registers stay separate reads.
+
+        (10,10) ends at 20 and (30,10) starts at 30: registers 20-29 are not
+        read by any group, so even though the combined span (30) fits in the
+        block size, they must NOT be merged into one read.
+        """
+        plan = coalesce_register_groups([("a", (10, 10)), ("b", (30, 10))], 120)
+        assert [(b.start, b.count) for b in plan] == [(10, 10), (30, 10)]
+
+    def test_merges_contiguous_and_contained(self) -> None:
+        """Contiguous groups merge; a fully-contained group folds in."""
+        plan = coalesce_register_groups([("a", (0, 10)), ("b", (10, 10)), ("c", (5, 3))], 120)
+        assert [(b.start, b.count) for b in plan] == [(0, 20)]
+        assert plan[0].members == ("a", "c", "b")
+
+    def test_oversized_single_group_is_never_split(self) -> None:
+        """A group larger than the limit stays one read (never split)."""
+        plan = coalesce_register_groups([("big", (0, 60))], 40)
+        assert [(b.start, b.count) for b in plan] == [(0, 60)]
+
+    def test_merge_stops_at_size_limit(self) -> None:
+        """A merge that would exceed the limit starts a new block."""
+        plan = coalesce_register_groups([("a", (0, 30)), ("b", (30, 30)), ("c", (60, 30))], 60)
+        assert [(b.start, b.count) for b in plan] == [(0, 60), (60, 30)]
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+class TestBlockSizeValidation:
+    def test_defaults(self) -> None:
+        assert DEFAULT_INPUT_BLOCK_SIZE == 40
+        assert MAX_INPUT_BLOCK_SIZE == 125
+        t = ModbusTransport(host="h", serial="CE12345678")
+        assert t._max_input_block_size == DEFAULT_INPUT_BLOCK_SIZE
+
+    @pytest.mark.parametrize("value", [40, 80, 120, 125])
+    def test_accepts_sane_values(self, value: int) -> None:
+        t = ModbusTransport(host="h", serial="CE12345678", max_input_block_size=value)
+        assert t._max_input_block_size == value
+
+    @pytest.mark.parametrize("value", [0, 39, 126, 1000, -1])
+    def test_rejects_out_of_range_modbus(self, value: int) -> None:
+        with pytest.raises(ValueError, match="max_input_block_size"):
+            ModbusTransport(host="h", serial="CE12345678", max_input_block_size=value)
+
+    @pytest.mark.parametrize("value", [39, 126])
+    def test_rejects_out_of_range_dongle(self, value: int) -> None:
+        with pytest.raises(ValueError, match="max_input_block_size"):
+            DongleTransport(
+                host="h",
+                dongle_serial="BA12345678",
+                inverter_serial="CE12345678",
+                max_input_block_size=value,
+            )
+
+    def test_dongle_accepts_120(self) -> None:
+        t = DongleTransport(
+            host="h",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+            max_input_block_size=120,
+        )
+        assert t._max_input_block_size == 120
+
+    def test_serial_transport_accepts_120(self) -> None:
+        t = ModbusSerialTransport(
+            port="/dev/ttyUSB0", serial="CE12345678", max_input_block_size=120
+        )
+        assert t._max_input_block_size == 120
+
+
+# ---------------------------------------------------------------------------
+# Default behavior is byte-identical to before the feature
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultUnchanged:
+    @pytest.mark.asyncio
+    async def test_combined_read_issues_grouped_reads(self) -> None:
+        transport = _transport()
+        fake = _make_fake_read()
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            runtime, energy, battery = await transport.read_all_input_data()
+
+        assert fake.calls == _GROUPED_READS
+        assert runtime is not None
+        assert energy is not None
+        assert battery is not None
+
+    @pytest.mark.asyncio
+    async def test_read_runtime_issues_grouped_reads(self) -> None:
+        transport = _transport()
+        fake = _make_fake_read()
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport.read_runtime()
+
+        assert fake.calls == _GROUPED_READS
+
+
+# ---------------------------------------------------------------------------
+# Opt-in coalesced reads
+# ---------------------------------------------------------------------------
+
+
+class TestCoalescedReads:
+    @pytest.mark.asyncio
+    async def test_combined_read_coalesces_at_120(self) -> None:
+        transport = _transport(max_input_block_size=120)
+        fake = _make_fake_read()
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            runtime, energy, battery = await transport.read_all_input_data()
+
+        assert fake.calls == _COALESCED_READS_120
+        assert runtime is not None
+        assert energy is not None
+        # bms_data (reg 96 et al) rode along in the 0-112 block
+        assert battery is not None
+        assert battery.soc == 82
+
+    @pytest.mark.asyncio
+    async def test_read_runtime_coalesces_at_120(self) -> None:
+        transport = _transport(max_input_block_size=120)
+        fake = _make_fake_read()
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport.read_runtime()
+
+        assert fake.calls == _COALESCED_READS_120
+
+    @pytest.mark.asyncio
+    async def test_read_energy_coalesces_main_groups(self) -> None:
+        """read_energy's power+status subset merges; bms stays its own read."""
+        transport = _transport(max_input_block_size=120)
+        fake = _make_fake_read()
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport.read_energy()
+
+        assert fake.calls == [(0, 64), (170, 4), (80, 33)]
+
+    @pytest.mark.asyncio
+    async def test_coalesced_data_equivalent_to_grouped(self) -> None:
+        """Runtime parsed from coalesced reads == parsed from grouped reads."""
+        fake_a = _make_fake_read()
+        grouped = _transport()
+        with patch.object(grouped, "_read_input_registers", side_effect=fake_a):
+            runtime_grouped, energy_grouped, battery_grouped = await grouped.read_all_input_data()
+
+        fake_b = _make_fake_read()
+        coalesced = _transport(max_input_block_size=120)
+        with patch.object(coalesced, "_read_input_registers", side_effect=fake_b):
+            (
+                runtime_coalesced,
+                energy_coalesced,
+                battery_coalesced,
+            ) = await coalesced.read_all_input_data()
+
+        assert runtime_coalesced.battery_voltage == runtime_grouped.battery_voltage
+        assert runtime_coalesced.battery_soc == runtime_grouped.battery_soc
+        assert energy_coalesced.pv_energy_today == energy_grouped.pv_energy_today
+        assert battery_grouped is not None and battery_coalesced is not None
+        assert battery_coalesced.soc == battery_grouped.soc
+
+
+# ---------------------------------------------------------------------------
+# Failure fallback latch
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLatch:
+    @pytest.mark.asyncio
+    async def test_failed_coalesced_read_falls_back_same_cycle(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """First coalesced failure -> WARNING + grouped completion + latch."""
+        transport = _transport(max_input_block_size=120)
+        # The coalesced 0-112 read fails; the plain group reads (0,32 etc.)
+        # succeed — only start=0 with count=113 must fail.
+        calls: list[tuple[int, int]] = []
+
+        async def fake_read(start: int, count: int) -> list[int]:
+            calls.append((start, count))
+            if (start, count) == (0, 113):
+                raise OSError("large read not supported by this dongle")
+            vals = [0] * count
+            for reg, value in ((4, _VOLTAGE_RAW), (5, _SOC_SOH_PACKED)):
+                if start <= reg < start + count:
+                    vals[reg - start] = value
+            return vals
+
+        with (
+            caplog.at_level(logging.WARNING, logger="pylxpweb.transports._register_data"),
+            patch.object(transport, "_read_input_registers", side_effect=fake_read),
+        ):
+            runtime, energy, battery = await transport.read_all_input_data()
+
+        # Same cycle completed via the conservative grouped reads
+        assert calls == [(0, 113), *_GROUPED_READS]
+        assert runtime is not None
+        assert energy is not None
+        assert battery is not None
+        # Latched off permanently for this transport
+        assert transport._input_coalescing_latched_off is True
+        assert any("falling back" in rec.message.lower() for rec in caplog.records), caplog.records
+
+    @pytest.mark.asyncio
+    async def test_latched_transport_stays_grouped_next_cycle(self) -> None:
+        transport = _transport(max_input_block_size=120)
+        transport._input_coalescing_latched_off = True
+        fake = _make_fake_read()
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport.read_all_input_data()
+
+        assert fake.calls == _GROUPED_READS
+
+    @pytest.mark.asyncio
+    async def test_short_coalesced_read_latches_and_falls_back(self) -> None:
+        """A truncated (non-raising) coalesced frame also degrades safely."""
+        transport = _transport(max_input_block_size=120)
+        calls: list[tuple[int, int]] = []
+
+        async def fake_read(start: int, count: int) -> list[int]:
+            calls.append((start, count))
+            # Truncate ONLY the coalesced 113-register read; the plain
+            # 32-register read of the same start must succeed.
+            if (start, count) == (0, 113):
+                return [0] * 5
+            vals = [0] * count
+            for reg, value in ((4, _VOLTAGE_RAW), (5, _SOC_SOH_PACKED)):
+                if start <= reg < start + count:
+                    vals[reg - start] = value
+            return vals
+
+        with patch.object(transport, "_read_input_registers", side_effect=fake_read):
+            runtime, _energy, battery = await transport.read_all_input_data()
+
+        assert transport._input_coalescing_latched_off is True
+        assert calls == [(0, 113), *_GROUPED_READS]
+        assert runtime is not None
+        assert battery is not None
+
+    @pytest.mark.asyncio
+    async def test_single_group_failure_in_coalesced_plan_raises(self) -> None:
+        """An unmerged block failing behaves exactly like today (no latch)."""
+        transport = _transport(max_input_block_size=120)
+        # split_phase_grid (193,12) is never merged; its failure must raise
+        # TransportReadError as before, without latching coalescing off.
+        fake = _make_fake_read(fail_starts={193})
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            pytest.raises(TransportReadError),
+        ):
+            await transport.read_runtime()
+
+        assert transport._input_coalescing_latched_off is False
+
+    @pytest.mark.asyncio
+    async def test_bms_semantics_preserved_in_fallback(self) -> None:
+        """Coalesced fail -> grouped fallback -> bms-only drop is non-fatal."""
+        transport = _transport(max_input_block_size=120)
+
+        async def fake_read(start: int, count: int) -> list[int]:
+            if (start, count) == (0, 113):
+                raise OSError("large read not supported")
+            if start == 80:  # bms_data group drops in the fallback too
+                raise OSError("bms flaky")
+            vals = [0] * count
+            for reg, value in ((4, _VOLTAGE_RAW), (5, _SOC_SOH_PACKED)):
+                if start <= reg < start + count:
+                    vals[reg - start] = value
+            return vals
+
+        with patch.object(transport, "_read_input_registers", side_effect=fake_read):
+            runtime, _energy, battery = await transport.read_all_input_data()
+
+        assert runtime is not None
+        assert battery is None  # degraded bank suppressed, cache preserved
+
+
+# ---------------------------------------------------------------------------
+# TransportConfig plumbing (hybrid attach path)
+# ---------------------------------------------------------------------------
+
+
+class TestTransportConfigField:
+    def test_round_trip(self) -> None:
+        config = TransportConfig(
+            host="192.168.1.100",
+            port=502,
+            serial="CE12345678",
+            transport_type=TransportType.MODBUS_TCP,
+            max_input_block_size=120,
+        )
+        data = config.to_dict()
+        assert data["max_input_block_size"] == 120
+        restored = TransportConfig.from_dict(data)
+        assert restored.max_input_block_size == 120
+
+    def test_from_dict_default_when_absent(self) -> None:
+        """Configs stored by older versions restore to the conservative default."""
+        restored = TransportConfig.from_dict(
+            {
+                "host": "192.168.1.100",
+                "port": 502,
+                "serial": "CE12345678",
+                "transport_type": "modbus_tcp",
+            }
+        )
+        assert restored.max_input_block_size == DEFAULT_INPUT_BLOCK_SIZE
+
+    def test_validate_rejects_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match="max_input_block_size"):
+            TransportConfig(
+                host="192.168.1.100",
+                port=502,
+                serial="CE12345678",
+                transport_type=TransportType.MODBUS_TCP,
+                max_input_block_size=200,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Factory plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryPlumbing:
+    def test_create_transport_modbus_forwards(self) -> None:
+        from pylxpweb.transports import create_transport
+
+        t = create_transport("modbus", host="h", serial="CE12345678", max_input_block_size=120)
+        assert t._max_input_block_size == 120
+
+    def test_create_transport_dongle_forwards(self) -> None:
+        from pylxpweb.transports import create_transport
+
+        t = create_transport(
+            "dongle",
+            host="h",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+            max_input_block_size=120,
+        )
+        assert t._max_input_block_size == 120
+
+    def test_create_transport_default_conservative(self) -> None:
+        from pylxpweb.transports import create_transport
+
+        t = create_transport("modbus", host="h", serial="CE12345678")
+        assert t._max_input_block_size == DEFAULT_INPUT_BLOCK_SIZE

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.36b18"
+version = "0.9.36b19"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Adds an opt-in **`max_input_block_size`** (40..125, default **40 = byte-identical current behavior**) to `ModbusTransport`, `ModbusSerialTransport`, `DongleTransport`, `TransportConfig`, and all factory paths (`create_transport`, `create_*_transport`, `create_transport_from_config`, `Station.attach_local_transports`). Values above 40 coalesce **adjacent/overlapping** `INPUT_REGISTER_GROUPS` into consolidated FC04 reads: at 120 the 8 inverter group reads become **4** — regs 0–112 in ONE transaction — cutting ~4 Modbus round-trips per poll per inverter (plus 1 more on `read_energy`'s partial-cache path). This is the library half of the reporter-requested faster local polling; the companion eg4_web_monitor PR exposes it as a Conservative/Fast options-flow preset.

## Design

**Coalescing** (`coalesce_register_groups`, pure + unit-tested): sort groups by span, merge the next group into the running block only when `next.start <= run_end` (contiguous or overlapping — no hole) and the merged span fits the limit. Generic over the group table — future group edits stay safe. A single group larger than the limit is never split. Plans:

| block size | reads for `read_all_input_data` |
|---|---|
| 40 (default) | `(0,32) (32,32) (64,16) (80,33) (113,41) (140,3) (170,4) (193,12)` — identical to today |
| 120 (fast) | `(0,113) (113,41) (170,4) (193,12)` |

**Fallback latch (probe-once)**: the FIRST failed **or short** coalesced read logs one WARNING, completes the **same cycle** via the plain grouped reads, and permanently latches the transport back to grouped mode (until recreation, e.g. HA reload). Old ~40-register-cap dongle firmware degrades gracefully instead of hard-failing polling; a transient outage at probe time costs only the fast mode until reload (warned). Unmerged blocks inside a coalesced plan keep today's exact error semantics (no latch, `TransportReadError`); `bms_data` non-fatality (#261) is preserved because the fallback re-runs the plain per-group loop.

**Out of coalescing scope (unchanged)**: the atomic 120-register battery block, PV4-6 extended reads, input reg 210, holding-register/parameter reads, and **GridBOSS/MID reads** — deliberately NOT coalesced because >40-register midbox reads *empirically failed on real GridBOSS hardware* (f050eb2 split them to ≤40 as a "dongle hardware limit" fix).

## Evidence for boundary safety

- Groups 0–153 are **strictly contiguous** (`0-31|32-63|64-79|80-112|113-153`); `eps_split_phase` (140–142) is a **subset** of `extended_data` (113–153) — an artifact of extended_data growing from (113,18) to (113,41) (7c3a2d8, e82af90) around it. A merged (113,41) read is byte-identical to the extended_data read already issued today.
- The inter-group gaps **154–169 and 174–192 are never read today and never bridged by coalescing** — merged blocks are exact unions of member spans (regression-tested, incl. a synthetic gap case).
- Large-read capability precedent on the same wire: the battery block already does an **atomic 120-register read on every poll** on all deployed dongle/Modbus hardware, and `extended_data` (41 regs) already exceeds the doc's 40-register block rule. The dongle frame's u8 byte-count caps at 127 registers; 125 is the FC04 PDU cap.
- Reporter's empirical data (@ivanfmartinez, eg4_web_monitor#254): DG dongle fw 2.04→2.09 reads 120-register blocks reliably (input/holding/battery); the vendor Modbus RTU doc (2025/6/13) documents the 40-register block boundary for old firmware — hence default 40 and the 40-multiples recommendation in the docstrings/validation message.

## Testing

- 38 new tests in `tests/unit/transports/test_input_block_coalescing.py`: planning (merges, gap-never-bridged, oversized group, size cutoff), **default-unchanged byte-identical read sequences**, coalesced read paths for `read_all_input_data`/`read_runtime`/`read_energy`, data equivalence coalesced vs grouped, failure + short-read fallback latch (same-cycle completion, next-cycle grouped), unmerged-block failure semantics, bms-drop-in-fallback, constructor validation on all three transports, `TransportConfig` round-trip/default/validation, factory forwarding.
- Full suite: **2505 passed, 4 skipped**. `ruff check` + `ruff format` clean; `mypy --strict` clean.
- `uv.lock`: one-line refresh recording the 0.9.36b19 version pyproject already declares (main's lock was stale; no dependency changes, no version bump).

## Live-hardware verification asks (@ivanfmartinez volunteered his DG dongle)

1. With the integration preset **Fast (120)**: confirm poll cycles issue the consolidated reads and complete faster; watch for any `Coalesced input-register read ... failed` WARNING.
2. On an **old-firmware dongle** (≤40-register cap), set Fast and confirm: exactly one WARNING, polling continues on grouped reads with no entity loss.
3. Sanity-check entity values match the Conservative setting (the merged spans are identical unions, so any divergence would indicate firmware misbehaving on large reads of 0–112).


## Review round (Codex + Opus adversarial)

Commit `0254860` addresses the confirmed findings:
- **Codex P1**: `Station._create_transport_from_config()` (the `from_local_discovery` path) now propagates `config.max_input_block_size` at both call sites; regression tests pin both transport types (verified failing pre-fix).
- **Codex/Opus P2**: boundary-sentinel tests plant distinct values at every merge seam (regs 112/113/153/170/173/193/204) and assert exact field placement + full-dataclass grouped-vs-coalesced equivalence (previous equivalence checks only planted regs 4-5).
- **Opus P2**: the latch WARNING no longer blames old firmware unconditionally — it states the failed block and reason, and names old ~40-register firmware as one possible cause alongside transient link errors (short/misrouted frames).

## Follow-ups (deferred by review — not in this PR)

1. **Exclude `bms_data` (regs 80-112) from coalescing** so a BMS-passthrough flake riding inside the (0,113) block can't latch off the healthy 0-79/extended-data merges. Needs live evidence from the reporter's Fast-mode trial before changing the plan shape.
2. **Latch tuning** — N-strike or time-based retry instead of the permanent probe-once latch, for misroute-prone dongles where a single transient flake currently disables fast mode until reload.
3. **Fallback-latch race on concurrent direct `read_runtime()` calls** that bypass `_op_lock` (public-library edge case; the HA integration serializes reads, so not reachable on that path).
4. **Feature-detection representativeness** (integration-side): `inspect.signature` on `ModbusTransport` stands in for all local transports — fine while the parameter ships on every transport in one release; revisit if that ever diverges.

Versioning: intentionally **no version bump** in this PR — the release chore (0.9.36b20) lands on main after merge.

Refs eg4_web_monitor#254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
