### PR TITLE
fix: link-down parameter guard, schedule getter edge cases, cloud schedule write verification (#206)

### DIFF
--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -1197,7 +1197,22 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         """
         async with self._parameters_cache_lock:
             try:
-                if self._transport is not None:
+                # Link-down guard (#206): the runtime/energy/battery legs of
+                # refresh() gate their transport reads behind
+                # transport_link_down + a rate-limited probe, but parameters
+                # walked straight into local Modbus reads.  Against a dead
+                # RS485 link a pymodbus read can hang for minutes (Python 3.11
+                # asyncio.wait_for cannot interrupt an in-flight read), so a
+                # single include_parameters refresh could stall the whole
+                # cycle.  While the link is down, skip the local read: fall
+                # back to cloud named-parameter reads when a client is
+                # available (the HTTP branch below), else skip entirely.
+                # Recovery is detected by the runtime probe — a successful
+                # transport read clears transport_link_down — so the next
+                # parameter refresh reads locally again without a parameter-
+                # side probe here.
+                link_down = self._transport is not None and self.transport_link_down
+                if self._transport is not None and not link_down:
                     # Use transport for direct register reads with named parameter mapping
                     # The read_named_parameters method handles:
                     # - Reading raw register values via Modbus/Dongle
@@ -1271,8 +1286,24 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                             self.serial_number,
                             ", ".join(failed_ranges),
                         )
+                elif link_down and not self._cloud_fallback_available:
+                    # Link-down, local-only (no cloud fallback): skip the read.
+                    # Preserve #282 sticky-merge semantics — leave
+                    # self.parameters and _parameters_cache_time untouched so
+                    # the read retries once the link recovers, and flag the
+                    # read incomplete so consumers see the degraded state.
+                    self.parameters_complete = False
+                    _LOGGER.debug(
+                        "Skipping local parameter read for %s: transport link "
+                        "down and no cloud fallback available",
+                        self.serial_number,
+                    )
+                    return
                 else:
-                    # Use HTTP API for full parameter access
+                    # Use HTTP API for full parameter access.  Reached by
+                    # pure-cloud devices and, per the link-down guard above, by
+                    # hybrid devices whose local link is down but which have a
+                    # usable cloud client (degraded cloud fallback).
                     range_tasks = [
                         self._client.api.control.read_parameters(
                             self.serial_number, 0, MAX_REGISTERS_PER_READ

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -406,7 +406,7 @@ class HybridInverter(GenericInverter):
         end_hour: int,
         end_minute: int,
     ) -> bool:
-        """Set a time period schedule via Modbus (generic helper).
+        """Set a time period schedule (generic helper, transport or cloud).
 
         Args:
             schedule_type: Which schedule to set
@@ -421,11 +421,37 @@ class HybridInverter(GenericInverter):
 
         Raises:
             ValueError: If period, hour, or minute is out of range
+
+        Note:
+            Local (Modbus) mode writes the packed-time registers directly via
+            FC06.  Cloud mode has no raw ``reg_<n>`` schedule write — the API
+            models schedules as named per-field params
+            (``{cloud_prefix}_START_HOUR`` etc.), the same convention the cloud
+            getter reads back (PR #205).  Writing a packed-time value to a raw
+            register address would not round-trip through the named getter, so
+            the cloud path delegates to the tested cloud setter, mirroring
+            :meth:`_get_schedule`'s cloud delegation.
         """
         from pylxpweb.constants import SCHEDULE_CONFIGS, pack_time
 
         if period not in (0, 1, 2):
             raise ValueError(f"period must be 0, 1, or 2, got {period}")
+
+        if self._transport is None:
+            if self._client is None:
+                raise LuxpowerDeviceError(
+                    "Setting a schedule requires a transport or a cloud client"
+                )
+            response = await self._client.api.control._set_schedule(
+                self.serial_number,
+                schedule_type,
+                period,
+                start_hour,
+                start_minute,
+                end_hour,
+                end_minute,
+            )
+            return response.success
 
         base_reg = SCHEDULE_CONFIGS[schedule_type].base_register
         start_reg = base_reg + (period * 2)

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -1407,11 +1407,26 @@ class ControlEndpoints(BaseEndpoint):
         suffix = "" if period == 0 else f"_{period}"
         params = await self.read_device_parameters_ranges(inverter_sn)
 
+        def _clock_field(value: object, upper: int) -> int:
+            """Coerce a cloud schedule field to an int in ``[0, upper]``.
+
+            The cloud API can return a key present-but-null (bare ``int(None)``
+            would raise) or, rarely, an out-of-range value; default null/garbage
+            to 0 and clamp so callers always get a valid clock component.
+            """
+            if value is None:
+                return 0
+            try:
+                parsed = int(str(value))
+            except (TypeError, ValueError):
+                return 0
+            return max(0, min(parsed, upper))
+
         return {
-            "start_hour": int(params.get(f"{prefix}_START_HOUR{suffix}", 0)),
-            "start_minute": int(params.get(f"{prefix}_START_MINUTE{suffix}", 0)),
-            "end_hour": int(params.get(f"{prefix}_END_HOUR{suffix}", 0)),
-            "end_minute": int(params.get(f"{prefix}_END_MINUTE{suffix}", 0)),
+            "start_hour": _clock_field(params.get(f"{prefix}_START_HOUR{suffix}"), 23),
+            "start_minute": _clock_field(params.get(f"{prefix}_START_MINUTE{suffix}"), 59),
+            "end_hour": _clock_field(params.get(f"{prefix}_END_HOUR{suffix}"), 23),
+            "end_minute": _clock_field(params.get(f"{prefix}_END_MINUTE{suffix}"), 59),
         }
 
     # ============================================================================

--- a/tests/unit/devices/inverters/test_hybrid.py
+++ b/tests/unit/devices/inverters/test_hybrid.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from pylxpweb import BatteryControlMode, LuxpowerClient
+from pylxpweb.constants import ScheduleType
 from pylxpweb.devices.inverters.hybrid import HybridInverter
 from pylxpweb.endpoints.control import ControlEndpoints
 from pylxpweb.exceptions import LuxpowerDeviceError
+from pylxpweb.models import SuccessResponse
 
 
 @pytest.fixture
@@ -434,62 +436,80 @@ class TestChargeDischargePowerOperations:
 class TestACChargeScheduleOperations:
     """Test AC charge time schedule operations."""
 
+    @staticmethod
+    def _transport_inverter(mock_client: LuxpowerClient) -> tuple[HybridInverter, Mock]:
+        """A transport-backed hybrid inverter (LOCAL packed-register write path)."""
+        transport = Mock()
+        transport.write_parameters = AsyncMock(return_value=True)
+        inverter = HybridInverter(
+            client=mock_client,
+            serial_number="1234567890",
+            model="FlexBOSS21",
+            transport=transport,
+        )
+        return inverter, transport
+
     @pytest.mark.asyncio
     async def test_set_ac_charge_schedule_period_0(self, mock_client: LuxpowerClient) -> None:
-        """Test setting AC charge schedule period 0."""
-        inverter = HybridInverter(
-            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
-        )
-
-        mock_write_response = Mock()
-        mock_write_response.success = True
-        mock_client.api.control.write_parameters = AsyncMock(return_value=mock_write_response)
+        """LOCAL: two packed FC06 register writes; cloud raw-write not used."""
+        inverter, transport = self._transport_inverter(mock_client)
 
         result = await inverter.set_ac_charge_schedule(0, 23, 0, 7, 0)
 
         # Two individual writes (FC06) — inverter rejects FC16 for schedule regs
-        assert mock_client.api.control.write_parameters.call_count == 2
-        mock_client.api.control.write_parameters.assert_any_call("1234567890", {68: 23})
-        mock_client.api.control.write_parameters.assert_any_call("1234567890", {69: 7})
+        assert transport.write_parameters.await_count == 2
+        transport.write_parameters.assert_any_await({68: 23})
+        transport.write_parameters.assert_any_await({69: 7})
+        assert not mock_client.api.control.write_parameters.called
         assert result is True
 
     @pytest.mark.asyncio
     async def test_set_ac_charge_schedule_period_1(self, mock_client: LuxpowerClient) -> None:
         """Test setting AC charge schedule period 1."""
-        inverter = HybridInverter(
-            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
-        )
-
-        mock_write_response = Mock()
-        mock_write_response.success = True
-        mock_client.api.control.write_parameters = AsyncMock(return_value=mock_write_response)
+        inverter, transport = self._transport_inverter(mock_client)
 
         result = await inverter.set_ac_charge_schedule(1, 12, 30, 14, 45)
 
         # Reg 70 = pack_time(12, 30) = 12|(30<<8) = 7692
         # Reg 71 = pack_time(14, 45) = 14|(45<<8) = 11534
-        assert mock_client.api.control.write_parameters.call_count == 2
-        mock_client.api.control.write_parameters.assert_any_call("1234567890", {70: 7692})
-        mock_client.api.control.write_parameters.assert_any_call("1234567890", {71: 11534})
+        assert transport.write_parameters.await_count == 2
+        transport.write_parameters.assert_any_await({70: 7692})
+        transport.write_parameters.assert_any_await({71: 11534})
         assert result is True
 
     @pytest.mark.asyncio
     async def test_set_ac_charge_schedule_period_2(self, mock_client: LuxpowerClient) -> None:
         """Test setting AC charge schedule period 2."""
-        inverter = HybridInverter(
-            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
-        )
-
-        mock_write_response = Mock()
-        mock_write_response.success = True
-        mock_client.api.control.write_parameters = AsyncMock(return_value=mock_write_response)
+        inverter, transport = self._transport_inverter(mock_client)
 
         result = await inverter.set_ac_charge_schedule(2, 0, 0, 6, 0)
 
         # Reg 72 = pack_time(0, 0) = 0, Reg 73 = pack_time(6, 0) = 6
-        assert mock_client.api.control.write_parameters.call_count == 2
-        mock_client.api.control.write_parameters.assert_any_call("1234567890", {72: 0})
-        mock_client.api.control.write_parameters.assert_any_call("1234567890", {73: 6})
+        assert transport.write_parameters.await_count == 2
+        transport.write_parameters.assert_any_await({72: 0})
+        transport.write_parameters.assert_any_await({73: 6})
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_set_ac_charge_schedule_cloud_delegates_to_named_setter(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """CLOUD (transport-less): delegate to the named cloud setter, not a raw
+        register write (mirror of the PR #205 read-side fix)."""
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+        mock_client.api.control._set_schedule = AsyncMock(
+            return_value=SuccessResponse(success=True)
+        )
+        mock_client.api.control.write_parameters = AsyncMock()
+
+        result = await inverter.set_ac_charge_schedule(1, 8, 30, 16, 0)
+
+        mock_client.api.control._set_schedule.assert_awaited_once_with(
+            "1234567890", ScheduleType.AC_CHARGE, 1, 8, 30, 16, 0
+        )
+        assert not mock_client.api.control.write_parameters.called
         assert result is True
 
     @pytest.mark.asyncio
@@ -504,10 +524,8 @@ class TestACChargeScheduleOperations:
 
     @pytest.mark.asyncio
     async def test_set_ac_charge_schedule_invalid_hour(self, mock_client: LuxpowerClient) -> None:
-        """Test invalid hour raises ValueError via pack_time."""
-        inverter = HybridInverter(
-            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
-        )
+        """Test invalid hour raises ValueError via pack_time (LOCAL path)."""
+        inverter, _transport = self._transport_inverter(mock_client)
 
         with pytest.raises(ValueError, match="Hour must be 0-23"):
             await inverter.set_ac_charge_schedule(0, 24, 0, 7, 0)

--- a/tests/unit/devices/inverters/test_parameter_fetch_sticky.py
+++ b/tests/unit/devices/inverters/test_parameter_fetch_sticky.py
@@ -26,6 +26,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from pylxpweb import LuxpowerClient
+from pylxpweb.devices.base import TRANSPORT_LINK_DOWN_THRESHOLD
 from pylxpweb.devices.inverters.generic import GenericInverter
 
 
@@ -178,6 +179,130 @@ class TestTransportParameterSticky:
 
         assert inverter.parameters_complete is True
         assert inverter._parameters_cache_time is not None
+
+
+class TestLinkDownParameterGuard:
+    """Link-down guard (#206): never walk into local parameter reads on a dead link.
+
+    The runtime/energy/battery legs of refresh() gate transport reads behind
+    ``transport_link_down`` + a rate-limited probe; ``_fetch_parameters`` did
+    not, so an ``include_parameters`` refresh could hang for minutes on a dead
+    RS485 link.  While down, skip the local read: fall back to cloud
+    named-parameter reads when a client exists, else skip entirely — preserving
+    the #282 sticky-merge semantics.
+    """
+
+    @staticmethod
+    def _down_transport() -> Mock:
+        transport = Mock()
+        transport.read_named_parameters = AsyncMock(
+            side_effect=AssertionError("local read attempted while link down")
+        )
+        return transport
+
+    @staticmethod
+    def _param_response(params: dict[str, int]) -> Mock:
+        response = Mock()
+        response.parameters = params
+        return response
+
+    @pytest.mark.asyncio
+    async def test_local_only_link_down_skips_read_and_preserves_parameters(self) -> None:
+        """No cloud fallback: the local read is skipped, parameters untouched."""
+        inverter = _make_inverter()  # client=None -> no cloud fallback
+        inverter.parameters = {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
+        inverter._transport = self._down_transport()
+        inverter._transport_consecutive_failures = TRANSPORT_LINK_DOWN_THRESHOLD
+        assert inverter.transport_link_down is True
+
+        await inverter._fetch_parameters()
+
+        # Dead-link local read never attempted (else the side_effect fires).
+        inverter._transport.read_named_parameters.assert_not_awaited()
+        # #282 sticky semantics: parameters carried, cache not stamped so the
+        # read retries once the link recovers, completeness flagged degraded.
+        assert inverter.parameters == {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
+        assert inverter.parameters_complete is False
+        assert inverter._parameters_cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_hybrid_link_down_falls_back_to_cloud(self, mock_client: LuxpowerClient) -> None:
+        """With a usable cloud client, a down link reads parameters via HTTP."""
+        inverter = _make_inverter(client=mock_client)
+        inverter._transport = self._down_transport()
+        inverter._transport_consecutive_failures = TRANSPORT_LINK_DOWN_THRESHOLD
+        assert inverter.transport_link_down is True
+
+        mock_client.api.control.read_parameters = AsyncMock(
+            side_effect=[
+                self._param_response({"HOLD_CHG_POWER_PERCENT_CMD": 60}),
+                self._param_response({"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90}),
+                self._param_response({}),
+            ]
+        )
+
+        await inverter._fetch_parameters()
+
+        # Local transport read skipped; cloud fallback used (3 ranges).
+        inverter._transport.read_named_parameters.assert_not_awaited()
+        assert mock_client.api.control.read_parameters.await_count == 3
+        assert inverter.parameters == {
+            "HOLD_CHG_POWER_PERCENT_CMD": 60,
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90,
+        }
+        assert inverter.parameters_complete is True
+        assert inverter._parameters_cache_time is not None
+
+    @pytest.mark.asyncio
+    async def test_recovered_link_reads_locally_again(self) -> None:
+        """After recovery (failure counter reset), the local read resumes."""
+        inverter = _make_inverter()
+        transport = _range_transport(
+            {
+                0: {"HOLD_CHG_POWER_PERCENT_CMD": 60},
+                125: {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90},
+            }
+        )
+        inverter._transport = transport
+        # Link recovered: a successful transport read elsewhere reset the
+        # counter, so transport_link_down is False again.
+        inverter._transport_consecutive_failures = 0
+        assert inverter.transport_link_down is False
+
+        await inverter._fetch_parameters()
+
+        assert transport.read_named_parameters.await_count == 2
+        assert inverter.parameters == {
+            "HOLD_CHG_POWER_PERCENT_CMD": 60,
+            "HOLD_SYSTEM_CHARGE_SOC_LIMIT": 90,
+        }
+        assert inverter.parameters_complete is True
+
+    @pytest.mark.asyncio
+    async def test_library_guard_holds_when_caller_does_not_pre_skip(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """Defense-in-depth: even if the caller requests parameters on a down
+        link (call-site gate missed), the library guard alone prevents the local
+        Modbus read and carried parameters survive (double-gating is harmless —
+        both layers skipping the local read is a no-op, not a conflict).
+        """
+        inverter = _make_inverter(client=mock_client)
+        inverter.parameters = {"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 101}
+        inverter._transport = self._down_transport()
+        inverter._transport_consecutive_failures = TRANSPORT_LINK_DOWN_THRESHOLD
+        mock_client.api.control.read_parameters = AsyncMock(
+            side_effect=[
+                self._param_response({"HOLD_SYSTEM_CHARGE_SOC_LIMIT": 95}),
+                self._param_response({}),
+                self._param_response({}),
+            ]
+        )
+
+        await inverter._fetch_parameters()
+
+        inverter._transport.read_named_parameters.assert_not_awaited()
+        assert inverter.parameters["HOLD_SYSTEM_CHARGE_SOC_LIMIT"] == 95
 
 
 class TestHttpParameterSticky:

--- a/tests/unit/endpoints/test_control_helpers.py
+++ b/tests/unit/endpoints/test_control_helpers.py
@@ -409,6 +409,68 @@ class TestACChargeScheduleCloud:
             "end_minute": 0,
         }
 
+    @pytest.mark.asyncio
+    async def test_get_schedule_present_but_null_field_defaults_zero(
+        self, control: ControlEndpoints
+    ) -> None:
+        """A field present-but-null must default to 0, not raise int(None)."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "HOLD_AC_CHARGE_START_HOUR": None,
+                "HOLD_AC_CHARGE_START_MINUTE": 30,
+                # END_HOUR / END_MINUTE absent entirely
+            }
+        )
+
+        schedule = await control.get_ac_charge_schedule(SERIAL, 0)
+
+        assert schedule == {
+            "start_hour": 0,
+            "start_minute": 30,
+            "end_hour": 0,
+            "end_minute": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_schedule_clamps_out_of_range(self, control: ControlEndpoints) -> None:
+        """Out-of-range cloud values are clamped to valid clock components."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "HOLD_AC_CHARGE_START_HOUR": 99,  # -> 23
+                "HOLD_AC_CHARGE_START_MINUTE": 250,  # -> 59
+                "HOLD_AC_CHARGE_END_HOUR": -5,  # -> 0
+                "HOLD_AC_CHARGE_END_MINUTE": "45",  # string coerces -> 45
+            }
+        )
+
+        schedule = await control.get_ac_charge_schedule(SERIAL, 0)
+
+        assert schedule == {
+            "start_hour": 23,
+            "start_minute": 59,
+            "end_hour": 0,
+            "end_minute": 45,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_schedule_non_numeric_defaults_zero(self, control: ControlEndpoints) -> None:
+        """Non-numeric garbage coerces to 0 rather than raising."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "HOLD_AC_CHARGE_START_HOUR": "",
+                "HOLD_AC_CHARGE_START_MINUTE": "oops",
+            }
+        )
+
+        schedule = await control.get_ac_charge_schedule(SERIAL, 0)
+
+        assert schedule == {
+            "start_hour": 0,
+            "start_minute": 0,
+            "end_hour": 0,
+            "end_minute": 0,
+        }
+
 
 class TestACChargeTypeCloud:
     """Test AC charge type cloud API methods."""

--- a/tests/unit/test_ac_first_schedule.py
+++ b/tests/unit/test_ac_first_schedule.py
@@ -187,36 +187,41 @@ class TestACFirstScheduleCloud:
 
 
 class TestACFirstScheduleModbus:
-    """Modbus wrappers write packed times to registers 152-157 via FC06."""
+    """Local (transport) path writes packed times to registers 152-157 via FC06."""
 
     @pytest.mark.asyncio
     async def test_set_ac_first_schedule_period_0(self, mock_client: LuxpowerClient) -> None:
-        inverter = HybridInverter(client=mock_client, serial_number=SERIAL, model="12000XP")
-        mock_write_response = Mock()
-        mock_write_response.success = True
-        mock_client.api.control.write_parameters = AsyncMock(return_value=mock_write_response)
+        transport = Mock()
+        transport.write_parameters = AsyncMock(return_value=True)
+        inverter = HybridInverter(
+            client=mock_client, serial_number=SERIAL, model="12000XP", transport=transport
+        )
 
         result = await inverter.set_ac_first_schedule(0, 23, 0, 7, 0)
 
         # Two individual writes (FC06) — firmware rejects FC16 multi-writes
-        # on schedule registers.
-        assert mock_client.api.control.write_parameters.call_count == 2
-        mock_client.api.control.write_parameters.assert_any_call(SERIAL, {152: 23})
-        mock_client.api.control.write_parameters.assert_any_call(SERIAL, {153: 7})
+        # on schedule registers.  reg 152 = pack_time(23, 0) = 23; reg 153 =
+        # pack_time(7, 0) = 7.
+        assert transport.write_parameters.await_count == 2
+        transport.write_parameters.assert_any_await({152: 23})
+        transport.write_parameters.assert_any_await({153: 7})
+        # Cloud raw-register write is NOT used on the transport path.
+        assert not mock_client.api.control.write_parameters.called
         assert result is True
 
     @pytest.mark.asyncio
     async def test_set_ac_first_schedule_period_2_packed(self, mock_client: LuxpowerClient) -> None:
-        inverter = HybridInverter(client=mock_client, serial_number=SERIAL, model="12000XP")
-        mock_write_response = Mock()
-        mock_write_response.success = True
-        mock_client.api.control.write_parameters = AsyncMock(return_value=mock_write_response)
+        transport = Mock()
+        transport.write_parameters = AsyncMock(return_value=True)
+        inverter = HybridInverter(
+            client=mock_client, serial_number=SERIAL, model="12000XP", transport=transport
+        )
 
         result = await inverter.set_ac_first_schedule(2, 12, 30, 14, 45)
 
         # pack_time(12, 30) = 12 | (30 << 8) = 7692; pack_time(14, 45) = 11534
-        mock_client.api.control.write_parameters.assert_any_call(SERIAL, {156: 7692})
-        mock_client.api.control.write_parameters.assert_any_call(SERIAL, {157: 11534})
+        transport.write_parameters.assert_any_await({156: 7692})
+        transport.write_parameters.assert_any_await({157: 11534})
         assert result is True
 
     @pytest.mark.asyncio
@@ -238,3 +243,47 @@ class TestACFirstScheduleModbus:
             "end_hour": 7,
             "end_minute": 30,
         }
+
+
+class TestScheduleHybridCloudWrite:
+    """Cloud (transport-less) schedule writes delegate to the named cloud setter.
+
+    Symmetric with the PR #205 read-side fix: the cloud API models schedules as
+    named per-field params (``{cloud_prefix}_START_HOUR`` etc.), not raw
+    ``reg_<n>`` writes.  ``HybridInverter._set_schedule`` used to POST a packed
+    register value to ``remoteSet/write`` keyed by register address, which would
+    not round-trip through the named cloud getter.  It now delegates to
+    ``ControlEndpoints._set_schedule``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cloud_set_delegates_to_named_setter(self, mock_client: LuxpowerClient) -> None:
+        inverter = HybridInverter(client=mock_client, serial_number=SERIAL, model="12000XP")
+        mock_client.api.control._set_schedule = AsyncMock(
+            return_value=SuccessResponse(success=True)
+        )
+        # A raw-register cloud write would go through control.write_parameters —
+        # it must NOT be used.
+        mock_client.api.control.write_parameters = AsyncMock()
+
+        result = await inverter.set_ac_first_schedule(1, 8, 30, 16, 0)
+
+        mock_client.api.control._set_schedule.assert_awaited_once_with(
+            SERIAL, ScheduleType.AC_FIRST, 1, 8, 30, 16, 0
+        )
+        assert not mock_client.api.control.write_parameters.called
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_cloud_set_propagates_failure(self, mock_client: LuxpowerClient) -> None:
+        inverter = HybridInverter(client=mock_client, serial_number=SERIAL, model="12000XP")
+        mock_client.api.control._set_schedule = AsyncMock(
+            return_value=SuccessResponse(success=False)
+        )
+
+        result = await inverter.set_forced_charge_schedule(0, 1, 0, 5, 0)
+
+        mock_client.api.control._set_schedule.assert_awaited_once_with(
+            SERIAL, ScheduleType.FORCED_CHARGE, 0, 1, 0, 5, 0
+        )
+        assert result is False


### PR DESCRIPTION
Fixes #206. Three items from the eg4_web_monitor PR #301 adversarial review.

## Item 1 — `_fetch_parameters` link-down guard (headline)

The runtime/energy/battery legs of `BaseInverter.refresh()` gate their transport reads behind `transport_link_down` + a rate-limited probe (`_link_probe_due()`), but `_fetch_parameters()` walked straight into local Modbus reads whenever a transport was attached. With an attached-but-down link, any `refresh(include_parameters=True)` could hang for minutes — Python 3.11 `asyncio.wait_for` does not interrupt an in-flight pymodbus read (Waveshare stale-RS485 3–5 min stalls).

**Fix (defense-in-depth at the library layer):** while `transport_link_down`, skip the local parameter read. Fall back to the cloud named-parameter read path when a usable client exists (`_cloud_fallback_available`), else skip entirely.

**Probe semantics decision:** no parameter-side transport probe. The runtime leg already probes the transport every interval; a successful runtime probe resets the failure counter and clears `transport_link_down`, so the next parameter refresh reads locally again. Adding a parameter probe would reintroduce exactly the multi-minute-hang risk the guard exists to avoid. This matches the runtime-leg intent (avoid the hang) while keeping parameters fresh via cloud.

**#282 sticky-merge preserved:** a skipped local read does not touch `self.parameters` or `_parameters_cache_time` (so it retries on recovery) and sets `parameters_complete = False`. Harmless double-gating with the eg4_web_monitor PR #301 call-site gate (both layers skipping is a no-op).

## Item 2 — `ControlEndpoints._get_schedule` int(None) edge

A cloud schedule field present-but-null raised `int(None)`, and the cloud path had no hour/minute clamp. Now coerces null/non-numeric → 0 and clamps hour to 0–23 / minute to 0–59 (local path already bounded by `pack_time`).

## Item 3 — `HybridInverter._set_schedule` cloud write (verified → fixed)

**Decision: broken, fixed.** For transport-less (cloud) devices, `_set_schedule` POSTed a packed-time value to a *raw register address* via `control.write_parameters`. The read-side counterpart (PR #205, Bug 1) proved the cloud API exposes schedules only as **named** per-field params (`{prefix}_START_HOUR` etc.) — there is no `reg_<n>` key — so a raw packed-register write would not round-trip through the named getter. A dedicated, portal-verified named cloud setter (`ControlEndpoints._set_schedule`) already exists and is the mirror of the getter the hybrid cloud path already delegates to.

**Fix:** the cloud path now delegates to `ControlEndpoints._set_schedule` (named `HOLD_*_{HOUR,MINUTE}`), symmetric with `_get_schedule`. The LOCAL packed-register FC06 path is unchanged. Two existing "Modbus" set tests that actually exercised the cloud path (no transport attached) are re-pointed at a genuine transport and assert packed `transport.write_parameters` writes; new tests pin the cloud delegation request shape.

## Tests
- Link-down: local skip (no cloud) preserves parameters + no stamp + `parameters_complete=False`; hybrid cloud fallback used; recovery reads locally; double-gate harmlessness.
- `_get_schedule`: present-but-null → 0, out-of-range clamp, non-numeric → 0.
- Cloud `_set_schedule` delegation (AC First + AC Charge) + transport packed-write coverage.

Gates: ruff check/format clean, `mypy src/pylxpweb` clean, **2589 passed, 4 skipped**.

No version bump. No suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)