### PR TITLE
fix: disambiguate duplicate battery serials by bank position + full-serial debug dump (#258)

### DIFF
--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -417,6 +417,7 @@ class RegisterDataMixin(_DataMixinBase):
             #     the firmware slot position.
             serial = read_battery_serial(raw_registers, base_address=slot_base)
             serial_reported = any(raw_registers.get(slot_base + off, 0) for off in range(17, 24))
+            pos = (raw_registers.get(slot_base + 24, 0) >> 8) & 0xFF
             if serial and len(serial) >= _MIN_BATTERY_SERIAL_LEN:
                 identity = serial
                 if identity in page_identities:
@@ -429,7 +430,6 @@ class RegisterDataMixin(_DataMixinBase):
                     # the battery's bank position (offset 24 high byte —
                     # stable per battery across rotation) and warn once per
                     # colliding serial.
-                    pos = (raw_registers.get(slot_base + 24, 0) >> 8) & 0xFF
                     identity = f"{serial}@pos{pos}"
                     dup_warned: set[str] = getattr(self, "_battery_dup_serial_warned", set())
                     if serial not in dup_warned:
@@ -454,8 +454,40 @@ class RegisterDataMixin(_DataMixinBase):
                 )
                 continue
             else:
-                pos = (raw_registers.get(slot_base + 24, 0) >> 8) & 0xFF
                 identity = f"pos:{pos}"
+
+            # Synthetic @pos reconciliation (#258 review P1): a "{serial}@posN"
+            # entry is only a snapshot of a SUSPECT read at bank position N.
+            # When position N is next read successfully under a different
+            # identity, that snapshot is stale — evict it so transient serial
+            # corruption self-heals instead of publishing a phantom twin until
+            # full-bank retirement.  A genuine duplicate pack appears in the
+            # same page as its twin and re-mints its @pos entry right there
+            # (the entry's own read ends with the suffix, so it never evicts
+            # itself) — the collapse protection above is preserved.
+            pos_suffix = f"@pos{pos}"
+            if not identity.endswith(pos_suffix):
+                for stale_key in [k for k in accumulator if k.endswith(pos_suffix)]:
+                    del accumulator[stale_key]
+                    stale_slot = slot_index.get(stale_key)
+                    if stale_slot is not None:
+                        # Keep the slot_index reservation: virtual slots are
+                        # assigned as len(slot_index), so deleting the row
+                        # would let a future identity collide with a live
+                        # slot.  Only the data and its clock are retired.
+                        last_seen.pop(stale_slot, None)
+                    stall_warned: set[str] = getattr(self, "_battery_stall_warned", set())
+                    stall_warned.discard(stale_key)
+                    self._battery_stall_warned = stall_warned
+                    _LOGGER.info(
+                        "[%s] Evicted synthetic duplicate-serial entry %r: bank "
+                        "position %d was read successfully as %r (transient "
+                        "serial corruption self-healed)",
+                        self._serial,
+                        stale_key,
+                        pos,
+                        identity,
+                    )
 
             raw_page.append(f"{phys_slot}={identity}")
             page_identities.add(identity)
@@ -493,7 +525,7 @@ class RegisterDataMixin(_DataMixinBase):
                 self._battery_accumulator = {}
                 self._battery_slot_index = {}
                 self._battery_last_seen = {}
-                self._battery_stall_warned: set[str] = set()
+                self._battery_stall_warned = set()
                 self._battery_dup_serial_warned = set()
                 _LOGGER.info(
                     "[%s] Battery bank converged to empty after %d consecutive "

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -379,6 +379,9 @@ class RegisterDataMixin(_DataMixinBase):
         # across reads shows exactly when a battery rotates into/out of a slot.
         raw_page: list[str] = []
         page_has_active_slot = False
+        # Identities already claimed by earlier slots of THIS page, for the
+        # duplicate-serial guard below (eg4_web_monitor#258).
+        page_identities: set[str] = set()
 
         for phys_slot in range(BATTERY_MAX_COUNT):
             slot_base = BATTERY_BASE_ADDRESS + (phys_slot * BATTERY_REGISTER_COUNT)
@@ -416,6 +419,31 @@ class RegisterDataMixin(_DataMixinBase):
             serial_reported = any(raw_registers.get(slot_base + off, 0) for off in range(17, 24))
             if serial and len(serial) >= _MIN_BATTERY_SERIAL_LEN:
                 identity = serial
+                if identity in page_identities:
+                    # Duplicate serial WITHIN one page: two physical slots
+                    # claiming one identity (corrupt serial bytes during a
+                    # misroute storm, or genuinely duplicated serial strings).
+                    # Silent last-write-wins would collapse two packs into one
+                    # accumulator entry and hide a battery with no log trace
+                    # (eg4_web_monitor#258).  Disambiguate the later slot by
+                    # the battery's bank position (offset 24 high byte —
+                    # stable per battery across rotation) and warn once per
+                    # colliding serial.
+                    pos = (raw_registers.get(slot_base + 24, 0) >> 8) & 0xFF
+                    identity = f"{serial}@pos{pos}"
+                    dup_warned: set[str] = getattr(self, "_battery_dup_serial_warned", set())
+                    if serial not in dup_warned:
+                        dup_warned.add(serial)
+                        self._battery_dup_serial_warned = dup_warned
+                        _LOGGER.warning(
+                            "[%s] Two battery slots in one page report the same "
+                            "serial %r; keeping both, disambiguating the second "
+                            "as %r by bank position (duplicate or corrupt BMS "
+                            "serial)",
+                            self._serial,
+                            serial,
+                            identity,
+                        )
             elif serial_reported:
                 raw_page.append(f"{phys_slot}={serial!r}~trunc")
                 _LOGGER.debug(
@@ -430,6 +458,7 @@ class RegisterDataMixin(_DataMixinBase):
                 identity = f"pos:{pos}"
 
             raw_page.append(f"{phys_slot}={identity}")
+            page_identities.add(identity)
             if identity not in slot_index:
                 slot_index[identity] = len(slot_index)
             accumulator[identity] = slot_regs
@@ -465,6 +494,7 @@ class RegisterDataMixin(_DataMixinBase):
                 self._battery_slot_index = {}
                 self._battery_last_seen = {}
                 self._battery_stall_warned: set[str] = set()
+                self._battery_dup_serial_warned = set()
                 _LOGGER.info(
                     "[%s] Battery bank converged to empty after %d consecutive "
                     "empty reads (reg 96 = 0, all slots ghost); retiring %d "
@@ -631,22 +661,19 @@ class RegisterDataMixin(_DataMixinBase):
             status = individual_registers.get(slot_base, 0)
             voltage_raw = individual_registers.get(slot_base + 6, 0)
 
-            # Offset 24: appears to encode battery position index in high byte
-            # (0x0100=pos1, 0x0200=pos2, etc.).  May change during round-robin
-            # rotation on systems with >4 batteries.
+            # Offset 24: encodes the battery position index in the high byte
+            # (0x0100=pos1, 0x0200=pos2, etc.) and the FINAL serial character
+            # in the low byte.  May change during round-robin rotation on
+            # systems with >4 batteries.
             reserved_24 = individual_registers.get(slot_base + 24, 0)
 
-            # Serial: 7 registers at offset 17-23, 2 ASCII chars per word
-            serial_chars: list[str] = []
-            for reg_offset in range(7):
-                raw_word = individual_registers.get(slot_base + 17 + reg_offset, 0)
-                lo_byte = raw_word & 0xFF
-                hi_byte = (raw_word >> 8) & 0xFF
-                if lo_byte > 0:
-                    serial_chars.append(chr(lo_byte))
-                if hi_byte > 0:
-                    serial_chars.append(chr(hi_byte))
-            slot_serial = "".join(serial_chars).strip("\x00")
+            # Serial: decode with the SAME reader the accumulator identity and
+            # BatteryData.serial_number use (offsets 17-24, non-printables
+            # filtered).  The previous manual 17-23 decode dropped the final
+            # character (offset 24 low byte), so a bank whose serials differ
+            # only there logged phantom "duplicate" serials
+            # (eg4_web_monitor#258 beta.18 red herring).
+            slot_serial = read_battery_serial(individual_registers, base_address=slot_base)
 
             _LOGGER.debug(
                 "[%s] Pos %d: status=0x%04X voltage_raw=%d serial=%r offset24=0x%04X (%d)",

--- a/tests/unit/transports/test_modbus.py
+++ b/tests/unit/transports/test_modbus.py
@@ -1411,6 +1411,148 @@ class TestBatteryAccumulatorReg96Unreliable:
         assert not any(k.startswith("pos:") for k in acc), "no phantom pos identity"
 
 
+class TestBatteryDuplicateSerialDisambiguation:
+    """Duplicate serials in one page must not silently collapse packs (#258).
+
+    Two physical batteries whose BMS-reported serials decode identically
+    (corrupt serial bytes during a misroute storm, or genuinely duplicated
+    serial strings) landed on ONE accumulator key — last-write-wins hid a
+    battery with no trace in the logs.  The colliding slot is disambiguated
+    by the battery's bank position (offset 24 high byte, stable across
+    rotation) and a single warning names the colliding serial.
+    """
+
+    def _make_transport(self) -> ModbusTransport:
+        return ModbusTransport(host="192.168.1.100", serial="CE12345678")
+
+    def _mock_client(
+        self,
+        slot_values_per_call: list[list[int]],
+    ) -> tuple[MagicMock, MagicMock]:
+        call_idx = [0]
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client.close = MagicMock()
+
+        async def mock_read(address: int, count: int, **kwargs: int) -> MagicMock:
+            resp = MagicMock()
+            resp.isError.return_value = False
+            if address == BATTERY_BASE_ADDRESS:
+                idx = min(call_idx[0], len(slot_values_per_call) - 1)
+                resp.registers = slot_values_per_call[idx]
+                call_idx[0] += 1
+            else:
+                resp.registers = [0] * count
+            return resp
+
+        mock_client.read_input_registers = mock_read
+        return mock_client, MagicMock(return_value=mock_client)
+
+    @staticmethod
+    def _dup_serial_page() -> list[int]:
+        """Page where slots 1 and 3 report the same serial at different positions."""
+        page = _build_battery_slots_with_serials(
+            [
+                ("BATTERYSER0000", 0),
+                ("BATTERYSER0001", 1),
+                ("BATTERYSER0002", 2),
+                ("BATTERYSER0001", 3),  # duplicate of slot 1's serial
+            ]
+        )
+        # Distinct electrical data so a collapse is observable.
+        page[1 * BATTERY_REGISTER_COUNT + 6] = 5320
+        page[3 * BATTERY_REGISTER_COUNT + 6] = 5318
+        return page
+
+    @pytest.mark.asyncio
+    async def test_duplicate_serial_disambiguated_by_position(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Both packs stay accumulated; one warning names the colliding serial."""
+        transport = self._make_transport()
+        _, mock_class = self._mock_client([self._dup_serial_page()])
+
+        with patch("pymodbus.client.AsyncModbusTcpClient", mock_class):
+            await transport.connect()
+            with caplog.at_level(logging.WARNING):
+                merged = await transport._read_individual_battery_registers(4)
+
+        assert merged is not None
+        acc = transport._battery_accumulator
+        assert len(acc) == 4, f"expected 4 accumulated batteries, got {set(acc)}"
+        # The colliding slot keeps a position-derived identity.
+        assert "BATTERYSER0001" in acc
+        assert "BATTERYSER0001@pos3" in acc
+        # Both physical packs' data survives (distinct voltages).
+        assert acc["BATTERYSER0001"][6] == 5320
+        assert acc["BATTERYSER0001@pos3"][6] == 5318
+        # Exactly one warning naming the colliding serial.
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "BATTERYSER0001" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_duplicate_serial_identity_stable_and_warning_once(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Repeated pages neither grow the accumulator nor re-warn."""
+        transport = self._make_transport()
+        page = self._dup_serial_page()
+        _, mock_class = self._mock_client([page, page, page])
+
+        with patch("pymodbus.client.AsyncModbusTcpClient", mock_class):
+            await transport.connect()
+            with caplog.at_level(logging.WARNING):
+                await transport._read_individual_battery_registers(4)
+                await transport._read_individual_battery_registers(4)
+                await transport._read_individual_battery_registers(4)
+
+        acc = transport._battery_accumulator
+        assert len(acc) == 4, f"accumulator grew: {set(acc)}"
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "BATTERYSER0001" in r.getMessage()
+        ]
+        assert len(warnings) == 1, "warning must be latched once per serial"
+
+
+class TestBatterySlotDebugSerial:
+    """The per-slot debug dump must show the full identity serial (#258).
+
+    The dump previously decoded only offsets 17-23 (14 chars) while the
+    accumulator identity and ``BatteryData.serial_number`` include offset
+    24's low byte (the final serial character).  On a bank whose serials
+    differ only in that final character, the dump showed phantom
+    "duplicate" serials — the exact red herring in the #258 beta.18 field
+    log analysis.
+    """
+
+    def test_slot_debug_logs_full_serial(self, caplog: pytest.LogCaptureFixture) -> None:
+        transport = ModbusTransport(host="192.168.1.100", serial="CE12345678")
+
+        # Two batteries whose serials differ ONLY in the 15th character,
+        # which lives in offset 24's low byte.
+        individual: dict[int, int] = {}
+        for slot, last_char in enumerate(("5", "7")):
+            base = BATTERY_BASE_ADDRESS + slot * BATTERY_REGISTER_COUNT
+            individual[base] = 0xC003
+            individual[base + 6] = 5246
+            for i, reg_val in enumerate(_encode_serial("BATTERYSER0016")):
+                individual[base + 17 + i] = reg_val
+            # pos in high byte, final serial char in low byte.
+            individual[base + 24] = (slot << 8) | ord(last_char)
+
+        with caplog.at_level(logging.DEBUG):
+            transport._log_battery_slot_debug(individual, battery_count=2)
+
+        assert "BATTERYSER00165" in caplog.text
+        assert "BATTERYSER00167" in caplog.text
+
+
 class TestWriteConnectionException:
     """ConnectionException during writes surfaces typed and heals (eg4-1cxn).
 

--- a/tests/unit/transports/test_modbus.py
+++ b/tests/unit/transports/test_modbus.py
@@ -1519,6 +1519,80 @@ class TestBatteryDuplicateSerialDisambiguation:
         ]
         assert len(warnings) == 1, "warning must be latched once per serial"
 
+    @pytest.mark.asyncio
+    async def test_synthetic_pos_entry_evicted_on_clean_read(self) -> None:
+        """A transient corrupt-serial @pos entry self-heals (#258 review P1).
+
+        A misroute-storm read that duplicates another slot's serial mints a
+        synthetic ``@posN`` entry.  Without reconciliation it persisted until
+        full-bank retirement, so the merged output carried two batteries with
+        the same raw serial forever — and eg4_web_monitor's LOCAL merge then
+        minted a lasting positional collision entity.  When bank position N is
+        next read successfully under a different identity, the snapshot is
+        stale and must be evicted.
+        """
+        transport = self._make_transport()
+        # Page 1: slot 1 (pos 1) corrupt-reads slot 0's serial.
+        corrupt = _build_battery_slots_with_serials(
+            [
+                ("BATTERYSER0000", 0),
+                ("BATTERYSER0000", 1),  # corrupt duplicate of slot 0's serial
+                ("BATTERYSER0002", 2),
+                ("BATTERYSER0003", 3),
+            ]
+        )
+        # Page 2: slot 1 (pos 1) reads its true serial.
+        clean = _build_battery_slots_with_serials(
+            [
+                ("BATTERYSER0000", 0),
+                ("BATTERYSER0001", 1),
+                ("BATTERYSER0002", 2),
+                ("BATTERYSER0003", 3),
+            ]
+        )
+        _, mock_class = self._mock_client([corrupt, clean])
+
+        with patch("pymodbus.client.AsyncModbusTcpClient", mock_class):
+            await transport.connect()
+            await transport._read_individual_battery_registers(4)
+            # The suspect read minted the synthetic entry.
+            assert "BATTERYSER0000@pos1" in transport._battery_accumulator
+            merged = await transport._read_individual_battery_registers(4)
+
+        acc = transport._battery_accumulator
+        assert set(acc) == {
+            "BATTERYSER0000",
+            "BATTERYSER0001",
+            "BATTERYSER0002",
+            "BATTERYSER0003",
+        }, f"synthetic entry must be evicted, got {set(acc)}"
+
+        # The merged output carries 4 batteries with 4 DISTINCT serials.
+        assert merged is not None
+        seen: set[str] = set()
+        for slot in range(20):
+            base = BATTERY_BASE_ADDRESS + slot * BATTERY_REGISTER_COUNT
+            if merged.get(base):
+                seen.add(read_battery_serial(merged, base_address=base))
+        assert len(seen) == 4
+
+    @pytest.mark.asyncio
+    async def test_genuine_duplicate_pack_survives_reconciliation(self) -> None:
+        """A genuine dup pack re-mints its @pos entry each page it appears in."""
+        transport = self._make_transport()
+        page = self._dup_serial_page()
+        _, mock_class = self._mock_client([page, page])
+
+        with patch("pymodbus.client.AsyncModbusTcpClient", mock_class):
+            await transport.connect()
+            await transport._read_individual_battery_registers(4)
+            await transport._read_individual_battery_registers(4)
+
+        acc = transport._battery_accumulator
+        # Reconciliation must not evict the entry the dup page itself re-mints.
+        assert "BATTERYSER0001@pos3" in acc
+        assert len(acc) == 4
+
 
 class TestBatterySlotDebugSerial:
     """The per-slot debug dump must show the full identity serial (#258).


### PR DESCRIPTION
Defense-in-depth companion to joyfulhouse/eg4_web_monitor#293 (issue eg4_web_monitor#258, beta.18 battery-entity gaps).

## Context

The beta.18 field log analysis cleared the accumulator of the live bug — it reported `Battery accumulator: 8 batteries populated` on every read through both entity-drop windows (the flapping was the integration's HYBRID merge using the cloud payload as the baseline; fixed integration-side). But the analysis surfaced two latent issues in this layer:

## 1. Duplicate serial within one page silently collapsed two packs

`_read_individual_battery_registers()` keys each slot's 30-register block by decoded BMS serial. Two physical slots in ONE page reporting the same serial (corrupt serial bytes during a dongle misroute storm — the reporter's rig logs `likely a misrouted cloud response` regularly — or genuinely duplicated serial strings) landed on one accumulator key: last-write-wins, one battery hidden, zero log trace.

Now: the colliding slot is disambiguated as `{serial}@pos{N}` using the battery's bank position (offset 24 high byte — stable per battery across rotation; the reporter's log shows position bytes 0x00–0x07 pinned to the same batteries across pages), and ONE latched WARNING names the colliding serial. Identity is stable across repeated pages (no accumulator growth), and the latch resets with the empty-bank retirement path.

## 2. The `Pos N:` debug dump printed phantom "duplicate" serials

The dump decoded serials from offsets 17–23 only (14 chars), while the accumulator identity and `BatteryData.serial_number` use `read_battery_serial` (offsets 17–24 — the final serial character lives in offset 24's **low byte**, e.g. `offset24=0x0437` → `'7'`). On the reporter's bank, whose serials differ only in that final character (`…0165`/`…0167`, `…0172`/`…0177`), the dump showed `Pos 3`/`Pos 7` both as `…016` and `Pos 4`/`Pos 6` both as `…017` — the exact red herring that initially pointed the #258 investigation at a serial-collision collapse that wasn't happening. The dump now uses the same canonical reader as the identity path.

## Tests

- `TestBatteryDuplicateSerialDisambiguation`: both packs survive with distinct data, position-derived identity, exactly one warning, identity stable across repeated pages.
- `TestBatterySlotDebugSerial`: two serials differing only in the offset-24 character are logged distinctly.
- Full suite green: **2536 passed** (baseline 2533 + 3 new), 4 skipped; `mypy --strict` clean, ruff clean. **No version bump** per release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review-round fix (Codex P1 confirmed)

**Synthetic `@posN` entries are now reconciled on clean reads.** A transient corrupt-serial read minted a `{serial}@posN` accumulator entry that was never re-verified — it persisted until full-bank retirement, so the merged output carried two `BatteryData` with the same raw serial indefinitely, and eg4_web_monitor's LOCAL merge then minted a lasting positional collision entity from it. Now, when bank position N is next read successfully under a **different** identity, any `*@posN` entry is evicted (one INFO): the synthetic entry was only ever a snapshot of a suspect read, so transient corruption self-heals on the next clean page. A **genuine** duplicate pack appears in the same page as its twin and re-mints its `@pos` entry right there (its own read ends with the suffix and never evicts itself), preserving the collapse protection. The evicted entry's virtual-slot reservation is kept (slots are assigned as `len(slot_index)`; deleting the row would let a future identity collide with a live slot).

**Informational (Opus, for the record):** for a genuine duplicate-serial pack pair, the data-preservation win exists only at THIS layer. The battery serial IS the Home Assistant identity, so HA can only represent such twins as one serial-keyed device plus a positional collision key — inherent to serial-keyed identity, not fixable downstream.

Both-sides tests: pylxpweb (transient dup → entry evicted on the next clean read of that position, merged output back to distinct serials; genuine dup survives repeated pages) and eg4 integration-level (transient dup does not create a lasting extra battery entity — eg4 PR #293).

Updated gates: full suite **2538 passed** (2536 + 2 new), `mypy --strict` clean, ruff clean, still no version bump.
