### PR TITLE
feat: shared-battery context in reg96 debug log (#288)

### DIFF
--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -263,6 +263,15 @@ class RegisterDataMixin(_DataMixinBase):
     in their ``__init__``.
     """
 
+    # Last-seen HOLD 110 value, opportunistically stashed by
+    # read_parameters()/write_parameters() when register 110 passes through
+    # an existing call (never triggers a read of its own).  Bit 3 is
+    # FUNC_BAT_SHARED — on a shared-bank *secondary* inverter (not on the
+    # battery CAN bus) reg96=0 is expected, and the battery_count debug
+    # lines annotate that so logs are not misread (eg4_web_monitor#288,
+    # the #282/#258 red herring).
+    _last_hold_110: int | None = None
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
@@ -271,6 +280,19 @@ class RegisterDataMixin(_DataMixinBase):
     def _registers_from_values(start: int, values: list[int]) -> dict[int, int]:
         """Build address-to-value dict from a contiguous register read."""
         return {start + offset: value for offset, value in enumerate(values)}
+
+    def _shared_battery_note(self, battery_count: int) -> str:
+        """Debug-log annotation for reg96=0 on a shared-battery secondary.
+
+        Returns a suffix for the ``battery_count (reg 96)`` debug lines when
+        the last-seen HOLD 110 has FUNC_BAT_SHARED (bit 3) set and reg 96
+        reads 0 — the expected state on a secondary inverter sharing another
+        inverter's battery bank (eg4_web_monitor#288).  Empty string
+        otherwise, or when HOLD 110 has not passed through this transport yet.
+        """
+        if battery_count == 0 and self._last_hold_110 is not None and self._last_hold_110 & 0x8:
+            return " (shared-battery secondary — reg96=0 expected)"
+        return ""
 
     async def _read_individual_battery_registers(
         self,
@@ -1113,10 +1135,11 @@ class RegisterDataMixin(_DataMixinBase):
         individual_registers: dict[int, int] | None = None
 
         _LOGGER.debug(
-            "[%s] battery_count (reg 96) = %d, include_individual = %s",
+            "[%s] battery_count (reg 96) = %d, include_individual = %s%s",
             self._serial,
             battery_count,
             include_individual,
+            self._shared_battery_note(battery_count),
         )
 
         # reg 96 is unreliable (#170/#258): a transient 0 on a battery-bearing
@@ -1274,9 +1297,10 @@ class RegisterDataMixin(_DataMixinBase):
         battery_count = input_registers.get(96, 0)
 
         _LOGGER.debug(
-            "[%s] combined path: battery_count (reg 96) = %d",
+            "[%s] combined path: battery_count (reg 96) = %d%s",
             self._serial,
             battery_count,
+            self._shared_battery_note(battery_count),
         )
 
         individual_registers: dict[int, int] | None = None
@@ -1373,6 +1397,10 @@ class RegisterDataMixin(_DataMixinBase):
             current_address += chunk_size
             remaining -= chunk_size
 
+        # Opportunistic stash for _shared_battery_note() — no extra read.
+        if 110 in result:
+            self._last_hold_110 = result[110]
+
         return result
 
     async def write_parameters(
@@ -1415,6 +1443,11 @@ class RegisterDataMixin(_DataMixinBase):
 
         for start_address, values in groups:
             await self._write_holding_registers(start_address, values)
+
+        # Keep the _shared_battery_note() stash coherent with our own writes
+        # (e.g. a FUNC_BAT_SHARED bit flip via read-modify-write of reg 110).
+        if 110 in parameters:
+            self._last_hold_110 = parameters[110]
 
         return True
 

--- a/tests/unit/transports/test_shared_battery_note.py
+++ b/tests/unit/transports/test_shared_battery_note.py
@@ -1,0 +1,153 @@
+"""Shared-battery context in the battery_count (reg 96) debug log (eg4#288).
+
+On a multi-inverter system sharing one battery bank, only the primary
+inverter sits on the battery CAN bus — a *secondary* legitimately reads
+``battery_count`` (reg 96) = 0.  That reading looked like a bug in the
+eg4_web_monitor #282/#258 investigations, so the reg96 debug lines now
+append "(shared-battery secondary — reg96=0 expected)" when the last-seen
+HOLD 110 has FUNC_BAT_SHARED (bit 3) set.
+
+HOLD 110 is stashed opportunistically when it passes through an existing
+``read_parameters()`` / ``write_parameters()`` call — the annotation never
+triggers a holding-register read of its own.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pylxpweb.transports.modbus import ModbusTransport
+
+_BAT_SHARED_BIT = 0x8  # HOLD 110 bit 3 = FUNC_BAT_SHARED
+_NOTE = "shared-battery secondary — reg96=0 expected"
+
+_POWER_GROUP_START = 0
+_BMS_GROUP_START = 80
+_VOLTAGE_RAW = 534  # reg 4, DIV_10 -> 53.4 V
+
+
+def _transport() -> ModbusTransport:
+    t = ModbusTransport(host="192.168.1.100", serial="CE12345678")
+    t.pv_string_count = 3  # skip the pv4-6 extended read
+    return t
+
+
+async def _fake_input_read(start: int, count: int) -> list[int]:
+    """All input groups read zeros (reg 96 = 0, no battery slots)."""
+    vals = [0] * count
+    if start == _POWER_GROUP_START:
+        vals[4] = _VOLTAGE_RAW
+    return vals
+
+
+class TestSharedBatteryNoteHelper:
+    """_shared_battery_note(): only bit 3 + reg96==0 produce the note."""
+
+    def test_note_when_bit3_set_and_count_zero(self) -> None:
+        transport = _transport()
+        transport._last_hold_110 = _BAT_SHARED_BIT
+        assert _NOTE in transport._shared_battery_note(0)
+
+    def test_no_note_when_bit3_clear(self) -> None:
+        transport = _transport()
+        transport._last_hold_110 = 0xFFF7  # everything except bit 3
+        assert transport._shared_battery_note(0) == ""
+
+    def test_no_note_when_count_nonzero(self) -> None:
+        """A primary (on the battery CAN bus) with sharing enabled still
+        reports its bank — reg96>0 needs no excuse."""
+        transport = _transport()
+        transport._last_hold_110 = _BAT_SHARED_BIT
+        assert transport._shared_battery_note(4) == ""
+
+    def test_no_note_before_hold_110_seen(self) -> None:
+        """No HOLD 110 has passed through yet -> stay silent (never guess,
+        never read)."""
+        transport = _transport()
+        assert transport._last_hold_110 is None
+        assert transport._shared_battery_note(0) == ""
+
+
+class TestHold110OpportunisticStash:
+    """read/write_parameters stash reg 110 when it passes through."""
+
+    @pytest.mark.asyncio
+    async def test_read_parameters_covering_110_stashes_value(self) -> None:
+        transport = _transport()
+
+        async def fake_holding(start: int, count: int) -> list[int]:
+            vals = [0] * count
+            if start <= 110 < start + count:
+                vals[110 - start] = _BAT_SHARED_BIT | 0x100
+            return vals
+
+        with patch.object(transport, "_read_holding_registers", side_effect=fake_holding):
+            await transport.read_parameters(80, 40)
+
+        assert transport._last_hold_110 == _BAT_SHARED_BIT | 0x100
+
+    @pytest.mark.asyncio
+    async def test_read_parameters_not_covering_110_leaves_stash(self) -> None:
+        transport = _transport()
+        transport._last_hold_110 = _BAT_SHARED_BIT
+
+        async def fake_holding(start: int, count: int) -> list[int]:
+            return [0] * count
+
+        with patch.object(transport, "_read_holding_registers", side_effect=fake_holding):
+            await transport.read_parameters(0, 40)
+
+        assert transport._last_hold_110 == _BAT_SHARED_BIT
+
+    @pytest.mark.asyncio
+    async def test_write_parameters_updates_stash(self) -> None:
+        """A local FUNC_BAT_SHARED bit flip (RMW of reg 110) keeps the
+        stash coherent without waiting for the next parameter read."""
+        transport = _transport()
+        transport._last_hold_110 = _BAT_SHARED_BIT
+
+        with patch.object(transport, "_write_holding_registers", new=AsyncMock(return_value=True)):
+            await transport.write_parameters({110: 0})
+
+        assert transport._last_hold_110 == 0
+
+
+class TestRegNinetySixDebugLineAnnotation:
+    """End to end: the combined-path reg96 debug line carries the note."""
+
+    @pytest.mark.asyncio
+    async def test_combined_path_notes_shared_secondary(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        transport = _transport()
+        transport._last_hold_110 = _BAT_SHARED_BIT
+
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=_fake_input_read),
+            caplog.at_level(logging.DEBUG),
+        ):
+            await transport.read_all_input_data()
+
+        line = next(
+            r.getMessage() for r in caplog.records if "battery_count (reg 96)" in r.getMessage()
+        )
+        assert "= 0" in line
+        assert _NOTE in line
+
+    @pytest.mark.asyncio
+    async def test_combined_path_silent_without_sharing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        transport = _transport()
+        transport._last_hold_110 = 0
+
+        with (
+            patch.object(transport, "_read_input_registers", side_effect=_fake_input_read),
+            caplog.at_level(logging.DEBUG),
+        ):
+            await transport.read_all_input_data()
+
+        assert _NOTE not in caplog.text


### PR DESCRIPTION
Companion to joyfulhouse/eg4_web_monitor#306 (Share Battery switch, eg4_web_monitor#288).

## What
On a shared-battery system only the primary inverter sits on the battery CAN bus — a *secondary* legitimately reads `battery_count` (reg 96) = 0. That reading was misread as a bug during the eg4_web_monitor #282/#258 investigations, so both `battery_count (reg 96)` debug lines (bms path and combined path in `RegisterDataMixin`) now append:

```
(shared-battery secondary — reg96=0 expected)
```

when the last-seen HOLD 110 has FUNC_BAT_SHARED (bit 3) set and reg 96 reads 0.

## How (no new reads)
HOLD 110 is not read on the input-register path, so the value is stashed **opportunistically**: `read_parameters()` records reg 110 whenever an existing holding read covers it (the periodic full-parameter refresh always does), and `write_parameters()` keeps the stash coherent after a local reg-110 read-modify-write. The annotation never triggers a holding-register read of its own; before any HOLD 110 sighting the log lines are byte-identical to today's.

## Tests
`tests/unit/transports/test_shared_battery_note.py` — helper truth table (bit 3 set/clear, count 0/nonzero, never-seen), read/write stash behavior, and end-to-end caplog assertions on the combined-path debug line.

Suite: **2588 passed, 4 skipped**. ruff + mypy clean. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)