### PR TITLE
chore: dead code cleanup and simplification

### DIFF
--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -901,12 +901,6 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                 # Keep existing cached data on API/connection errors
                 _LOGGER.debug("Failed to fetch runtime data for %s: %s", self.serial_number, err)
 
-    def _energy_elapsed_seconds(self) -> float | None:
-        """Seconds since last successful energy cache, or None at startup."""
-        if self._energy_cache_time is None:
-            return None
-        return (datetime.now() - self._energy_cache_time).total_seconds()
-
     async def _fetch_energy(self) -> None:
         """Fetch energy data with caching.
 

--- a/src/pylxpweb/devices/mid_device.py
+++ b/src/pylxpweb/devices/mid_device.py
@@ -195,12 +195,6 @@ class MIDDevice(FirmwareUpdateMixin, MIDRuntimePropertiesMixin, BaseDevice):
 
         return mid_device
 
-    def _runtime_elapsed_seconds(self) -> float | None:
-        """Seconds since last successful runtime cache, or None at startup."""
-        if self._runtime_cache_time is None:
-            return None
-        return (datetime.now() - self._runtime_cache_time).total_seconds()
-
     def _validate_runtime_energy(self, new_runtime: MidboxRuntimeData) -> bool:
         """Validate lifetime and daily energy in a new runtime read.
 

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -75,15 +75,6 @@ def _obfuscate_email(email: str) -> str:
     return f"{local[0]}{'*' * (len(local) - 1)}@{domain}"
 
 
-def _obfuscate_coordinate(coord: str | float) -> str:
-    """Obfuscate latitude/longitude to 1 decimal place."""
-    try:
-        val = float(coord)
-        return f"{val:.1f}"
-    except (ValueError, TypeError):
-        return "***"
-
-
 class BatteryType(StrEnum):
     """Battery type enumeration."""
 

--- a/src/pylxpweb/transports/data.py
+++ b/src/pylxpweb/transports/data.py
@@ -87,11 +87,6 @@ _RUNTIME_INT_FIELDS: frozenset[str] = frozenset(
 )
 
 
-# Legacy helper aliases are now imported from _canonical_reader.py:
-# _clamp_percentage = clamp_percentage
-# _sum_optional = sum_optional
-
-
 def _merge_status_code(inverter_code: int | None, bms_code: int | None) -> int | None:
     """Merge an inverter fault/warning code with its BMS fallback.
 


### PR DESCRIPTION
## Summary

Conservative dead-code removal in `src/pylxpweb/` — **26 deletions, zero functional change**. All four removed items are unreferenced across `src/`, `tests/`, and the downstream `eg4_web_monitor` integration.

## Removals (itemized, with justification)

| File | Removed | Why it's dead |
|------|---------|---------------|
| `models.py` | `_obfuscate_coordinate()` helper | Referenced nowhere. Its siblings `_obfuscate_serial`/`_obfuscate_email` stay — they're wired into Pydantic field serializers; this one never was. |
| `devices/inverters/base.py` | `_energy_elapsed_seconds()` method | Orphaned wall-clock helper. Daily-energy validation now computes its elapsed window inline from the monotonic `_daily_energy_change_monotonic` tracker (`devices/base.py`), which superseded this. `_energy_cache_time` attribute stays (6 other uses). |
| `devices/mid_device.py` | `_runtime_elapsed_seconds()` method | Same orphaned wall-clock helper on `MIDDevice`, superseded by the monotonic path. `_runtime_cache_time` attribute stays (other uses). |
| `transports/data.py` | commented-out legacy alias block | `# _clamp_percentage = ...` / `# _sum_optional = ...` — the real aliased imports directly above already bind these names; the comment was stale noise. |

## Safety

- **Vulture** (`--min-confidence 80`) surfaced only false positives — `__aexit__`/`__exit__` protocol params and an `@overload` signature param — all deliberately kept.
- Register/param constants, cloud param-name strings, enum members, dataclass/Pydantic fields, and the public API surface were **not touched**, per the protocol-documentation constraint.
- Removed methods verified orphaned by grep across src, tests, and the integration's `custom_components/`.

## Gates (in isolated worktree)

- `ruff check src/ tests/` — clean
- `mypy src/pylxpweb` (strict) — Success, no issues in 94 files
- `pytest tests/` — **2563 passed, 4 skipped** (identical to pre-change baseline)

Do **not** merge automatically; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)