### PR TITLE
fix: sticky parameter carry-forward + parameters_complete flag + reg96-zero gate guard (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failed on real GridBOSS hardware); the atomic 120-register battery block,
   PV4-6 extended reads, and input-register 210 are unchanged.
 
+- **`BaseInverter.parameters_complete`** ([eg4_web_monitor#282](https://github.com/joyfulhouse/eg4_web_monitor/issues/282)):
+  public flag reporting whether the LAST parameter fetch read every register
+  range. After a partial/failed fetch it is `False` while `parameters` still
+  holds last-known values for the failed ranges (sticky carry-forward below).
+  Consumers — e.g. the HA integration's hourly parameter throttle — can use it
+  to retry sooner instead of serving a degraded snapshot for a full interval.
+
 - **Battery rotation-stall watchdog** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   the 2026-06-28 report pinned the firmware's battery page for ~9 hours with
   ZERO non-debug logs — every 120-register block read succeeded, so nothing
@@ -75,6 +82,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   between the two spellings. The minor number is now zero-padded to two
   digits, matching both the cloud and the RS485 battery protocol's existing
   formatting.
+
+- **A failed/partial parameter read no longer blanks previously-known parameters** ([eg4_web_monitor#282](https://github.com/joyfulhouse/eg4_web_monitor/issues/282)):
+  `_fetch_parameters` swallowed per-range failures and then REPLACED
+  `parameters` with the partial result — one misrouted WiFi-dongle response
+  (`Failed to read registers 125-250`) wiped every parameter in registers
+  125-249 (e.g. `HOLD_SYSTEM_CHARGE_SOC_LIMIT`, reg 227 — the reporter's
+  "System Charge SOC Limit became unknown") — and stamped the parameter cache
+  anyway, so the degraded snapshot persisted for the whole TTL. Both the
+  transport (Modbus/dongle) and HTTP paths now merge a partial read OVER the
+  last-known parameters (only successfully re-read ranges change; a fully
+  successful read remains authoritative and prunes stale keys), stamp the
+  cache only on a FULLY successful read (so the next `include_parameters`
+  refresh retries), and log one INFO line naming the failed range(s).
+
+- **A transient reg 96 = 0 no longer wipes accumulated batteries** ([eg4_web_monitor#282](https://github.com/joyfulhouse/eg4_web_monitor/issues/282)):
+  the 5002+ individual-battery block read was gated on `battery_count > 0`
+  (reg 96), which is known-unreliable (#170/#258). On a battery-bearing unit a
+  transient 0 skipped the block read entirely — the never-evict accumulator
+  was not consulted (its failure fallback only covers *raised* reads, not a
+  gate skip) — so the bank was built with `batteries=[]` and every accumulated
+  battery vanished for the cycle. Once anything has been accumulated the block
+  is now read regardless of reg 96; genuinely battery-less units (nothing ever
+  accumulated, e.g. a second parallel inverter with no BMS connection) still
+  skip the read.
 
 - **A failed battery block read no longer wipes individual batteries for the cycle** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   when the atomic 5002-5121 read failed (`Failed to read battery registers

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -1263,6 +1263,16 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                             # refresh instead of serving a degraded snapshot
                             # for the whole parameter TTL.
                             self._parameters_cache_time = datetime.now()
+                    elif failed_ranges and self.parameters:
+                        # Total failure with carried parameters: without this
+                        # the staleness signal was silent (#282 review P2).
+                        _LOGGER.info(
+                            "Parameter read for %s failed entirely (register "
+                            "range(s) %s); serving last-known parameters and "
+                            "retrying on the next parameter refresh",
+                            self.serial_number,
+                            ", ".join(failed_ranges),
+                        )
                 else:
                     # Use HTTP API for full parameter access
                     range_tasks = [
@@ -1279,24 +1289,31 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
 
                     responses = await asyncio.gather(*range_tasks, return_exceptions=True)
 
-                    # Merge all parameter dictionaries
+                    # Merge all parameter dictionaries.  Starts mirror the
+                    # range_tasks list above so failures can be NAMED — "N of
+                    # 3 ranges failed" hides which parameters went stale.
+                    range_starts = (0, MAX_REGISTERS_PER_READ, 240)
                     all_parameters = {}
-                    failures = 0
-                    for response in responses:
+                    failed_cloud_ranges: list[str] = []
+                    for start, response in zip(range_starts, responses, strict=True):
                         if isinstance(response, BaseException):
-                            failures += 1
+                            failed_cloud_ranges.append(
+                                f"{start}-{start + MAX_REGISTERS_PER_READ - 1}"
+                            )
                             _LOGGER.debug(
-                                "Parameter range read failed for %s: %s",
+                                "Parameter range %d-%d read failed for %s: %s",
+                                start,
+                                start + MAX_REGISTERS_PER_READ - 1,
                                 self.serial_number,
                                 response,
                             )
                         else:
                             all_parameters.update(response.parameters)
 
-                    self.parameters_complete = failures == 0
+                    self.parameters_complete = not failed_cloud_ranges
                     # Only update if we got at least some parameters
                     if all_parameters:
-                        if failures and self.parameters:
+                        if failed_cloud_ranges and self.parameters:
                             # Sticky carry-forward (eg4_web_monitor#282): keep
                             # last-known values for the dropped range(s); only
                             # successfully re-read ranges change.
@@ -1304,19 +1321,29 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                             merged.update(all_parameters)
                             all_parameters = merged
                             _LOGGER.info(
-                                "Parameter read for %s incomplete (%d of %d "
-                                "cloud ranges failed); serving last-known "
-                                "values for the failed range(s) and retrying "
-                                "on the next parameter refresh",
+                                "Parameter read for %s incomplete (cloud "
+                                "register range(s) %s failed); serving "
+                                "last-known values for the failed range(s) "
+                                "and retrying on the next parameter refresh",
                                 self.serial_number,
-                                failures,
-                                len(responses),
+                                ", ".join(failed_cloud_ranges),
                             )
                         self.parameters = all_parameters
-                        if failures == 0:
+                        if not failed_cloud_ranges:
                             # Stamp only a FULLY successful read (see the
                             # transport path above).
                             self._parameters_cache_time = datetime.now()
+                    elif failed_cloud_ranges and self.parameters:
+                        # Total failure with carried parameters: without this
+                        # the staleness signal was silent (#282 review P2).
+                        _LOGGER.info(
+                            "Parameter read for %s failed entirely (cloud "
+                            "register range(s) %s); serving last-known "
+                            "parameters and retrying on the next parameter "
+                            "refresh",
+                            self.serial_number,
+                            ", ".join(failed_cloud_ranges),
+                        )
             except (LuxpowerAPIError, LuxpowerConnectionError, LuxpowerDeviceError) as err:
                 # Keep existing cached data on API/connection errors
                 self.parameters_complete = False

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -133,6 +133,13 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
 
         # Parameters (configuration registers, refreshed hourly)
         self.parameters: dict[str, Any] | None = None
+        # True when the LAST parameter fetch read every register range.
+        # After a partial/failed fetch this is False and ``parameters`` still
+        # holds last-known values for the failed ranges (sticky carry-forward,
+        # eg4_web_monitor#282).  Consumers — e.g. the HA integration's hourly
+        # parameter throttle — can use this to retry sooner instead of serving
+        # a degraded snapshot for the whole refresh interval.
+        self.parameters_complete: bool = True
 
         # Battery metadata cache (cloud-supplemented for hybrid mode)
         # Stores battery_type, battery_type_text, model keyed by battery serial
@@ -1209,6 +1216,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                         (125, 125),  # Registers 125-249
                     ]
 
+                    failed_ranges: list[str] = []
                     for start, count in register_groups:
                         try:
                             # Use read_named_parameters to get properly decoded parameter names
@@ -1216,6 +1224,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                             named_params = await self._transport.read_named_parameters(start, count)
                             all_parameters.update(named_params)
                         except Exception as err:
+                            failed_ranges.append(f"{start}-{start + count - 1}")
                             _LOGGER.debug(
                                 "Failed to read registers %d-%d for %s: %s",
                                 start,
@@ -1224,9 +1233,36 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                                 err,
                             )
 
+                    self.parameters_complete = not failed_ranges
                     if all_parameters:
+                        if failed_ranges and self.parameters:
+                            # Sticky carry-forward (eg4_web_monitor#282; the
+                            # #261 fault/warning-code precedent): a dropped
+                            # range must not blank previously-known values —
+                            # one misrouted dongle response used to wipe every
+                            # parameter in registers 125-249 (e.g. the
+                            # reg-227 System Charge SOC Limit) for the whole
+                            # parameter interval.  Merge the fresh partial
+                            # read OVER the last-known parameters so only
+                            # successfully re-read ranges change.
+                            merged = dict(self.parameters)
+                            merged.update(all_parameters)
+                            all_parameters = merged
+                            _LOGGER.info(
+                                "Parameter read for %s incomplete (register "
+                                "range(s) %s failed); serving last-known "
+                                "values for the failed range(s) and retrying "
+                                "on the next parameter refresh",
+                                self.serial_number,
+                                ", ".join(failed_ranges),
+                            )
                         self.parameters = all_parameters
-                        self._parameters_cache_time = datetime.now()
+                        if not failed_ranges:
+                            # Stamp only a FULLY successful read: a partial
+                            # one must retry on the next include_parameters
+                            # refresh instead of serving a degraded snapshot
+                            # for the whole parameter TTL.
+                            self._parameters_cache_time = datetime.now()
                 else:
                     # Use HTTP API for full parameter access
                     range_tasks = [
@@ -1245,19 +1281,49 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
 
                     # Merge all parameter dictionaries
                     all_parameters = {}
+                    failures = 0
                     for response in responses:
-                        if not isinstance(response, BaseException):
+                        if isinstance(response, BaseException):
+                            failures += 1
+                            _LOGGER.debug(
+                                "Parameter range read failed for %s: %s",
+                                self.serial_number,
+                                response,
+                            )
+                        else:
                             all_parameters.update(response.parameters)
 
+                    self.parameters_complete = failures == 0
                     # Only update if we got at least some parameters
                     if all_parameters:
+                        if failures and self.parameters:
+                            # Sticky carry-forward (eg4_web_monitor#282): keep
+                            # last-known values for the dropped range(s); only
+                            # successfully re-read ranges change.
+                            merged = dict(self.parameters)
+                            merged.update(all_parameters)
+                            all_parameters = merged
+                            _LOGGER.info(
+                                "Parameter read for %s incomplete (%d of %d "
+                                "cloud ranges failed); serving last-known "
+                                "values for the failed range(s) and retrying "
+                                "on the next parameter refresh",
+                                self.serial_number,
+                                failures,
+                                len(responses),
+                            )
                         self.parameters = all_parameters
-                        self._parameters_cache_time = datetime.now()
+                        if failures == 0:
+                            # Stamp only a FULLY successful read (see the
+                            # transport path above).
+                            self._parameters_cache_time = datetime.now()
             except (LuxpowerAPIError, LuxpowerConnectionError, LuxpowerDeviceError) as err:
                 # Keep existing cached data on API/connection errors
+                self.parameters_complete = False
                 _LOGGER.debug("Failed to fetch parameters for %s: %s", self.serial_number, err)
             except Exception as err:
                 # Catch transport errors as well
+                self.parameters_complete = False
                 _LOGGER.debug("Failed to fetch parameters for %s: %s", self.serial_number, err)
 
     def to_device_info(self) -> DeviceInfo:

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -982,7 +982,17 @@ class RegisterDataMixin(_DataMixinBase):
             include_individual,
         )
 
-        if include_individual and battery_count > 0:
+        # reg 96 is unreliable (#170/#258): a transient 0 on a battery-bearing
+        # unit must not bypass the block read — the accumulator would never be
+        # consulted (its failure fallback only covers RAISED reads, not a
+        # gate skip), so the bank would be built with batteries=[] and every
+        # accumulated battery would vanish for the cycle (eg4_web_monitor#282
+        # review flag, same family as the #258 wipe).  Once anything has been
+        # accumulated, read the block regardless of reg 96; a unit that never
+        # accumulated anything (genuinely battery-less) still skips the read.
+        if include_individual and (
+            battery_count > 0 or getattr(self, "_battery_accumulator", None)
+        ):
             await self._read_battery_header_registers()
             individual_registers = await self._read_individual_battery_registers(
                 battery_count,
@@ -1133,7 +1143,15 @@ class RegisterDataMixin(_DataMixinBase):
         )
 
         individual_registers: dict[int, int] | None = None
-        if battery_count > 0:
+        # reg 96 is unreliable (#170/#258): a transient 0 on a battery-bearing
+        # unit must not bypass the block read — the accumulator would never be
+        # consulted (its failure fallback only covers RAISED reads, not a
+        # gate skip), so the bank would be built with batteries=[] and every
+        # accumulated battery would vanish for the cycle (eg4_web_monitor#282
+        # review flag, same family as the #258 wipe).  Once anything has been
+        # accumulated, read the block regardless of reg 96; a unit that never
+        # accumulated anything (genuinely battery-less) still skips the read.
+        if battery_count > 0 or getattr(self, "_battery_accumulator", None):
             await self._read_battery_header_registers()
             individual_registers = await self._read_individual_battery_registers(
                 battery_count,

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -76,6 +76,13 @@ _MIN_BATTERY_SERIAL_LEN = 10
 BATTERY_ROTATION_STALL_WARN_AFTER = timedelta(minutes=45)
 _BATTERY_STALL_PER_PAGE = timedelta(minutes=15)
 
+# Empty-bank convergence (#282 review): consecutive SUCCESSFUL block reads
+# reporting reg 96 = 0 with an all-ghost page before the never-evict
+# accumulator is retired.  One or two empty reads are indistinguishable from
+# a transient reg-96/bms glitch (the reason the gate guard exists); three in
+# a row on a healthy link means the batteries are genuinely gone.
+_BATTERY_EMPTY_BANK_RETIRE_STREAK = 3
+
 # ---------------------------------------------------------------------------
 # Register group constants (unified across Modbus and Dongle transports)
 # ---------------------------------------------------------------------------
@@ -371,6 +378,7 @@ class RegisterDataMixin(_DataMixinBase):
         # firmware rotation cannot be characterized from logs.  Diffing this line
         # across reads shows exactly when a battery rotates into/out of a slot.
         raw_page: list[str] = []
+        page_has_active_slot = False
 
         for phys_slot in range(BATTERY_MAX_COUNT):
             slot_base = BATTERY_BASE_ADDRESS + (phys_slot * BATTERY_REGISTER_COUNT)
@@ -378,6 +386,14 @@ class RegisterDataMixin(_DataMixinBase):
             if not status:
                 raw_page.append(f"{phys_slot}=empty")
                 continue  # Empty physical slot — skip
+
+            # Ghost slot: status set but no electrical data (canonical ghost
+            # definition, voltage=0 and soc=0).  Counted as inactive for the
+            # empty-bank convergence streak below.
+            slot_voltage = raw_registers.get(slot_base + 6, 0)
+            slot_soc = raw_registers.get(slot_base + 8, 0) & 0xFF
+            if slot_voltage or slot_soc:
+                page_has_active_slot = True
 
             # Extract this slot's 30-register block (using slot-local offsets 0-29)
             slot_regs: dict[int, int] = {}
@@ -429,6 +445,37 @@ class RegisterDataMixin(_DataMixinBase):
             " ".join(raw_page),
             battery_count,
         )
+
+        # Empty-bank convergence streak (#282 review P1): the accumulator
+        # never evicts, and since the reg96-zero gate guard it is consulted
+        # on every read — so a bank whose batteries were PHYSICALLY removed
+        # would be served from stale accumulation forever (pre-guard, the
+        # gate skip was accidentally the only convergence path, wiping
+        # transients along with real removals).  Retire the accumulator only
+        # after N consecutive SUCCESSFUL reads that report reg 96 = 0 AND an
+        # all-ghost page.  Failed reads never reach this code (the failure
+        # path above returns first), so a #258-style misroute storm cannot
+        # advance the streak, and any real slot or reg 96 > 0 resets it.
+        if battery_count == 0 and not page_has_active_slot:
+            streak = getattr(self, "_battery_empty_page_streak", 0) + 1
+            self._battery_empty_page_streak = streak
+            if streak >= _BATTERY_EMPTY_BANK_RETIRE_STREAK and accumulator:
+                retired = len(accumulator)
+                self._battery_accumulator = {}
+                self._battery_slot_index = {}
+                self._battery_last_seen = {}
+                self._battery_stall_warned: set[str] = set()
+                _LOGGER.info(
+                    "[%s] Battery bank converged to empty after %d consecutive "
+                    "empty reads (reg 96 = 0, all slots ghost); retiring %d "
+                    "accumulated batteries",
+                    self._serial,
+                    streak,
+                    retired,
+                )
+                return None
+        else:
+            self._battery_empty_page_streak = 0
 
         if not accumulator:
             return None

--- a/tests/unit/devices/inverters/test_parameter_fetch_sticky.py
+++ b/tests/unit/devices/inverters/test_parameter_fetch_sticky.py
@@ -20,6 +20,7 @@ degraded one.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -107,16 +108,23 @@ class TestTransportParameterSticky:
         assert inverter._parameters_cache_time is not None
 
     @pytest.mark.asyncio
-    async def test_total_failure_keeps_parameters_untouched(self) -> None:
+    async def test_total_failure_keeps_parameters_untouched(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         inverter = _make_inverter()
         inverter.parameters = {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
         inverter._transport = _range_transport({0: OSError("boom"), 125: OSError("boom")})
 
-        await inverter._fetch_parameters()
+        with caplog.at_level(logging.INFO):
+            await inverter._fetch_parameters()
 
         assert inverter.parameters == {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
         assert inverter.parameters_complete is False
         assert inverter._parameters_cache_time is None
+        # Total failure with carried parameters is announced, naming ranges
+        # (#282 review P2 — the staleness signal must not be silent).
+        assert "failed entirely" in caplog.text
+        assert "0-124" in caplog.text and "125-249" in caplog.text
 
     @pytest.mark.asyncio
     async def test_partial_failure_retries_on_next_unforced_refresh(self) -> None:
@@ -182,7 +190,9 @@ class TestHttpParameterSticky:
         return response
 
     @pytest.mark.asyncio
-    async def test_http_partial_failure_carries_forward(self, mock_client: LuxpowerClient) -> None:
+    async def test_http_partial_failure_carries_forward(
+        self, mock_client: LuxpowerClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
         inverter = _make_inverter(client=mock_client)
         inverter.parameters = {
             "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101,
@@ -196,7 +206,8 @@ class TestHttpParameterSticky:
             ]
         )
 
-        await inverter._fetch_parameters()
+        with caplog.at_level(logging.INFO):
+            await inverter._fetch_parameters()
 
         assert inverter.parameters == {
             "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101,  # carried forward
@@ -205,6 +216,30 @@ class TestHttpParameterSticky:
         }
         assert inverter.parameters_complete is False
         assert inverter._parameters_cache_time is None
+        # The INFO names WHICH cloud range failed (#282 review P2): the
+        # second range starts at MAX_REGISTERS_PER_READ = 127.
+        assert "127-253" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_http_total_failure_logs_ranges_and_keeps_parameters(
+        self, mock_client: LuxpowerClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """All three cloud ranges fail: parameters carried, ranges named."""
+        inverter = _make_inverter(client=mock_client)
+        inverter.parameters = {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
+        mock_client.api.control.read_parameters = AsyncMock(
+            side_effect=[OSError("boom"), OSError("boom"), OSError("boom")]
+        )
+
+        with caplog.at_level(logging.INFO):
+            await inverter._fetch_parameters()
+
+        assert inverter.parameters == {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
+        assert inverter.parameters_complete is False
+        assert inverter._parameters_cache_time is None
+        assert "failed entirely" in caplog.text
+        assert "0-126" in caplog.text
+        assert "240-366" in caplog.text
 
     @pytest.mark.asyncio
     async def test_http_full_success_replaces_and_stamps(self, mock_client: LuxpowerClient) -> None:

--- a/tests/unit/devices/inverters/test_parameter_fetch_sticky.py
+++ b/tests/unit/devices/inverters/test_parameter_fetch_sticky.py
@@ -1,0 +1,228 @@
+"""A failed/partial parameter read must not blank previously-known parameters.
+
+Regression for eg4_web_monitor#282 (ivanfmartinez, 2026-07-01, beta.17 HYBRID):
+a WiFi-dongle misroute storm failed the second holding-register range read
+(``Failed to read registers 125-250``).  ``_fetch_parameters`` swallowed the
+failure per range and then REPLACED ``self.parameters`` with the partial dict
+(range 0-124 only) — every parameter backed by registers 125-249 (e.g.
+``HOLD_SYSTEM_CHARGE_SOC_LIMIT``, reg 227) vanished, flipping the entity to
+*unknown*.  It also stamped ``_parameters_cache_time``, arming the cache/
+throttle so the blank state persisted for up to an hour.
+
+Sticky semantics (the #261 fault/warning-code precedent): a partial read
+merges fresh values OVER the previous parameters (failed ranges keep their
+last-known values), the cache timestamp is stamped only on a FULLY successful
+read (so the next ``include_parameters`` refresh retries instead of waiting
+out the TTL), and the new public ``parameters_complete`` flag lets consumers
+(the HA integration's refresh throttle) distinguish a clean read from a
+degraded one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from pylxpweb import LuxpowerClient
+from pylxpweb.devices.inverters.generic import GenericInverter
+
+
+def _make_inverter(client: LuxpowerClient | None = None) -> GenericInverter:
+    return GenericInverter(client=client, serial_number="1234567890", model="TestModel")
+
+
+@pytest.fixture
+def mock_client() -> LuxpowerClient:
+    client = Mock(spec=LuxpowerClient)
+    client.username = "user@example.com"
+    client.api = Mock()
+    client.api.devices = Mock()
+    client.api.control = Mock()
+    return client
+
+
+def _range_transport(responses: dict[int, dict[str, int] | Exception]) -> Mock:
+    """Transport whose ``read_named_parameters`` is scripted per start register."""
+
+    async def read_named(start: int, count: int) -> dict[str, int]:
+        entry = responses[start]
+        if isinstance(entry, Exception):
+            raise entry
+        return entry
+
+    transport = Mock()
+    transport.read_named_parameters = AsyncMock(side_effect=read_named)
+    return transport
+
+
+class TestTransportParameterSticky:
+    """Transport path: per-range carry-forward, completeness, stamping."""
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_carries_forward_previous_values(self) -> None:
+        """The exact #282 shape: range 125-249 drops, reg-227 param survives."""
+        inverter = _make_inverter()
+        inverter.parameters = {
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101,  # reg 227, in the failed range
+            "HOLD_CHG_POWER_PERCENT_CMD": 80,  # reg 64, in the healthy range
+        }
+        inverter._transport = _range_transport(
+            {
+                0: {"HOLD_CHG_POWER_PERCENT_CMD": 60},
+                125: OSError("Response function mismatch: expected 0x03, got 0x04"),
+            }
+        )
+
+        await inverter._fetch_parameters()
+
+        assert inverter.parameters == {
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101,  # carried forward, NOT blanked
+            "HOLD_CHG_POWER_PERCENT_CMD": 60,  # fresh value from the healthy range
+        }
+        assert inverter.parameters_complete is False
+        # Not stamped: the next include_parameters refresh must retry, not
+        # wait out the full parameter TTL with a degraded dict.
+        assert inverter._parameters_cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_full_success_replaces_and_stamps(self) -> None:
+        """A clean read is authoritative: stale keys go, cache is stamped."""
+        inverter = _make_inverter()
+        inverter.parameters = {"STALE_KEY": 1, "HOLD_CHG_POWER_PERCENT_CMD": 80}
+        inverter._transport = _range_transport(
+            {
+                0: {"HOLD_CHG_POWER_PERCENT_CMD": 60},
+                125: {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90},
+            }
+        )
+
+        await inverter._fetch_parameters()
+
+        assert inverter.parameters == {
+            "HOLD_CHG_POWER_PERCENT_CMD": 60,
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90,
+        }
+        assert inverter.parameters_complete is True
+        assert inverter._parameters_cache_time is not None
+
+    @pytest.mark.asyncio
+    async def test_total_failure_keeps_parameters_untouched(self) -> None:
+        inverter = _make_inverter()
+        inverter.parameters = {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
+        inverter._transport = _range_transport({0: OSError("boom"), 125: OSError("boom")})
+
+        await inverter._fetch_parameters()
+
+        assert inverter.parameters == {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
+        assert inverter.parameters_complete is False
+        assert inverter._parameters_cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_retries_on_next_unforced_refresh(self) -> None:
+        """No stamp on partial -> the next include_parameters refresh re-reads.
+
+        This is the amplifier from #282: stamping the cache on a partial read
+        armed the TTL/throttle, so one bad read meant a degraded dict for the
+        whole parameter interval (~1 h at the integration level).
+        """
+        inverter = _make_inverter()
+        transport = _range_transport(
+            {
+                0: {"HOLD_CHG_POWER_PERCENT_CMD": 60},
+                125: OSError("boom"),
+            }
+        )
+        inverter._transport = transport
+
+        await inverter._fetch_parameters()
+        first_calls = transport.read_named_parameters.await_count
+        assert first_calls == 2
+
+        # Unforced second parameter fetch happens because the cache was never
+        # stamped (refresh() gates _fetch_parameters on the cache TTL).
+        assert inverter._is_cache_expired(
+            inverter._parameters_cache_time, inverter._parameters_cache_ttl, force=False
+        )
+        await inverter._fetch_parameters()
+        assert transport.read_named_parameters.await_count == first_calls + 2
+
+    @pytest.mark.asyncio
+    async def test_full_success_after_partial_restores_completeness(self) -> None:
+        inverter = _make_inverter()
+        transport = _range_transport(
+            {
+                0: {"HOLD_CHG_POWER_PERCENT_CMD": 60},
+                125: OSError("boom"),
+            }
+        )
+        inverter._transport = transport
+        await inverter._fetch_parameters()
+        assert inverter.parameters_complete is False
+
+        inverter._transport = _range_transport(
+            {
+                0: {"HOLD_CHG_POWER_PERCENT_CMD": 61},
+                125: {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90},
+            }
+        )
+        await inverter._fetch_parameters()
+
+        assert inverter.parameters_complete is True
+        assert inverter._parameters_cache_time is not None
+
+
+class TestHttpParameterSticky:
+    """HTTP path: one dropped range must not blank the other ranges' values."""
+
+    @staticmethod
+    def _param_response(params: dict[str, int]) -> Mock:
+        response = Mock()
+        response.parameters = params
+        return response
+
+    @pytest.mark.asyncio
+    async def test_http_partial_failure_carries_forward(self, mock_client: LuxpowerClient) -> None:
+        inverter = _make_inverter(client=mock_client)
+        inverter.parameters = {
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101,
+            "HOLD_CHG_POWER_PERCENT_CMD": 80,
+        }
+        mock_client.api.control.read_parameters = AsyncMock(
+            side_effect=[
+                self._param_response({"HOLD_CHG_POWER_PERCENT_CMD": 60}),
+                OSError("DATAFRAME_TIMEOUT"),
+                self._param_response({"HOLD_LEAD_ACID_CHARGE_RATE": 40}),
+            ]
+        )
+
+        await inverter._fetch_parameters()
+
+        assert inverter.parameters == {
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101,  # carried forward
+            "HOLD_CHG_POWER_PERCENT_CMD": 60,
+            "HOLD_LEAD_ACID_CHARGE_RATE": 40,
+        }
+        assert inverter.parameters_complete is False
+        assert inverter._parameters_cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_http_full_success_replaces_and_stamps(self, mock_client: LuxpowerClient) -> None:
+        inverter = _make_inverter(client=mock_client)
+        inverter.parameters = {"STALE_KEY": 1}
+        mock_client.api.control.read_parameters = AsyncMock(
+            side_effect=[
+                self._param_response({"HOLD_CHG_POWER_PERCENT_CMD": 60}),
+                self._param_response({"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90}),
+                self._param_response({}),
+            ]
+        )
+
+        await inverter._fetch_parameters()
+
+        assert inverter.parameters == {
+            "HOLD_CHG_POWER_PERCENT_CMD": 60,
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90,
+        }
+        assert inverter.parameters_complete is True
+        assert inverter._parameters_cache_time is not None

--- a/tests/unit/transports/test_battery_block_drop_serves_accumulator.py
+++ b/tests/unit/transports/test_battery_block_drop_serves_accumulator.py
@@ -449,3 +449,134 @@ class TestTransientReg96ZeroGate:
         assert reads_5002[0] == 0  # no pointless block read
         assert battery is not None
         assert battery.batteries == []
+
+
+class TestEmptyBankConvergence:
+    """Physically-removed banks converge to empty; transients never do (#282 review).
+
+    The reg96-zero gate guard means the accumulator is consulted on every
+    read — which would serve a REMOVED bank's stale batteries forever
+    (pre-guard, the gate skip was accidentally the only convergence path).
+    Convergence now requires ``_BATTERY_EMPTY_BANK_RETIRE_STREAK`` (3)
+    consecutive SUCCESSFUL reads with reg 96 = 0 and an all-ghost page;
+    failed reads (the #258 misroute-storm case) never touch the streak.
+    """
+
+    @staticmethod
+    async def _accumulate_eight(transport: ModbusTransport, fake) -> None:
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+
+    @pytest.mark.asyncio
+    async def test_transient_ghost_pages_do_not_retire(self) -> None:
+        """1-2 empty reads then a real page: accumulator intact, no flicker."""
+        transport = _transport()
+        pages: list[list[int] | Exception] = [
+            _page([0, 1, 2, 3]),
+            _page([4, 5, 6, 7]),
+            _page([]),  # transient empty read #1
+            _page([]),  # transient empty read #2
+            _page([0, 1, 2, 3]),  # bank is back
+        ]
+        fake = _make_fake_read(pages)
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            ghost1 = await transport._read_individual_battery_registers(0)
+            ghost2 = await transport._read_individual_battery_registers(0)
+            real = await transport._read_individual_battery_registers(8)
+
+        # No flicker: the accumulator is served throughout.
+        for result in (ghost1, ghost2, real):
+            assert result is not None
+            assert len(result) == 8 * BATTERY_REGISTER_COUNT
+        # The real page reset the streak.
+        assert transport._battery_empty_page_streak == 0
+
+    @pytest.mark.asyncio
+    async def test_three_consecutive_empty_reads_retire_bank(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Physical removal: 3 successful empty reads -> bank empty + INFO."""
+        transport = _transport()
+        pages: list[list[int] | Exception] = [
+            _page([0, 1, 2, 3]),
+            _page([4, 5, 6, 7]),
+            _page([]),
+            _page([]),
+            _page([]),
+        ]
+        fake = _make_fake_read(pages)
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            caplog.at_level(logging.INFO),
+        ):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            assert await transport._read_individual_battery_registers(0) is not None
+            assert await transport._read_individual_battery_registers(0) is not None
+            retired = await transport._read_individual_battery_registers(0)
+
+        assert retired is None  # bank converged to empty
+        assert transport._battery_accumulator == {}
+        assert "converged to empty" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_reg96_positive_ghost_page_resets_streak(self) -> None:
+        """reg 96 > 0 means the firmware still claims batteries: no streak."""
+        transport = _transport()
+        pages: list[list[int] | Exception] = [
+            _page([0, 1, 2, 3]),
+            _page([4, 5, 6, 7]),
+            _page([]),  # ghost page but reg96 still 8 (below)
+        ]
+        fake = _make_fake_read(pages)
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            result = await transport._read_individual_battery_registers(8)
+
+        assert result is not None
+        assert transport._battery_empty_page_streak == 0
+
+    @pytest.mark.asyncio
+    async def test_failed_reads_do_not_advance_streak(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Interleaved FAILED reads (the #258 storm) neither advance nor reset.
+
+        ghost(1) FAIL ghost(2) FAIL ghost(3) -> retirement happens exactly on
+        the third SUCCESSFUL empty read; the failed reads keep serving the
+        accumulator as today.
+        """
+        transport = _transport()
+        pages: list[list[int] | Exception] = [
+            _page([0, 1, 2, 3]),
+            _page([4, 5, 6, 7]),
+            _page([]),  # successful empty #1
+            OSError("misroute storm"),
+            _page([]),  # successful empty #2
+            OSError("misroute storm"),
+            _page([]),  # successful empty #3 -> retire
+        ]
+        fake = _make_fake_read(pages)
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+            caplog.at_level(logging.INFO),
+        ):
+            await transport._read_individual_battery_registers(8)
+            await transport._read_individual_battery_registers(8)
+            assert await transport._read_individual_battery_registers(0) is not None
+            failed1 = await transport._read_individual_battery_registers(0)
+            assert failed1 is not None  # served from the accumulator
+            assert transport._battery_empty_page_streak == 1  # untouched by FAIL
+            assert await transport._read_individual_battery_registers(0) is not None
+            failed2 = await transport._read_individual_battery_registers(0)
+            assert failed2 is not None
+            assert transport._battery_empty_page_streak == 2
+            retired = await transport._read_individual_battery_registers(0)
+
+        assert retired is None
+        assert transport._battery_accumulator == {}
+        assert "converged to empty" in caplog.text

--- a/tests/unit/transports/test_battery_block_drop_serves_accumulator.py
+++ b/tests/unit/transports/test_battery_block_drop_serves_accumulator.py
@@ -365,3 +365,87 @@ class TestBatteryRotationStallWarning:
             await transport._read_individual_battery_registers(24)
 
         assert "Battery rotation stalled" in caplog.text
+
+
+class TestTransientReg96ZeroGate:
+    """A transient reg 96 = 0 must not bypass the block read once accumulated.
+
+    The 5002+ block read is gated on ``battery_count > 0`` (reg 96).  reg 96
+    is known-unreliable (#170/#258: under-reports on parallel systems; a
+    misrouted/degraded bms read can surface a plausible 0).  On a
+    battery-bearing unit a transient 0 used to skip the block read entirely —
+    the accumulator was never consulted (the failure fallback only covers
+    raised reads) — so the bank was built with ``batteries=[]`` and every
+    accumulated battery vanished for the cycle (eg4_web_monitor#282 review
+    flag, same family as the #258 wipe).  Once anything has been accumulated,
+    the block is read regardless of reg 96; a genuinely battery-less unit
+    (never accumulated anything) still skips the read.
+    """
+
+    @staticmethod
+    def _fake_read_with_counts(
+        block_pages: list[list[int] | Exception],
+        battery_counts: list[int],
+        reads_5002: list[int],
+    ):
+        """Like ``_make_fake_read`` but reg 96 follows a per-bms-read schedule."""
+        block_idx = [0]
+        bms_idx = [0]
+
+        async def fake_read(start: int, count: int) -> list[int]:
+            if start == BATTERY_BASE_ADDRESS:
+                reads_5002[0] += 1
+                idx = min(block_idx[0], len(block_pages) - 1)
+                block_idx[0] += 1
+                entry = block_pages[idx]
+                if isinstance(entry, Exception):
+                    raise entry
+                return entry
+            vals = [0] * count
+            if start == _POWER_GROUP_START:
+                vals[4] = _VOLTAGE_RAW
+                vals[5] = _SOC_SOH_PACKED
+            if start == _BMS_GROUP_START:
+                idx = min(bms_idx[0], len(battery_counts) - 1)
+                bms_idx[0] += 1
+                vals[_BATTERY_COUNT_OFFSET] = battery_counts[idx]
+            return vals
+
+        return fake_read
+
+    @pytest.mark.asyncio
+    async def test_transient_reg96_zero_after_accumulation_still_reads_block(
+        self,
+    ) -> None:
+        transport = _transport()
+        reads_5002 = [0]
+        fake = self._fake_read_with_counts(
+            [_page([0, 1, 2, 3]), _page([4, 5, 6, 7]), _page([0, 1, 2, 3])],
+            battery_counts=[8, 8, 0],  # third bms read transiently reports 0
+            reads_5002=reads_5002,
+        )
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            await transport.read_all_input_data()
+            await transport.read_all_input_data()
+            _, _, battery = await transport.read_all_input_data()
+
+        assert reads_5002[0] == 3  # the reg96=0 cycle still read the block
+        assert battery is not None
+        assert len(battery.batteries) == 8  # nothing wiped
+
+    @pytest.mark.asyncio
+    async def test_reg96_zero_with_empty_accumulator_skips_block_read(self) -> None:
+        """A genuinely battery-less unit (inv ...94 in #282) keeps skipping."""
+        transport = _transport()
+        reads_5002 = [0]
+        fake = self._fake_read_with_counts(
+            [_page([0, 1, 2, 3])],
+            battery_counts=[0],
+            reads_5002=reads_5002,
+        )
+        with patch.object(transport, "_read_input_registers", side_effect=fake):
+            _, _, battery = await transport.read_all_input_data()
+
+        assert reads_5002[0] == 0  # no pointless block read
+        assert battery is not None
+        assert battery.batteries == []


### PR DESCRIPTION
## Summary

Root fix for eg4_web_monitor#282 (ivanfmartinez, 2026-07-01, beta.17 HYBRID, DG WiFi dongles): seconds after a dongle-misroute storm failed the reg 125-249 holding-register read (`Failed to read registers 125-250 ... expected 0x03, got 0x04`), the **System Charge SOC Limit** number (HOLD reg 227) flipped to *unknown* and stayed degraded for up to an hour.

## Root cause

`BaseInverter._fetch_parameters` (transport path) swallows per-range failures, then **replaces** `self.parameters` with the partial result — every parameter backed by the failed range vanishes — and **stamps `_parameters_cache_time` anyway**, arming the parameter TTL so nothing retries. The HTTP path had the identical replace-partial-and-stamp shape. This is **long-standing behavior, not a beta.17/b18 regression**: the `_fetch_parameters` body predates the 0.9.36 beta line entirely (last touched by the `read_named_parameters` migration), and the reporter's own beta.16 log (#258 thread, 2026-06-28) already contained the same failed-range line. Dongle misroute storms just make it frequent on this setup.

## Changes

- **Sticky carry-forward (the #261 fault/warning-code precedent)** — transport *and* HTTP paths: a partial read merges fresh values OVER the last-known `parameters` (failed ranges keep their values; only successfully re-read ranges change). A **fully successful** read remains authoritative (stale keys pruned). One INFO line names the failed range(s) instead of silent blanking.
- **No stamp on partial** — `_parameters_cache_time` is stamped only by a fully successful read, so the next `include_parameters` refresh retries instead of waiting out the TTL with a degraded snapshot.
- **New public `BaseInverter.parameters_complete`** — `True` iff the last parameter fetch read every range; `False` after a partial/failed fetch (also set by the outer exception paths). Lets the HA integration's hourly parameter throttle retry early (integration PR pairs with this; `getattr(..., True)` keeps old-lib behavior).
- **Secondary (#282 review flag): reg 96 = 0 gate guard** — the 5002+ individual-battery block read was gated on `battery_count > 0` (reg 96, known-unreliable per #170/#258). A transient 0 on a battery-bearing unit skipped the read entirely, so the never-evict accumulator was never consulted (its failure fallback only covers *raised* reads) and the bank was built with `batteries=[]`, wiping every accumulated battery for the cycle. Once anything has been accumulated, the block is now read regardless of reg 96; never-accumulated units (genuinely battery-less, e.g. the reporter's second inverter that always reports reg96=0) still skip — no new reads for them.

## Testing

- New `tests/unit/devices/inverters/test_parameter_fetch_sticky.py` (7 tests): the exact #282 shape (range 125-249 drops → reg-227 parameter survives, `parameters_complete` False, cache unstamped), full-success authoritative replace + stamp, total-failure untouched, retry-on-next-unforced-refresh (the TTL amplifier), completeness restoration, and both HTTP-path variants.
- New `TestTransientReg96ZeroGate` (2 tests) in `tests/unit/transports/test_battery_block_drop_serves_accumulator.py`: transient reg96=0 after accumulation still reads the block (nothing wiped); reg96=0 with an empty accumulator still skips.
- All 9 new tests verified failing before the fix (TDD). Full suite: **2476 passed, 4 skipped**; `ruff check`/`format` clean; `mypy --strict src/pylxpweb/` clean.

No version bump (release handled separately).

Refs joyfulhouse/eg4_web_monitor#282

🤖 Generated with [Claude Code](https://claude.com/claude-code)