### PR TITLE
fix: zero-pad battery firmware minor version to match cloud rendering (eg4_web_monitor#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Battery firmware version string matches the cloud rendering** ([eg4_web_monitor#287](https://github.com/joyfulhouse/eg4_web_monitor/issues/287)):
+  the local register decode formatted the packed version as `1.3` where the
+  cloud API's `fwVersionText` reports `1.03` — HYBRID mode flapped the entity
+  between the two spellings. The minor number is now zero-padded to two
+  digits, matching both the cloud and the RS485 battery protocol's existing
+  formatting.
+
 - **A failed battery block read no longer wipes individual batteries for the cycle** ([eg4_web_monitor#258](https://github.com/joyfulhouse/eg4_web_monitor/issues/258)):
   when the atomic 5002-5121 read failed (`Failed to read battery registers
   5002-5121, will retry next poll`) but the bms_data group succeeded,

--- a/src/pylxpweb/transports/_canonical_reader.py
+++ b/src/pylxpweb/transports/_canonical_reader.py
@@ -92,13 +92,18 @@ def read_battery_firmware(
     *,
     base_address: int,
 ) -> str:
-    """Read packed firmware version: high byte = major, low byte = minor."""
+    """Read packed firmware version: high byte = major, low byte = minor.
+
+    The minor number is zero-padded to two digits to match the cloud API's
+    ``fwVersionText`` rendering (raw 0x0103 -> "1.03", not "1.3"), so HYBRID
+    mode does not flap between two spellings of the same version.
+    """
     raw = read_raw(registers, reg, base_address=base_address)
     if not raw:
         return ""
     major = (raw >> 8) & 0xFF
     minor = raw & 0xFF
-    return f"{major}.{minor}"
+    return f"{major}.{minor:02d}"
 
 
 def read_battery_serial(

--- a/tests/unit/transports/test_canonical_reader.py
+++ b/tests/unit/transports/test_canonical_reader.py
@@ -1,0 +1,41 @@
+"""Unit tests for canonical battery register readers.
+
+Regression coverage for eg4_web_monitor#287: the local battery firmware
+version string must match the cloud API's ``fwVersionText`` rendering
+(zero-padded two-digit minor), otherwise HYBRID mode flaps the entity
+between two spellings of the same version ("1.3" vs "1.03").
+"""
+
+import pytest
+
+from pylxpweb.registers.battery import BY_NAME
+from pylxpweb.transports._canonical_reader import read_battery_firmware
+
+FW_REG = BY_NAME["battery_firmware_version"]
+BASE = 5002
+
+
+def _registers(raw: int) -> dict[int, int]:
+    return {BASE + FW_REG.offset: raw}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0x0103, "1.03"),  # eg4_web_monitor#287: cloud shows 1.03, local said 1.3
+        (0x0211, "2.17"),  # already two digits, unchanged by the padding
+        (0x011E, "1.30"),  # minor 30 keeps its trailing zero
+        (0x0200, "2.00"),  # minor 0 pads to two digits
+        (0x0A63, "10.99"),  # two-digit major passes through untouched
+    ],
+)
+def test_firmware_version_matches_cloud_rendering(raw: int, expected: str) -> None:
+    assert read_battery_firmware(_registers(raw), FW_REG, base_address=BASE) == expected
+
+
+def test_firmware_version_zero_register_reads_empty() -> None:
+    assert read_battery_firmware(_registers(0), FW_REG, base_address=BASE) == ""
+
+
+def test_firmware_version_missing_register_reads_empty() -> None:
+    assert read_battery_firmware({}, FW_REG, base_address=BASE) == ""


### PR DESCRIPTION
## Summary
- `read_battery_firmware()` in `_canonical_reader.py` rendered packed raw `0x0103` as `1.3`; the cloud API's `fwVersionText` reports `1.03` for the same version, so HYBRID mode flapped the battery firmware entity between the two spellings ([eg4_web_monitor#287](https://github.com/joyfulhouse/eg4_web_monitor/issues/287), reporter screenshot pins both renderings).
- Minor is now zero-padded to two digits — identical to the RS485 battery protocol's existing `f"{fw_high}.{fw_low:02d}"` in `battery_protocols/eg4_master.py:192`, which was already the library's convention.
- The string is display-only (nothing parses it numerically); existing two-digit-minor assertions ("2.17") are unchanged.

## Tests
- New `tests/unit/transports/test_canonical_reader.py`: parametrized raw↔string pins including the reporter's exact case (0x0103 → "1.03"), trailing-zero minor, minor 0, two-digit major, and empty/zero register cases.
- Full suite: 2507 passed, 5 skipped. ruff + mypy (project config, 94 files) clean.

Rides the next release (0.9.36b20) alongside #197/#198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)