### PR TITLE
feat: AC First schedule type + canonical names for schedule registers 84-89/152-157

### DIFF
--- a/src/pylxpweb/constants/__init__.py
+++ b/src/pylxpweb/constants/__init__.py
@@ -145,6 +145,13 @@ from .registers import (
     HOLD_AC_CHARGE_TIME_2_END,
     HOLD_AC_CHARGE_TIME_2_START,
     HOLD_AC_CHARGE_TYPE_REGISTER,
+    # AC First time schedule (off-grid/SNA working mode, packed time format)
+    HOLD_AC_FIRST_TIME_0_END,
+    HOLD_AC_FIRST_TIME_0_START,
+    HOLD_AC_FIRST_TIME_1_END,
+    HOLD_AC_FIRST_TIME_1_START,
+    HOLD_AC_FIRST_TIME_2_END,
+    HOLD_AC_FIRST_TIME_2_START,
     # Battery protection parameters
     HOLD_BAT_VOLT_MAX_CHG,
     HOLD_BAT_VOLT_MAX_DISCHG,  # deprecated alias for HOLD_LEAD_ACID_CHARGE_RATE
@@ -401,6 +408,13 @@ __all__ = [
     "HOLD_AC_CHARGE_TIME_1_END",
     "HOLD_AC_CHARGE_TIME_2_START",
     "HOLD_AC_CHARGE_TIME_2_END",
+    # AC First time schedule (regs 152-157, off-grid/SNA working mode)
+    "HOLD_AC_FIRST_TIME_0_START",
+    "HOLD_AC_FIRST_TIME_0_END",
+    "HOLD_AC_FIRST_TIME_1_START",
+    "HOLD_AC_FIRST_TIME_1_END",
+    "HOLD_AC_FIRST_TIME_2_START",
+    "HOLD_AC_FIRST_TIME_2_END",
     # Forced charge parameters (regs 74-81)
     "HOLD_FORCED_CHG_POWER_CMD",
     "HOLD_FORCED_CHG_SOC_LIMIT",

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -27,6 +27,7 @@ class ScheduleType(StrEnum):
     """
 
     AC_CHARGE = "ac_charge"
+    AC_FIRST = "ac_first"
     FORCED_CHARGE = "forced_charge"
     FORCED_DISCHARGE = "forced_discharge"
 
@@ -51,6 +52,12 @@ class ScheduleConfig:
 # Used by both cloud API (control.py) and Modbus (hybrid.py) code paths.
 SCHEDULE_CONFIGS: dict[ScheduleType, ScheduleConfig] = {
     ScheduleType.AC_CHARGE: ScheduleConfig("HOLD_AC_CHARGE", 68),
+    # AC First (off-grid/SNA "AC first" working mode; eg4_web_monitor #295):
+    # the portal's SNA working-mode page (/WManage/web/maintain/workingMode/sna)
+    # declares HOLD_AC_FIRST_{START|END}_{HOUR|MINUTE}{""|_1|_2} holdParams and
+    # the live SNA12K-US register probe (docs/inverters/SNA12KUS_52XXXXXX68.json,
+    # blocks 106-111) maps them to holding registers 152-157.
+    ScheduleType.AC_FIRST: ScheduleConfig("HOLD_AC_FIRST", 152),
     ScheduleType.FORCED_CHARGE: ScheduleConfig("HOLD_FORCED_CHARGE", 76),
     ScheduleType.FORCED_DISCHARGE: ScheduleConfig("HOLD_FORCED_DISCHARGE", 84),
 }
@@ -157,6 +164,18 @@ HOLD_FORCED_DISCHARGE_TIME_1_START = 86  # Period 1 start
 HOLD_FORCED_DISCHARGE_TIME_1_END = 87  # Period 1 end
 HOLD_FORCED_DISCHARGE_TIME_2_START = 88  # Period 2 start
 HOLD_FORCED_DISCHARGE_TIME_2_END = 89  # Period 2 end
+
+# AC First Time Schedule (regs 152-157) - packed time format (Modbus)
+# Off-grid/SNA "AC first" working mode (eg4_web_monitor #295). Cloud API
+# names: HOLD_AC_FIRST_{START|END}_{HOUR|MINUTE}{suffix} — declared by the
+# portal's SNA working-mode page and mapped to these registers by the live
+# SNA12K-US probe (docs/inverters/SNA12KUS_52XXXXXX68.json, blocks 106-111).
+HOLD_AC_FIRST_TIME_0_START = 152  # Period 0 start (packed hour|minute)
+HOLD_AC_FIRST_TIME_0_END = 153  # Period 0 end
+HOLD_AC_FIRST_TIME_1_START = 154  # Period 1 start
+HOLD_AC_FIRST_TIME_1_END = 155  # Period 1 end
+HOLD_AC_FIRST_TIME_2_START = 156  # Period 2 start
+HOLD_AC_FIRST_TIME_2_END = 157  # Period 2 end
 
 # Battery Protection Parameters
 HOLD_BAT_VOLT_MAX_CHG = 99  # Battery max charge voltage (V, ×10 decivolts)
@@ -530,6 +549,18 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
     # float kW [0, 25.5] for reg 82 and int % [0, 100] for reg 83.
     82: ["HOLD_FORCED_DISCHG_POWER_CMD"],
     83: ["HOLD_FORCED_DISCHG_SOC_LIMIT"],
+    # Forced discharge time schedule (84-89, packed hour|minute per register;
+    # eg4_web_monitor #295).  Previously unmapped — LOCAL reads surfaced raw
+    # numeric keys.  Named with the canonical packed-time constants so the
+    # values land under stable keys; the cloud's separated
+    # HOLD_FORCED_DISCHARGE_{START|END}_{HOUR|MINUTE}{suffix} names are
+    # distinct, so no collision with cloud-populated parameter caches.
+    84: ["HOLD_FORCED_DISCHARGE_TIME_0_START"],
+    85: ["HOLD_FORCED_DISCHARGE_TIME_0_END"],
+    86: ["HOLD_FORCED_DISCHARGE_TIME_1_START"],
+    87: ["HOLD_FORCED_DISCHARGE_TIME_1_END"],
+    88: ["HOLD_FORCED_DISCHARGE_TIME_2_START"],
+    89: ["HOLD_FORCED_DISCHARGE_TIME_2_END"],
     # Battery protection
     100: ["HOLD_LEAD_ACID_DISCHARGE_CUT_OFF_VOLT"],
     # Battery charge/discharge current limits (A, confirmed 2026-02-18)
@@ -580,6 +611,15 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
     # Additional verified registers
     125: ["HOLD_SOC_LOW_LIMIT_EPS_DISCHG"],  # Off-grid SOC limit (verified 2026-01-27)
     150: ["HOLD_EQUALIZATION_PERIOD"],
+    # AC First time schedule (152-157, packed hour|minute per register;
+    # off-grid/SNA working mode, eg4_web_monitor #295).  Same canonical
+    # packed-time naming rationale as 84-89 above.
+    152: ["HOLD_AC_FIRST_TIME_0_START"],
+    153: ["HOLD_AC_FIRST_TIME_0_END"],
+    154: ["HOLD_AC_FIRST_TIME_1_START"],
+    155: ["HOLD_AC_FIRST_TIME_1_END"],
+    156: ["HOLD_AC_FIRST_TIME_2_START"],
+    157: ["HOLD_AC_FIRST_TIME_2_END"],
     158: ["HOLD_AC_CHARGE_START_BATTERY_VOLTAGE"],
     159: ["HOLD_AC_CHARGE_END_BATTERY_VOLTAGE"],
     160: ["HOLD_AC_CHARGE_START_BATTERY_SOC"],

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -614,6 +614,59 @@ class HybridInverter(GenericInverter):
         """
         return await self._get_schedule(ScheduleType.FORCED_DISCHARGE, period)
 
+    async def set_ac_first_schedule(
+        self,
+        period: int,
+        start_hour: int,
+        start_minute: int,
+        end_hour: int,
+        end_minute: int,
+    ) -> bool:
+        """Set AC first time period schedule (off-grid/SNA working mode).
+
+        Registers 152-157 (packed hour|minute per register), verified by the
+        live SNA12K-US register probe (docs/inverters/SNA12KUS_52XXXXXX68.json).
+
+        Args:
+            period: Time period index (0, 1, or 2)
+            start_hour: Schedule start hour (0-23)
+            start_minute: Schedule start minute (0-59)
+            end_hour: Schedule end hour (0-23)
+            end_minute: Schedule end minute (0-59)
+
+        Returns:
+            True if successful
+
+        Raises:
+            ValueError: If period, hour, or minute is out of range
+
+        Example:
+            >>> await inverter.set_ac_first_schedule(0, 8, 0, 16, 0)
+            True
+        """
+        return await self._set_schedule(
+            ScheduleType.AC_FIRST, period, start_hour, start_minute, end_hour, end_minute
+        )
+
+    async def get_ac_first_schedule(self, period: int) -> dict[str, int]:
+        """Read AC first time period schedule (off-grid/SNA working mode).
+
+        Args:
+            period: Time period index (0, 1, or 2)
+
+        Returns:
+            Dictionary with start_hour, start_minute, end_hour, end_minute
+
+        Raises:
+            ValueError: If period is not 0, 1, or 2
+
+        Example:
+            >>> schedule = await inverter.get_ac_first_schedule(0)
+            >>> schedule
+            {'start_hour': 8, 'start_minute': 0, 'end_hour': 16, 'end_minute': 0}
+        """
+        return await self._get_schedule(ScheduleType.AC_FIRST, period)
+
     async def get_ac_charge_type(self) -> int:
         """Get AC charge type (what the charge schedule is based on).
 

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -1628,6 +1628,81 @@ class ControlEndpoints(BaseEndpoint):
         return await self._get_schedule(inverter_sn, ScheduleType.FORCED_DISCHARGE, period)
 
     # ============================================================================
+    # AC First Schedule Controls (Cloud API) — off-grid/SNA working mode
+    # ============================================================================
+
+    async def set_ac_first_schedule(
+        self,
+        inverter_sn: str,
+        period: int,
+        start_hour: int,
+        start_minute: int,
+        end_hour: int,
+        end_minute: int,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Set AC first time period schedule via cloud API.
+
+        AC First is the off-grid (SNA) working mode's schedule — the portal
+        exposes it only on the SNA working-mode page
+        (``/WManage/web/maintain/workingMode/sna``).
+
+        Args:
+            inverter_sn: Inverter serial number
+            period: Time period index (0, 1, or 2)
+            start_hour: Schedule start hour (0-23)
+            start_minute: Schedule start minute (0-59)
+            end_hour: Schedule end hour (0-23)
+            end_minute: Schedule end minute (0-59)
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Raises:
+            ValueError: If period, hour, or minute is out of range
+
+        Example:
+            >>> await client.control.set_ac_first_schedule(
+            ...     "1234567890", 0, 8, 0, 16, 0
+            ... )
+        """
+        return await self._set_schedule(
+            inverter_sn,
+            ScheduleType.AC_FIRST,
+            period,
+            start_hour,
+            start_minute,
+            end_hour,
+            end_minute,
+            client_type,
+        )
+
+    async def get_ac_first_schedule(
+        self,
+        inverter_sn: str,
+        period: int,
+    ) -> dict[str, int]:
+        """Read AC first time period schedule via cloud API.
+
+        Args:
+            inverter_sn: Inverter serial number
+            period: Time period index (0, 1, or 2)
+
+        Returns:
+            Dictionary with start_hour, start_minute, end_hour, end_minute
+
+        Raises:
+            ValueError: If period is not 0, 1, or 2
+
+        Example:
+            >>> schedule = await client.control.get_ac_first_schedule(
+            ...     "1234567890", 0
+            ... )
+        """
+        return await self._get_schedule(inverter_sn, ScheduleType.AC_FIRST, period)
+
+    # ============================================================================
     # AC Charge Type Controls (Cloud API)
     # ============================================================================
 

--- a/tests/unit/test_ac_first_schedule.py
+++ b/tests/unit/test_ac_first_schedule.py
@@ -1,0 +1,237 @@
+"""Tests for the AC First schedule type (eg4_web_monitor issue #295).
+
+AC First is the off-grid (SNA / EG4_OFFGRID) counterpart of the AC Charge
+schedule: the EG4 portal's SNA working-mode page
+(``/WManage/web/maintain/workingMode/sna``) declares cloud write params
+``HOLD_AC_FIRST_{START|END}_{HOUR|MINUTE}`` with window suffixes ``""``/
+``_1``/``_2`` — the identical convention to AC Charge — and the live register
+probe (docs/inverters/SNA12KUS_52XXXXXX68.json, blocks 106-111) maps them to
+Modbus holding registers 152-157 (152/153 = window-1 start/end, 154/155 =
+window 2, 156/157 = window 3), packed hour-low/minute-high per register.
+
+These tests also pin the REGISTER_TO_PARAM_KEYS names for the forced
+discharge schedule registers 84-89, which were previously unmapped (LOCAL
+reads surfaced raw numeric keys).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from pylxpweb import LuxpowerClient
+from pylxpweb.constants import (
+    HOLD_AC_FIRST_TIME_0_END,
+    HOLD_AC_FIRST_TIME_0_START,
+    HOLD_AC_FIRST_TIME_1_END,
+    HOLD_AC_FIRST_TIME_1_START,
+    HOLD_AC_FIRST_TIME_2_END,
+    HOLD_AC_FIRST_TIME_2_START,
+    REGISTER_TO_PARAM_KEYS,
+    SCHEDULE_CONFIGS,
+    ScheduleType,
+)
+from pylxpweb.devices.inverters.hybrid import HybridInverter
+from pylxpweb.endpoints.control import ControlEndpoints
+from pylxpweb.models import SuccessResponse
+
+SERIAL = "1234567890"
+
+
+@pytest.fixture
+def control() -> ControlEndpoints:
+    """Create a ControlEndpoints instance with a mocked client."""
+    return ControlEndpoints(Mock(spec=LuxpowerClient))
+
+
+@pytest.fixture
+def mock_client() -> LuxpowerClient:
+    """Create a mock client for testing."""
+    client = Mock(spec=LuxpowerClient)
+    client.api = Mock()
+    client.api.control = Mock()
+    return client
+
+
+class TestACFirstScheduleConfig:
+    """The AC First schedule type is wired into the shared infrastructure."""
+
+    def test_schedule_type_member(self) -> None:
+        assert ScheduleType.AC_FIRST == "ac_first"
+
+    def test_schedule_config_entry(self) -> None:
+        config = SCHEDULE_CONFIGS[ScheduleType.AC_FIRST]
+        assert config.cloud_prefix == "HOLD_AC_FIRST"
+        assert config.base_register == 152
+
+    def test_every_schedule_type_has_a_config(self) -> None:
+        """SCHEDULE_CONFIGS must cover every ScheduleType member."""
+        assert set(SCHEDULE_CONFIGS) == set(ScheduleType)
+
+    def test_register_constants(self) -> None:
+        assert HOLD_AC_FIRST_TIME_0_START == 152
+        assert HOLD_AC_FIRST_TIME_0_END == 153
+        assert HOLD_AC_FIRST_TIME_1_START == 154
+        assert HOLD_AC_FIRST_TIME_1_END == 155
+        assert HOLD_AC_FIRST_TIME_2_START == 156
+        assert HOLD_AC_FIRST_TIME_2_END == 157
+
+    def test_schedule_bases_do_not_overlap(self) -> None:
+        """Each schedule occupies 6 registers; the blocks must be disjoint."""
+        blocks = [
+            set(range(cfg.base_register, cfg.base_register + 6))
+            for cfg in SCHEDULE_CONFIGS.values()
+        ]
+        merged: set[int] = set()
+        for block in blocks:
+            assert not (merged & block)
+            merged |= block
+
+
+class TestScheduleRegisterNames:
+    """LOCAL read_named_parameters surfaces schedule registers under
+    canonical packed-time names (not raw numeric keys)."""
+
+    @pytest.mark.parametrize(
+        ("register", "name"),
+        [
+            (84, "HOLD_FORCED_DISCHARGE_TIME_0_START"),
+            (85, "HOLD_FORCED_DISCHARGE_TIME_0_END"),
+            (86, "HOLD_FORCED_DISCHARGE_TIME_1_START"),
+            (87, "HOLD_FORCED_DISCHARGE_TIME_1_END"),
+            (88, "HOLD_FORCED_DISCHARGE_TIME_2_START"),
+            (89, "HOLD_FORCED_DISCHARGE_TIME_2_END"),
+            (152, "HOLD_AC_FIRST_TIME_0_START"),
+            (153, "HOLD_AC_FIRST_TIME_0_END"),
+            (154, "HOLD_AC_FIRST_TIME_1_START"),
+            (155, "HOLD_AC_FIRST_TIME_1_END"),
+            (156, "HOLD_AC_FIRST_TIME_2_START"),
+            (157, "HOLD_AC_FIRST_TIME_2_END"),
+        ],
+    )
+    def test_register_to_param_keys(self, register: int, name: str) -> None:
+        assert REGISTER_TO_PARAM_KEYS[register] == [name]
+
+    def test_forced_charge_names_unchanged(self) -> None:
+        """Regression: the pre-existing 76-81 names must not drift."""
+        for offset in range(6):
+            period, boundary = divmod(offset, 2)
+            expected = f"HOLD_FORCED_CHARGE_TIME_{period}_{'END' if boundary else 'START'}"
+            assert REGISTER_TO_PARAM_KEYS[76 + offset] == [expected]
+
+
+class TestACFirstScheduleCloud:
+    """Cloud API wrappers mirror the AC charge/forced charge pattern."""
+
+    @pytest.mark.asyncio
+    async def test_set_ac_first_schedule_period_0(self, control: ControlEndpoints) -> None:
+        """Period 0 uses the unsuffixed HOLD_AC_FIRST_* params."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        result = await control.set_ac_first_schedule(SERIAL, 0, 23, 0, 7, 0)
+
+        assert result.success is True
+        assert control.write_parameter.call_count == 4
+        control.write_parameter.assert_any_call(
+            SERIAL, "HOLD_AC_FIRST_START_HOUR", "23", client_type="WEB"
+        )
+        control.write_parameter.assert_any_call(
+            SERIAL, "HOLD_AC_FIRST_START_MINUTE", "0", client_type="WEB"
+        )
+        control.write_parameter.assert_any_call(
+            SERIAL, "HOLD_AC_FIRST_END_HOUR", "7", client_type="WEB"
+        )
+        control.write_parameter.assert_any_call(
+            SERIAL, "HOLD_AC_FIRST_END_MINUTE", "0", client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_ac_first_schedule_period_1_suffix(self, control: ControlEndpoints) -> None:
+        """Periods 1/2 use the _1/_2 suffixes (portal holdParam convention)."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        await control.set_ac_first_schedule(SERIAL, 1, 8, 30, 16, 0)
+
+        control.write_parameter.assert_any_call(
+            SERIAL, "HOLD_AC_FIRST_START_HOUR_1", "8", client_type="WEB"
+        )
+        control.write_parameter.assert_any_call(
+            SERIAL, "HOLD_AC_FIRST_END_MINUTE_1", "0", client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_ac_first_schedule_invalid_period(self, control: ControlEndpoints) -> None:
+        with pytest.raises(ValueError, match="period must be 0, 1, or 2"):
+            await control.set_ac_first_schedule(SERIAL, 3, 0, 0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_get_ac_first_schedule(self, control: ControlEndpoints) -> None:
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "HOLD_AC_FIRST_START_HOUR": 23,
+                "HOLD_AC_FIRST_START_MINUTE": 0,
+                "HOLD_AC_FIRST_END_HOUR": 7,
+                "HOLD_AC_FIRST_END_MINUTE": 30,
+            }
+        )
+
+        schedule = await control.get_ac_first_schedule(SERIAL, 0)
+
+        assert schedule == {
+            "start_hour": 23,
+            "start_minute": 0,
+            "end_hour": 7,
+            "end_minute": 30,
+        }
+
+
+class TestACFirstScheduleModbus:
+    """Modbus wrappers write packed times to registers 152-157 via FC06."""
+
+    @pytest.mark.asyncio
+    async def test_set_ac_first_schedule_period_0(self, mock_client: LuxpowerClient) -> None:
+        inverter = HybridInverter(client=mock_client, serial_number=SERIAL, model="12000XP")
+        mock_write_response = Mock()
+        mock_write_response.success = True
+        mock_client.api.control.write_parameters = AsyncMock(return_value=mock_write_response)
+
+        result = await inverter.set_ac_first_schedule(0, 23, 0, 7, 0)
+
+        # Two individual writes (FC06) — firmware rejects FC16 multi-writes
+        # on schedule registers.
+        assert mock_client.api.control.write_parameters.call_count == 2
+        mock_client.api.control.write_parameters.assert_any_call(SERIAL, {152: 23})
+        mock_client.api.control.write_parameters.assert_any_call(SERIAL, {153: 7})
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_set_ac_first_schedule_period_2_packed(self, mock_client: LuxpowerClient) -> None:
+        inverter = HybridInverter(client=mock_client, serial_number=SERIAL, model="12000XP")
+        mock_write_response = Mock()
+        mock_write_response.success = True
+        mock_client.api.control.write_parameters = AsyncMock(return_value=mock_write_response)
+
+        result = await inverter.set_ac_first_schedule(2, 12, 30, 14, 45)
+
+        # pack_time(12, 30) = 12 | (30 << 8) = 7692; pack_time(14, 45) = 11534
+        mock_client.api.control.write_parameters.assert_any_call(SERIAL, {156: 7692})
+        mock_client.api.control.write_parameters.assert_any_call(SERIAL, {157: 11534})
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_get_ac_first_schedule(self, mock_client: LuxpowerClient) -> None:
+        inverter = HybridInverter(client=mock_client, serial_number=SERIAL, model="12000XP")
+        mock_response = Mock()
+        mock_response.parameters = {"reg_152": 23, "reg_153": (30 << 8) | 7}
+        mock_client.api.control.read_parameters = AsyncMock(return_value=mock_response)
+
+        schedule = await inverter.get_ac_first_schedule(0)
+
+        mock_client.api.control.read_parameters.assert_called_once_with(SERIAL, 152, 2)
+        assert schedule == {
+            "start_hour": 23,
+            "start_minute": 0,
+            "end_hour": 7,
+            "end_minute": 30,
+        }


### PR DESCRIPTION
## Summary

Supports [eg4_web_monitor#295](https://github.com/joyfulhouse/eg4_web_monitor/issues/295) (AC First / Forced Charge / Forced Discharge schedule time entities).

- **`ScheduleType.AC_FIRST`** + `ScheduleConfig("HOLD_AC_FIRST", 152)` in `SCHEDULE_CONFIGS` — the existing generic `_set_schedule`/`_get_schedule` plumbing (cloud `control.py` + Modbus `hybrid.py`) now covers the off-grid/SNA "AC first" working-mode schedule. Symmetric `set_ac_first_schedule`/`get_ac_first_schedule` wrappers added on both paths, matching the AC charge / forced charge / forced discharge wrappers.
- **Canonical names for previously-unmapped schedule registers** in `REGISTER_TO_PARAM_KEYS`: `84-89 → HOLD_FORCED_DISCHARGE_TIME_{0..2}_{START|END}` and `152-157 → HOLD_AC_FIRST_TIME_{0..2}_{START|END}` (new exported constants). Local `read_named_parameters()` previously surfaced these as raw numeric address keys (`"84"`, `"152"`, …); nothing consumed those keys, and the cloud's separated `*_HOUR`/`*_MINUTE` names are distinct, so this is purely additive. The stale 68-73 AC-charge names are deliberately untouched (the integration's alias chains depend on them; see eg4_web_monitor `LOCAL_AC_CHARGE_TIME_PARAM_KEYS`).

## Evidence

- The EG4 portal's **SNA working-mode page** (`/WManage/web/maintain/workingMode/sna`, logged-in fetch) declares `holdParam` attributes `HOLD_AC_FIRST_{START|END}_{HOUR|MINUTE}` with window suffixes `""`/`_1`/`_2` — the identical convention to AC Charge. The AC First section exists **only** on the SNA page.
- The live SNA12K-US register probe (`docs/inverters/SNA12KUS_52XXXXXX68.json`, blocks 106-111) maps those params to holding registers **152-157** (152/153 = window-1 start/end, 154/155 = window 2, 156/157 = window 3), packed hour-low/minute-high per register — the same paired hour+minute-per-register readback as regs 68-73.
- Forced Charge (base 76) / Forced Discharge (base 84) were already in `SCHEDULE_CONFIGS`; all probed families' cloud dumps (12kPV, FlexBOSS18/21, LXP-US 8-10K, SNA12K-US) report the named `HOLD_FORCED_{CHARGE|DISCHARGE}_*` and `HOLD_AC_FIRST_*` params.

## Tests

25 new unit tests (`tests/unit/test_ac_first_schedule.py`): config/enum completeness + register-block non-overlap, `REGISTER_TO_PARAM_KEYS` pins for 84-89/152-157 plus a 76-81 no-drift regression, cloud wrappers (exact named-param writes, `_1` suffix, period validation), Modbus wrappers (exact FC06 packed single-register writes, packed read decode).

Full suite: **2525 passed** (2500 baseline + 25 new). `ruff` clean, `mypy --strict` clean. No version bump (per release process, CI/CD handles publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
