### PR TITLE
fix: reject truncated holding-register responses on dongle transport

### DIFF
--- a/src/pylxpweb/transports/_modbus_base.py
+++ b/src/pylxpweb/transports/_modbus_base.py
@@ -219,8 +219,25 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
                             "no registers in response"
                         )
 
+                    registers = list(result.registers)
+                    # pymodbus decodes registers from the response's own
+                    # byte_count and never checks it against the requested
+                    # count, so a device reporting fewer registers than asked
+                    # returns a short list without error.  On the holding /
+                    # parameter path that silently drops registers (skipping
+                    # the sticky-merge that keeps last-known parameters), so
+                    # reject it inside the retry loop: a transient short read
+                    # recovers on retry and, once exhausted, raises rather
+                    # than returning partial data.  Input reads keep their
+                    # existing higher-layer short-read handling (#261).
+                    if not input_registers and len(registers) < count:
+                        raise TransportReadError(
+                            f"Short holding read at address {address}: "
+                            f"expected {count} registers, got {len(registers)}"
+                        )
+
                     self._consecutive_errors = 0
-                    return list(result.registers)
+                    return registers
 
                 except ModbusException as err:
                     # Catch the pymodbus BASE class: ConnectionException

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -587,6 +587,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         max_retries: int = 2,
         expected_func: int | None = None,
         expected_register: int | None = None,
+        expected_count: int | None = None,
         retry_on_timeout: bool = False,
     ) -> list[int]:
         """Send a packet and receive response with retry logic.
@@ -612,6 +613,9 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                 Handles exception responses (high bit set) by masking to base code.
             expected_register: Expected starting register address.
                 When provided, rejects responses for a different register range.
+            expected_count: Expected number of registers.  When provided,
+                rejects a response carrying fewer registers than requested
+                (short read) so it retries and, on exhaustion, raises.
             retry_on_timeout: Resend the request in-call after a response
                 timeout (the connection is torn down on every timeout
                 regardless of this flag).  Safe for idempotent requests
@@ -691,7 +695,9 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                         )
 
                     # Parse response with cross-request validation
-                    return self._parse_response(response, expected_func, expected_register)
+                    return self._parse_response(
+                        response, expected_func, expected_register, expected_count
+                    )
 
                 except TimeoutError as err:
                     # The connection is suspect after ANY response timeout:
@@ -782,6 +788,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         response: bytes,
         expected_func: int | None = None,
         expected_register: int | None = None,
+        expected_count: int | None = None,
     ) -> list[int]:
         """Parse a dongle response packet with cross-request validation.
 
@@ -797,6 +804,14 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                 with a different base function code.
             expected_register: Expected starting register address.  When
                 provided, rejects responses for a different register range.
+            expected_count: Expected number of registers.  When provided,
+                rejects a response carrying FEWER registers than requested.
+                Serial/function/register validation all pass on a truncated
+                frame (correct header, valid CRC over the short payload), so
+                without this a short read would return a partial register
+                list — on the holding/parameter path that silently drops
+                registers from the parameter dict, skipping the #282 sticky
+                merge and blanking HA entities for the full cache TTL.
 
         Returns:
             List of register values
@@ -947,6 +962,16 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                 value = struct.unpack("<H", register_data[i : i + 2])[0]
                 registers.append(value)
 
+        # Reject a short read: the frame is well-formed (matching serial /
+        # function / register, valid CRC) but carries fewer registers than
+        # requested.  Raising here — inside the _send_receive retry loop —
+        # lets a transient truncation recover on retry and, once retries are
+        # exhausted, surfaces as a failed range instead of a partial result.
+        if expected_count is not None and len(registers) < expected_count:
+            raise TransportReadError(
+                f"Short read: expected {expected_count} registers, got {len(registers)}"
+            )
+
         return registers
 
     async def _read_input_registers(
@@ -1009,6 +1034,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
             packet,
             expected_func=MODBUS_READ_HOLDING,
             expected_register=address,
+            expected_count=count,
         )
 
     async def _write_holding_registers(

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -496,6 +496,143 @@ class TestDongleResponseValidation:
         assert registers == [100, 200]
 
 
+class TestDongleShortReadGuard:
+    """Tests for the short-read guard on the holding/parameter path.
+
+    A truncated frame passes serial/function/register validation and its
+    CRC (computed over the short payload), so without the length guard the
+    holding path would return a partial parameter dict — silently dropping
+    registers and skipping the sticky-parameter merge.
+    """
+
+    def _make_transport(self) -> DongleTransport:
+        return DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+        )
+
+    def test_parse_short_read_raises_when_count_expected(self) -> None:
+        """A response with fewer registers than requested raises."""
+        transport = self._make_transport()
+        # Frame carries 1 register but 3 were requested.
+        response = _build_mock_response(
+            modbus_func=MODBUS_READ_HOLDING,
+            start_register=105,
+            register_values=[42],
+        )
+
+        with pytest.raises(TransportReadError, match="Short read"):
+            transport._parse_response(
+                response,
+                expected_func=MODBUS_READ_HOLDING,
+                expected_register=105,
+                expected_count=3,
+            )
+
+    def test_parse_partial_returned_without_expected_count(self) -> None:
+        """Without expected_count the parser is unchanged (returns partial).
+
+        Input reads never pass expected_count and rely on their own
+        higher-layer short-read handling (#261), so the parser must keep
+        returning whatever the frame carried when the count is not given.
+        """
+        transport = self._make_transport()
+        response = _build_mock_response(
+            modbus_func=MODBUS_READ_HOLDING,
+            start_register=105,
+            register_values=[42],
+        )
+
+        registers = transport._parse_response(
+            response,
+            expected_func=MODBUS_READ_HOLDING,
+            expected_register=105,
+        )
+        assert registers == [42]
+
+    def test_parse_full_length_accepted(self) -> None:
+        """A full-length response passes the count guard unchanged."""
+        transport = self._make_transport()
+        response = _build_mock_response(
+            modbus_func=MODBUS_READ_HOLDING,
+            start_register=105,
+            register_values=[10, 20, 30],
+        )
+
+        registers = transport._parse_response(
+            response,
+            expected_func=MODBUS_READ_HOLDING,
+            expected_register=105,
+            expected_count=3,
+        )
+        assert registers == [10, 20, 30]
+
+    @pytest.mark.asyncio
+    async def test_holding_short_read_raises_after_retries(self) -> None:
+        """Every attempt truncated → holding read raises after retries.
+
+        ``_read_holding_registers`` wires ``expected_count=count`` through
+        ``_send_receive``; a persistently short read exhausts the retry
+        budget and surfaces as a TransportReadError (a failed range for the
+        parameter reader), never a partial list.
+        """
+        transport = self._make_transport()
+        transport._connected = True
+
+        short = _build_mock_response(
+            modbus_func=MODBUS_READ_HOLDING,
+            start_register=105,
+            register_values=[42],  # only 1 of 3 requested
+        )
+        reader = AsyncMock()
+        # Each attempt: drain read (b"") then the (short) response.  A
+        # TransportReadError does not tear the socket down, so the same
+        # reader serves all three attempts (max_retries defaults to 2).
+        reader.read = AsyncMock(side_effect=[b"", short, b"", short, b"", short])
+        writer = AsyncMock()
+        writer.write = MagicMock()
+        writer.close = MagicMock()
+        transport._reader = reader
+        transport._writer = writer
+
+        with (
+            patch("asyncio.sleep", AsyncMock()),
+            pytest.raises(TransportReadError, match="Short read"),
+        ):
+            await transport._read_holding_registers(105, 3)
+
+    @pytest.mark.asyncio
+    async def test_holding_short_read_recovers_on_retry(self) -> None:
+        """A transient short read recovers when the retry returns full data."""
+        transport = self._make_transport()
+        transport._connected = True
+
+        short = _build_mock_response(
+            modbus_func=MODBUS_READ_HOLDING,
+            start_register=105,
+            register_values=[42],
+        )
+        full = _build_mock_response(
+            modbus_func=MODBUS_READ_HOLDING,
+            start_register=105,
+            register_values=[10, 20, 30],
+        )
+        reader = AsyncMock()
+        # Attempt 0: short (raises, retries). Attempt 1: full (succeeds).
+        reader.read = AsyncMock(side_effect=[b"", short, b"", full])
+        writer = AsyncMock()
+        writer.write = MagicMock()
+        writer.close = MagicMock()
+        transport._reader = reader
+        transport._writer = writer
+
+        with patch("asyncio.sleep", AsyncMock()):
+            result = await transport._read_holding_registers(105, 3)
+
+        assert result == [10, 20, 30]
+
+
 class TestDongleRegisterOperations:
     """Tests for register read/write operations."""
 

--- a/tests/unit/transports/test_modbus.py
+++ b/tests/unit/transports/test_modbus.py
@@ -417,6 +417,101 @@ class TestModbusRegisterReading:
                 await transport.read_parameters(0, 10)
 
     @pytest.mark.asyncio
+    async def test_holding_short_read_raises_after_retries(self) -> None:
+        """A short holding read (fewer registers than requested) raises.
+
+        pymodbus decodes registers from the response byte_count and never
+        checks it against the requested count, so a truncated-but-well-formed
+        holding response would otherwise silently drop parameters.  The guard
+        retries and, on exhaustion, raises rather than returning partial data.
+        """
+        transport = ModbusTransport(host="192.168.1.100", serial="CE12345678")
+
+        with (
+            patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class,
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_client = MagicMock()
+            mock_client.connect = AsyncMock(return_value=True)
+            mock_client.close = MagicMock()
+
+            # Every attempt returns only 3 of the 5 requested registers.
+            short = MagicMock()
+            short.isError.return_value = False
+            short.registers = [100, 200, 300]
+            mock_client.read_holding_registers = AsyncMock(return_value=short)
+            mock_client_class.return_value = mock_client
+
+            await transport.connect()
+            with pytest.raises(TransportReadError, match="Short holding read"):
+                await transport.read_parameters(0, 5)
+
+            # retries defaults to 2 → 3 read attempts before raising.
+            assert mock_client.read_holding_registers.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_holding_short_read_recovers_on_retry(self) -> None:
+        """A transient short holding read recovers when the retry is full."""
+        transport = ModbusTransport(host="192.168.1.100", serial="CE12345678")
+
+        with (
+            patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class,
+            patch("asyncio.sleep", AsyncMock()),
+        ):
+            mock_client = MagicMock()
+            mock_client.connect = AsyncMock(return_value=True)
+            mock_client.close = MagicMock()
+
+            call_count = 0
+
+            async def make_response(**kwargs: int) -> MagicMock:
+                nonlocal call_count
+                response = MagicMock()
+                response.isError.return_value = False
+                # First attempt short (3/5), retry returns the full 5.
+                if call_count == 0:
+                    response.registers = [100, 200, 300]
+                else:
+                    response.registers = [100, 200, 300, 400, 500]
+                call_count += 1
+                return response
+
+            mock_client.read_holding_registers = make_response
+            mock_client_class.return_value = mock_client
+
+            await transport.connect()
+            params = await transport.read_parameters(0, 5)
+
+            assert params[4] == 500
+            assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_input_short_read_not_guarded(self) -> None:
+        """Input reads keep returning partial data (guarded higher up, #261).
+
+        The count guard is holding-only; the input path has its own
+        short-read handling, so a short input read must NOT raise here.
+        """
+        transport = ModbusTransport(host="192.168.1.100", serial="CE12345678")
+
+        with patch("pymodbus.client.AsyncModbusTcpClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.connect = AsyncMock(return_value=True)
+            mock_client.close = MagicMock()
+
+            short = MagicMock()
+            short.isError.return_value = False
+            short.registers = [100, 200]  # 2 of 5 requested
+            mock_client.read_input_registers = AsyncMock(return_value=short)
+            mock_client_class.return_value = mock_client
+
+            await transport.connect()
+            values = await transport._read_input_registers(0, 5)
+
+            assert values == [100, 200]
+            assert mock_client.read_input_registers.await_count == 1
+
+    @pytest.mark.asyncio
     async def test_write_parameters_success(self) -> None:
         """Test successful parameter write."""
         transport = ModbusTransport(


### PR DESCRIPTION
## Root cause

A truncated holding-register response passes every existing dongle cross-request check — matching inverter serial, function code, and start register, with a valid CRC computed over the short payload. `DongleTransport._parse_response` then returned however many registers the frame's `byte_count` implied, with no check that the count matched what was requested.

On the parameter path (`_read_holding_registers` → `read_parameters` → `_fetch_parameters`) that silently produced a **partial parameter dict**: the missing registers never landed in `failed_ranges`, `parameters_complete` was stamped `True`, the #282 sticky-parameter merge was skipped, and the absent parameters blanked their HA entities for the full 1-hour cache TTL.

## Why the input path already had this

The input-register path already rejects short reads — `len(bms_regs) < 33` in `_register_data.py` and the coalesced short-read latch, both added for #261. The holding/parameter path never got an equivalent guard.

## Fix

- **Dongle:** thread an `expected_count` through `_send_receive` into `_parse_response`, passed only from `_read_holding_registers`. A response carrying fewer registers than requested now raises `TransportReadError` **inside the `_send_receive` retry loop**, so a transient truncation recovers on retry and only surfaces as a failed range once the retry budget is exhausted. Input reads do not pass `expected_count` and keep their existing higher-layer handling.
- **Modbus TCP:** verified pymodbus 3.13.1 decodes registers from the response's own `byte_count` and never compares it to the requested count (`ReadHoldingRegistersResponse.decode`), so a device reporting fewer registers than asked returns a short list without error there too. Added the same holding-only guard inside `_read_registers`, within its retry loop. Input reads stay unguarded (handled higher up per #261).

## Tests

- Dongle: short read raises at parse level and after retries; recovers on a subsequent full read; no-`expected_count` and full-length paths unchanged.
- Modbus TCP: short holding read raises after retries; recovers on retry; short input read is **not** guarded.

Full suite: 2571 passed, 4 skipped. `ruff` + `mypy --strict` clean. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)