### PR TITLE
fix: cloud-mode schedule getters + skip combined read in link-down probe

### DIFF
--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -754,10 +754,14 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             getattr(self._transport, "read_all_input_data", None) if self._transport else None
         )
 
-        if runtime_expired and combined_fn is not None:
+        if runtime_expired and combined_fn is not None and not link_down:
             tasks.append(self._fetch_combined_input_data())
         else:
-            # Individual read path
+            # Individual read path.  In link-down probe mode the combined
+            # read is intentionally bypassed: energy/battery are already
+            # gated off above, so this issues only the single cheap runtime
+            # probe needed to detect link recovery — not the full
+            # all-input-groups read.
             if runtime_expired:
                 tasks.append(self._fetch_runtime())
 

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -438,7 +438,7 @@ class HybridInverter(GenericInverter):
         return True
 
     async def _get_schedule(self, schedule_type: ScheduleType, period: int) -> dict[str, int]:
-        """Read a time period schedule via Modbus (generic helper).
+        """Read a time period schedule (generic helper, transport or cloud).
 
         Args:
             schedule_type: Which schedule to read
@@ -449,11 +449,27 @@ class HybridInverter(GenericInverter):
 
         Raises:
             ValueError: If period is not 0, 1, or 2
+
+        Note:
+            Local (Modbus) mode reads the packed-time registers directly. Cloud
+            mode has no ``reg_<n>`` keys — the API returns named schedule params
+            (``{cloud_prefix}_START_HOUR`` etc.), so it delegates to the cloud
+            endpoint getter, which mirrors the cloud setter's named-field
+            convention.
         """
         from pylxpweb.constants import SCHEDULE_CONFIGS, unpack_time
 
         if period not in (0, 1, 2):
             raise ValueError(f"period must be 0, 1, or 2, got {period}")
+
+        if self._transport is None:
+            if self._client is None:
+                raise LuxpowerDeviceError(
+                    "Reading a schedule requires a transport or a cloud client"
+                )
+            return await self._client.api.control._get_schedule(
+                self.serial_number, schedule_type, period
+            )
 
         base_reg = SCHEDULE_CONFIGS[schedule_type].base_register
         start_reg = base_reg + (period * 2)

--- a/tests/unit/devices/inverters/test_hybrid.py
+++ b/tests/unit/devices/inverters/test_hybrid.py
@@ -9,6 +9,7 @@ import pytest
 
 from pylxpweb import BatteryControlMode, LuxpowerClient
 from pylxpweb.devices.inverters.hybrid import HybridInverter
+from pylxpweb.endpoints.control import ControlEndpoints
 from pylxpweb.exceptions import LuxpowerDeviceError
 
 
@@ -512,20 +513,22 @@ class TestACChargeScheduleOperations:
             await inverter.set_ac_charge_schedule(0, 24, 0, 7, 0)
 
     @pytest.mark.asyncio
-    async def test_get_ac_charge_schedule(self, mock_client: LuxpowerClient) -> None:
-        """Test reading AC charge schedule."""
+    async def test_get_ac_charge_schedule_local(self, mock_client: LuxpowerClient) -> None:
+        """LOCAL mode reads the packed-time registers via the transport."""
+        transport = Mock()
+        # Transport read_parameters returns {addr: value}; reg 68 = pack_time(23, 0)
+        # = 23, reg 69 = pack_time(7, 0) = 7.
+        transport.read_parameters = AsyncMock(return_value={68: 23, 69: 7})
         inverter = HybridInverter(
-            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+            client=mock_client,
+            serial_number="1234567890",
+            model="FlexBOSS21",
+            transport=transport,
         )
-
-        # Mock read response - reg 68 = pack_time(23, 0) = 23, reg 69 = pack_time(7, 0) = 7
-        mock_response = Mock()
-        mock_response.parameters = {"reg_68": 23, "reg_69": 7}
-        mock_client.api.control.read_parameters = AsyncMock(return_value=mock_response)
 
         schedule = await inverter.get_ac_charge_schedule(0)
 
-        mock_client.api.control.read_parameters.assert_called_once_with("1234567890", 68, 2)
+        transport.read_parameters.assert_awaited_once_with(68, 2)
         assert schedule == {
             "start_hour": 23,
             "start_minute": 0,
@@ -534,17 +537,20 @@ class TestACChargeScheduleOperations:
         }
 
     @pytest.mark.asyncio
-    async def test_get_ac_charge_schedule_with_minutes(self, mock_client: LuxpowerClient) -> None:
-        """Test reading AC charge schedule with non-zero minutes."""
-        inverter = HybridInverter(
-            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
-        )
-
+    async def test_get_ac_charge_schedule_local_with_minutes(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """LOCAL mode unpacks non-zero minutes from the packed-time registers."""
+        transport = Mock()
         # pack_time(22, 30) = 22 | (30 << 8) = 7702
         # pack_time(6, 45) = 6 | (45 << 8) = 11526
-        mock_response = Mock()
-        mock_response.parameters = {"reg_68": 7702, "reg_69": 11526}
-        mock_client.api.control.read_parameters = AsyncMock(return_value=mock_response)
+        transport.read_parameters = AsyncMock(return_value={68: 7702, 69: 11526})
+        inverter = HybridInverter(
+            client=mock_client,
+            serial_number="1234567890",
+            model="FlexBOSS21",
+            transport=transport,
+        )
 
         schedule = await inverter.get_ac_charge_schedule(0)
 
@@ -554,6 +560,98 @@ class TestACChargeScheduleOperations:
             "end_hour": 6,
             "end_minute": 45,
         }
+
+    @pytest.mark.asyncio
+    async def test_get_ac_charge_schedule_cloud(self, mock_client: LuxpowerClient) -> None:
+        """CLOUD mode resolves the schedule from named params, not reg_<n> keys.
+
+        Regression: the getter used to read reg_<n> keys, which the cloud
+        read_parameters never returns — so every cloud schedule read came back
+        00:00-00:00 regardless of the actual configuration.
+        """
+        control = ControlEndpoints(mock_client)
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "HOLD_AC_CHARGE_START_HOUR": 23,
+                "HOLD_AC_CHARGE_START_MINUTE": 30,
+                "HOLD_AC_CHARGE_END_HOUR": 7,
+                "HOLD_AC_CHARGE_END_MINUTE": 15,
+            }
+        )
+        mock_client.api.control = control
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+
+        schedule = await inverter.get_ac_charge_schedule(0)
+
+        assert schedule == {
+            "start_hour": 23,
+            "start_minute": 30,
+            "end_hour": 7,
+            "end_minute": 15,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_forced_discharge_schedule_cloud(self, mock_client: LuxpowerClient) -> None:
+        """CLOUD mode resolves a non-AC-charge schedule from its named params."""
+        control = ControlEndpoints(mock_client)
+        # Period 1 uses the _1 suffix on the HOLD_FORCED_DISCHARGE prefix.
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "HOLD_FORCED_DISCHARGE_START_HOUR_1": 18,
+                "HOLD_FORCED_DISCHARGE_START_MINUTE_1": 0,
+                "HOLD_FORCED_DISCHARGE_END_HOUR_1": 21,
+                "HOLD_FORCED_DISCHARGE_END_MINUTE_1": 45,
+            }
+        )
+        mock_client.api.control = control
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+
+        schedule = await inverter.get_forced_discharge_schedule(1)
+
+        assert schedule == {
+            "start_hour": 18,
+            "start_minute": 0,
+            "end_hour": 21,
+            "end_minute": 45,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_ac_first_schedule_cloud(self, mock_client: LuxpowerClient) -> None:
+        """CLOUD mode resolves the AC First schedule from its named params."""
+        control = ControlEndpoints(mock_client)
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "HOLD_AC_FIRST_START_HOUR": 9,
+                "HOLD_AC_FIRST_START_MINUTE": 5,
+                "HOLD_AC_FIRST_END_HOUR": 17,
+                "HOLD_AC_FIRST_END_MINUTE": 55,
+            }
+        )
+        mock_client.api.control = control
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+
+        schedule = await inverter.get_ac_first_schedule(0)
+
+        assert schedule == {
+            "start_hour": 9,
+            "start_minute": 5,
+            "end_hour": 17,
+            "end_minute": 55,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_schedule_cloud_requires_client(self) -> None:
+        """CLOUD mode with neither transport nor client raises a clear error."""
+        inverter = HybridInverter(client=None, serial_number="1234567890", model="FlexBOSS21")
+
+        with pytest.raises(LuxpowerDeviceError, match="transport or a cloud client"):
+            await inverter.get_ac_charge_schedule(0)
 
     @pytest.mark.asyncio
     async def test_get_ac_charge_schedule_invalid_period(self, mock_client: LuxpowerClient) -> None:

--- a/tests/unit/devices/test_transport_link_health.py
+++ b/tests/unit/devices/test_transport_link_health.py
@@ -54,9 +54,16 @@ def _make_combined_data() -> tuple[Mock, Mock, Mock]:
 
 
 def _attach_failing_combined_transport(inverter: GenericInverter) -> AsyncMock:
-    """Attach a transport whose combined read always fails."""
+    """Attach a transport whose reads always fail.
+
+    Both the combined read (used while the link is healthy, to trip the
+    counter down) and the runtime probe (the single cheap read used once the
+    link is down) fail, so the failure counter keeps climbing through both the
+    trip-down and the degraded-probe phases.
+    """
     transport = AsyncMock()
     transport.read_all_input_data = AsyncMock(side_effect=OSError("link dead"))
+    transport.read_runtime = AsyncMock(side_effect=OSError("link dead"))
     inverter._transport = transport
     return transport
 
@@ -189,7 +196,8 @@ class TestInverterFailureCounter:
 
     @pytest.mark.asyncio
     async def test_recovery_repopulates_transport_data(self) -> None:
-        """A successful probe after link-down restores local data serving."""
+        """Recovery is detected by the cheap runtime probe; the next healthy
+        refresh repopulates energy/battery via the combined read."""
         inverter = _make_inverter()
         transport = _attach_failing_combined_transport(inverter)
 
@@ -198,12 +206,17 @@ class TestInverterFailureCounter:
         assert inverter.transport_link_down is True
 
         runtime, energy, battery = _make_combined_data()
+        # While down, only the runtime probe runs — recovery is detected there.
+        transport.read_runtime.side_effect = None
+        transport.read_runtime.return_value = runtime
+        await inverter.refresh(force=True)
+        assert inverter.transport_link_down is False
+        assert inverter._transport_runtime is runtime
+
+        # Link healthy again: the combined read resumes and repopulates energy.
         transport.read_all_input_data.side_effect = None
         transport.read_all_input_data.return_value = (runtime, energy, battery)
         await inverter.refresh(force=True)
-
-        assert inverter.transport_link_down is False
-        assert inverter._transport_runtime is runtime
         assert inverter._transport_energy is energy
 
     @pytest.mark.asyncio
@@ -238,22 +251,27 @@ class TestInverterFailureCounter:
         for _ in range(TRANSPORT_LINK_DOWN_THRESHOLD):
             await inverter.refresh(force=True)
         assert inverter.transport_link_down is True
-        calls_after_down = transport.read_all_input_data.await_count
+        # While down the probe is the cheap runtime read, never the full
+        # combined read (Bug 2 fix).
+        combined_after_down = transport.read_all_input_data.await_count
+        probe_calls = transport.read_runtime.await_count
 
         # First post-down refresh probes (no force, no expired cache needed)
         await inverter.refresh()
-        assert transport.read_all_input_data.await_count == calls_after_down + 1
+        assert transport.read_runtime.await_count == probe_calls + 1
+        assert transport.read_all_input_data.await_count == combined_after_down
 
         # Same-tick duplicates collapse — no second dead-link read, even
         # with force=True (force cannot exceed the probe rate while down).
         await inverter.refresh()
         await inverter.refresh(force=True)
-        assert transport.read_all_input_data.await_count == calls_after_down + 1
+        assert transport.read_runtime.await_count == probe_calls + 1
 
         # Next coordinator tick (interval elapsed): probes again.
         inverter._last_link_probe_monotonic = time.monotonic() - LINK_PROBE_MIN_INTERVAL_SECONDS
         await inverter.refresh()
-        assert transport.read_all_input_data.await_count == calls_after_down + 2
+        assert transport.read_runtime.await_count == probe_calls + 2
+        assert transport.read_all_input_data.await_count == combined_after_down
 
     @pytest.mark.asyncio
     async def test_probe_throttle_resets_on_recovery(self) -> None:
@@ -267,14 +285,41 @@ class TestInverterFailureCounter:
         await inverter.refresh()  # engages the probe gate
         assert inverter._last_link_probe_monotonic is not None
 
-        runtime, energy, battery = _make_combined_data()
-        transport.read_all_input_data.side_effect = None
-        transport.read_all_input_data.return_value = (runtime, energy, battery)
+        runtime, _energy, _battery = _make_combined_data()
+        # Recovery is detected by the runtime probe while the link is down.
+        transport.read_runtime.side_effect = None
+        transport.read_runtime.return_value = runtime
         inverter._last_link_probe_monotonic = time.monotonic() - LINK_PROBE_MIN_INTERVAL_SECONDS
         await inverter.refresh()
 
         assert inverter.transport_link_down is False
         assert inverter._last_link_probe_monotonic is None
+
+    @pytest.mark.asyncio
+    async def test_link_down_probe_skips_combined_read(self) -> None:
+        """Bug 2: while down, the probe is a single runtime read.
+
+        Even when the transport exposes ``read_all_input_data``, the link-down
+        probe must NOT run the full combined input read — it issues only the
+        cheap runtime read, and link recovery is still detected from it.
+        """
+        inverter = _make_inverter()
+        transport = _attach_failing_combined_transport(inverter)
+
+        for _ in range(TRANSPORT_LINK_DOWN_THRESHOLD):
+            await inverter.refresh(force=True)
+        assert inverter.transport_link_down is True
+        combined_after_down = transport.read_all_input_data.await_count
+
+        # Probe recovers via the runtime read; the combined read is untouched.
+        runtime, _energy, _battery = _make_combined_data()
+        transport.read_runtime.side_effect = None
+        transport.read_runtime.return_value = runtime
+        await inverter.refresh(force=True)
+
+        transport.read_runtime.assert_awaited()
+        assert transport.read_all_input_data.await_count == combined_after_down
+        assert inverter.transport_link_down is False
 
     @pytest.mark.asyncio
     async def test_cloud_only_device_never_link_down(self, mock_client: LuxpowerClient) -> None:
@@ -312,9 +357,10 @@ class TestInverterLinkDownLogging:
             ]
             assert len(warnings) == 1
 
-            runtime, energy, battery = _make_combined_data()
-            transport.read_all_input_data.side_effect = None
-            transport.read_all_input_data.return_value = (runtime, energy, battery)
+            runtime, _energy, _battery = _make_combined_data()
+            # Recovery is detected by the runtime probe while down.
+            transport.read_runtime.side_effect = None
+            transport.read_runtime.return_value = runtime
             # Age the probe gate: recovery happens on a later coordinator
             # tick, not within the same-tick throttle window.
             inverter._last_link_probe_monotonic = time.monotonic() - LINK_PROBE_MIN_INTERVAL_SECONDS
@@ -367,10 +413,15 @@ class TestInverterHttpFallback:
         # Transport data cleared -> properties now serve the HTTP values
         assert inverter._transport_runtime is None
 
-        # Next cycle: probe still attempted, fallback keeps fetching
-        probe_calls = transport.read_all_input_data.await_count
+        # Next cycle: probe still attempted, fallback keeps fetching.  The
+        # probe is the single cheap runtime read, not the full combined read
+        # (Bug 2 fix) — degraded-HYBRID polls must not spend the extra
+        # local read/timeout work before the cloud fallback runs.
+        combined_after_down = transport.read_all_input_data.await_count
+        probe_calls = transport.read_runtime.await_count
         await inverter.refresh()
-        assert transport.read_all_input_data.await_count == probe_calls + 1
+        assert transport.read_runtime.await_count == probe_calls + 1
+        assert transport.read_all_input_data.await_count == combined_after_down
         assert mock_client.api.devices.get_inverter_runtime.await_count >= 2
 
     @pytest.mark.asyncio

--- a/tests/unit/test_ac_first_schedule.py
+++ b/tests/unit/test_ac_first_schedule.py
@@ -221,14 +221,17 @@ class TestACFirstScheduleModbus:
 
     @pytest.mark.asyncio
     async def test_get_ac_first_schedule(self, mock_client: LuxpowerClient) -> None:
-        inverter = HybridInverter(client=mock_client, serial_number=SERIAL, model="12000XP")
-        mock_response = Mock()
-        mock_response.parameters = {"reg_152": 23, "reg_153": (30 << 8) | 7}
-        mock_client.api.control.read_parameters = AsyncMock(return_value=mock_response)
+        # LOCAL (Modbus) path: read the packed-time registers via the transport.
+        # reg 152 = pack_time(23, 0) = 23; reg 153 = pack_time(7, 30) = (30<<8)|7.
+        transport = Mock()
+        transport.read_parameters = AsyncMock(return_value={152: 23, 153: (30 << 8) | 7})
+        inverter = HybridInverter(
+            client=mock_client, serial_number=SERIAL, model="12000XP", transport=transport
+        )
 
         schedule = await inverter.get_ac_first_schedule(0)
 
-        mock_client.api.control.read_parameters.assert_called_once_with(SERIAL, 152, 2)
+        transport.read_parameters.assert_awaited_once_with(152, 2)
         assert schedule == {
             "start_hour": 23,
             "start_minute": 0,


### PR DESCRIPTION
## Summary

Two Codex-confirmed bugs in the HYBRID inverter code path. Both verified by tracing before fixing.

### Bug 1 — cloud-mode schedule getters always returned 00:00-00:00 (CONFIRMED)

`HybridInverter._get_schedule()` read `reg_<n>` keys from `read_parameters()`. That works for the LOCAL transport (returns `{f"reg_{addr}": value}`), but the CLOUD `read_parameters()` path returns **named** hold params (`HOLD_AC_CHARGE_START_HOUR`, etc.) — there is no `reg_68` key. So every cloud-only `get_ac_charge_schedule()` / `get_forced_charge_schedule()` / `get_forced_discharge_schedule()` / `get_ac_first_schedule()` returned `{start_hour:0, start_minute:0, end_hour:0, end_minute:0}` regardless of the actual device configuration.

**Fix:** when no transport is attached, delegate to the existing, tested `ControlEndpoints._get_schedule()`, which resolves values from the named params via `SCHEDULE_CONFIGS[...].cloud_prefix` and mirrors the cloud **setter's** per-field hour/minute convention. The LOCAL packed-register path is unchanged.

### Bug 2 — link-down probe ran the full combined input read (CONFIRMED)

In link-down "runtime-only probe" mode, `refresh()` gates `energy_expired`/`battery_expired` to `False` and intends a single cheap runtime probe. But when the transport exposed `read_all_input_data`, it still scheduled `_fetch_combined_input_data()` — the **full** all-input-groups read — spending extra local read/timeout work on every degraded-HYBRID poll before the cloud fallback ran.

**Fix:** gate the combined path on `not link_down`. A degraded poll now issues only `_fetch_runtime()` (the single runtime read). Recovery is still detected because `_fetch_runtime()` goes through `_tracked_transport_read()` like the combined path. Normal-mode combined-read behavior is byte-identical (`link_down` is `False`).

## Tests

- `test_hybrid.py`: cloud-mode getters for AC charge, forced discharge, and AC First now assert real values resolved from named params; local-mode getters assert the packed-register read via the transport; a cloud-with-no-client case raises a clear error.
- `test_ac_first_schedule.py`: the Modbus-class getter test converted to a genuine transport read (it previously fed fabricated `reg_` keys through the cloud path — encoding the bug).
- `test_transport_link_health.py`: new `test_link_down_probe_skips_combined_read` asserts the probe calls `read_runtime` but not `read_all_input_data` and still detects recovery; existing probe/recovery tests updated to the corrected semantics.

## Gates

- `ruff check src/ tests/` — clean
- `ruff format` — clean
- `.venv/bin/mypy src/pylxpweb` — clean
- `pytest tests/` — **2568 passed, 4 skipped**

No version bump. No linter suppressions. Did not touch `_modbus_base.py` / `dongle.py` (open PR #203).

🤖 Generated with [Claude Code](https://claude.com/claude-code)