### PR TITLE
fix: stop serving unverified FUNC_GREEN_EN bit 8 on EG4_OFFGRID

### DIFF
--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -763,12 +763,17 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
 # (buzzer -> bit 7, Battery ECO -> bit 15).  Displaced or unverifiable
 # slots become FUNC_110_BITn placeholders (same convention as register
 # 179/233 unknowns) rather than inheriting unproven 18kPV names.
-# FUNC_GREEN_EN deliberately KEEPS the 18kPV position (bit 8) for
-# continuity: no SNA hardware toggle test exists yet, and consumers
-# (green mode controls) would otherwise lose local read/write entirely.
-# If the lxp_modbus layout fully applies, green may actually be bit 14 —
-# a community toggle test (read 110, toggle Green in the EG4 cloud UI,
-# read 110 again) settles it; see eg4_web_monitor issue #197 follow-ups.
+# FUNC_GREEN_EN is deliberately ABSENT: no SNA hardware toggle test
+# exists, and lxp_modbus puts green at bit 14, not the 18kPV bit 8.  An
+# earlier revision kept the 18kPV position "for continuity", but an
+# unverified decode served as truth is worse than an honest gap — a
+# local read of bit 8 silently clobbered cloud-confirmed green-mode
+# state in hybrid setups (eg4_web_monitor #310 review), and a local
+# write would likely flip a CT-sampling config bit while reporting
+# success.  Green mode on EG4_OFFGRID is therefore cloud-only (the
+# server applies the bit correctly) until a community toggle test
+# (read 110, toggle Green in the EG4 cloud UI, read 110 again) pins the
+# bit; see eg4_web_monitor issue #197 follow-ups.
 OFFGRID_REGISTER_110_PARAM_KEYS: list[str] = [
     "FUNC_PV_GRID_OFF_EN",  # Bit 0 (all sources agree on bits 0-4)
     "FUNC_RUN_WITHOUT_GRID",  # Bit 1
@@ -778,7 +783,7 @@ OFFGRID_REGISTER_110_PARAM_KEYS: list[str] = [
     "FUNC_TAKE_LOAD_TOGETHER",  # Bit 5 (UNVERIFIED on SNA; lxp_modbus: CT ratio low bit)
     "FUNC_110_BIT6",  # Bit 6: unknown (18kPV buzzer slot; lxp_modbus: CT ratio high bit)
     "FUNC_BUZZER_EN",  # Bit 7 (SNA cloud decode + raw 0x0080; lxp_modbus agrees)
-    "FUNC_GREEN_EN",  # Bit 8 (UNVERIFIED on SNA — kept from 18kPV; lxp_modbus puts green at 14)
+    "FUNC_110_BIT8",  # Bit 8: unknown (18kPV green slot; lxp_modbus: PVCT sample type low bit)
     "FUNC_110_BIT9",  # Bit 9: unknown (18kPV ECO slot; lxp_modbus: PVCT sample type high bit)
     "BIT_WORKING_MODE",  # Bit 10 (UNVERIFIED on SNA)
     "BIT_PVCT_SAMPLE_TYPE",  # Bit 11 (UNVERIFIED on SNA)

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -2357,15 +2357,21 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         EG4 web monitoring interface.
 
         Returns:
-            True if green mode is enabled, False if disabled,
-            or None if parameters not loaded
+            True if green mode is enabled, False if disabled, or None when
+            the status is UNKNOWN: parameters not loaded, or the loaded
+            parameters do not carry ``FUNC_GREEN_EN`` at all. The latter is
+            the EG4_OFFGRID local-read case — the SNA register-110 bit for
+            green is unverified, so local reads deliberately omit the key
+            and absence must not masquerade as "disabled".
 
         Example:
             >>> enabled = inverter.green_mode_enabled
             >>> enabled
             True
         """
-        value = self._get_parameter("FUNC_GREEN_EN", False, bool)
+        if self.parameters is None:
+            return None
+        value = self.parameters.get("FUNC_GREEN_EN")
         return bool(value) if value is not None else None
 
     # ============================================================================

--- a/tests/unit/devices/inverters/test_base.py
+++ b/tests/unit/devices/inverters/test_base.py
@@ -1197,3 +1197,46 @@ class TestWorkingModeControls:
         # Verify correct endpoint call
         mock_client.api.control.get_peak_shaving_mode_status.assert_called_once_with("1234567890")
         assert status is True
+
+
+class TestGreenModeEnabledProperty:
+    """green_mode_enabled distinguishes absent (unknown) from disabled.
+
+    EG4_OFFGRID local parameter reads deliberately omit FUNC_GREEN_EN
+    (the SNA register-110 bit is unverified), so an absent key means the
+    status is UNKNOWN — returning False for it would report a
+    cloud-enabled inverter as "disabled" after any successful local
+    parameter refresh (eg4_web_monitor #310 review round 2).
+    """
+
+    def test_none_when_parameters_not_loaded(self, mock_client: LuxpowerClient) -> None:
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        assert inverter.parameters is None
+        assert inverter.green_mode_enabled is None
+
+    def test_none_when_key_absent_from_loaded_parameters(self, mock_client: LuxpowerClient) -> None:
+        """Offgrid local read: params loaded, FUNC_GREEN_EN not served."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        inverter.parameters = {"FUNC_BUZZER_EN": True, "FUNC_CHARGE_LAST": False}
+        assert inverter.green_mode_enabled is None
+
+    def test_true_when_enabled(self, mock_client: LuxpowerClient) -> None:
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        inverter.parameters = {"FUNC_GREEN_EN": True}
+        assert inverter.green_mode_enabled is True
+
+    def test_false_when_disabled(self, mock_client: LuxpowerClient) -> None:
+        """A present falsy value (bool or raw int 0) is a real 'disabled'."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        inverter.parameters = {"FUNC_GREEN_EN": False}
+        assert inverter.green_mode_enabled is False
+        inverter.parameters = {"FUNC_GREEN_EN": 0}
+        assert inverter.green_mode_enabled is False

--- a/tests/unit/transports/test_named_parameters.py
+++ b/tests/unit/transports/test_named_parameters.py
@@ -772,10 +772,14 @@ class TestOffgridRegister110Override:
         assert len(layout) == 16
         assert layout.index("FUNC_BATTERY_ECO_EN") == 15
         assert layout.index("FUNC_BUZZER_EN") == 7
-        # Green deliberately keeps the 18kPV position until SNA-verified.
-        assert layout.index("FUNC_GREEN_EN") == 8
+        # Green is NOT served on SNA: the 18kPV bit 8 is unverified there
+        # (lxp_modbus puts green at 14), and the unverified decode silently
+        # clobbered cloud-confirmed state in hybrid setups
+        # (eg4_web_monitor #310 review).
+        assert "FUNC_GREEN_EN" not in layout
         # Displaced 18kPV names become placeholders, not silent reuse.
         assert layout[6] == "FUNC_110_BIT6"
+        assert layout[8] == "FUNC_110_BIT8"
         assert layout[9] == "FUNC_110_BIT9"
         assert layout[14] == "FUNC_110_BIT14"
         assert "FUNC_GO_TO_OFFGRID" not in layout
@@ -868,6 +872,33 @@ class TestOffgridRegister110Override:
         assert result is True
         offgrid_transport.write_parameters.assert_called_once_with({110: 0x0090})
 
+    @pytest.mark.asyncio
+    async def test_offgrid_green_write_fails_closed(
+        self, offgrid_transport: ModbusTransport
+    ) -> None:
+        """FUNC_GREEN_EN writes on SNA raise instead of flipping bit 8.
+
+        The bit position is unverified on this family (lxp_modbus puts
+        green at 14); a bit-8 write would likely flip a CT-sampling
+        config bit while reporting success.  Cloud-only until pinned.
+        """
+        offgrid_transport.read_parameters = AsyncMock(return_value={110: 0x0080})
+
+        with pytest.raises(ValueError, match="FUNC_GREEN_EN"):
+            await offgrid_transport.write_named_parameters({"FUNC_GREEN_EN": True})
+
+        offgrid_transport.write_parameters.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_hybrid_green_still_writes_bit_8(self, hybrid_transport: ModbusTransport) -> None:
+        """EG4_HYBRID keeps the 18kPV-verified green bit 8 (regression pin)."""
+        hybrid_transport.read_parameters = AsyncMock(return_value={110: 0x0000})
+
+        result = await hybrid_transport.write_named_parameters({"FUNC_GREEN_EN": True})
+
+        assert result is True
+        hybrid_transport.write_parameters.assert_called_once_with({110: 0x0100})
+
     # ------------------------------------------------------------------
     # Read path (decode)
     # ------------------------------------------------------------------
@@ -881,7 +912,9 @@ class TestOffgridRegister110Override:
 
         assert result["FUNC_BATTERY_ECO_EN"] is True
         assert result["FUNC_BUZZER_EN"] is True
-        assert result["FUNC_GREEN_EN"] is False
+        # Green is not decoded on SNA (bit 8 unverified) — an unverified
+        # False here clobbered cloud-confirmed state (eg4_web_monitor #310).
+        assert "FUNC_GREEN_EN" not in result
 
     @pytest.mark.asyncio
     async def test_offgrid_decode_eco_off(self, offgrid_transport: ModbusTransport) -> None:


### PR DESCRIPTION
Found during the eg4_web_monitor #310 Codex adversarial review (joyfulhouse/eg4_web_monitor#311).

## Problem
`OFFGRID_REGISTER_110_PARAM_KEYS` mapped bit 8 → `FUNC_GREEN_EN` with its own comment saying **UNVERIFIED on SNA** ("kept from 18kPV; lxp_modbus puts green at 14"). Unverified decode served as truth violates the table's own convention (displaced/unverifiable slots become `FUNC_110_BITn` placeholders) and caused real harm:

- **Reads**: in HYBRID setups, a local parameter read of the untrusted bit-8 value silently clobbered cloud-confirmed green-mode state (including the new eg4 #310 `note_parameters_written` seed) after link recovery.
- **Writes**: a bit-8 write on SNA hardware would likely flip a CT-sampling config bit (lxp_modbus: PVCT sample field at 8-9) while reading back as success — the exact failure mode that made eg4_web_monitor withhold offgrid green local writes (`cloud_only`) in the first place.

## Fix
- Bit 8 → `FUNC_110_BIT8` placeholder ("18kPV green slot; lxp_modbus: PVCT sample type low bit").
- Header comment rewritten: green on EG4_OFFGRID is cloud-only until a community toggle test (read 110 → toggle Green in the EG4 cloud UI → read 110) pins the bit; see eg4_web_monitor #197 follow-ups.
- All other families keep the hardware-verified 18kPV bit 8 layout.

## Behavior change (EG4_OFFGRID local access only)
- `read_named_parameters` no longer emits `FUNC_GREEN_EN` (honest gap instead of untrusted False/True).
- `write_named_parameters({"FUNC_GREEN_EN": ...})` fails closed with `ValueError: Unknown parameter name` instead of flipping a suspect bit.
- Cloud path (`control_function` / `enable_green_mode`) unaffected — the server applies the bit correctly.

## Tests
- Offgrid layout: `FUNC_GREEN_EN` absent, `layout[8] == "FUNC_110_BIT8"` (placeholder convention held).
- Offgrid decode: result contains no `FUNC_GREEN_EN`.
- Offgrid write: raises `ValueError`, no register write issued (fails closed).
- Hybrid regression pin: `FUNC_GREEN_EN` still writes bit 8 (`0x0100`).

**Suite: 2600 passed, 4 skipped.** mypy (pydantic plugin): clean, 94 files. ruff: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Codex round 2 (coupled absent-key fix)

- **`BaseInverter.green_mode_enabled`**: `_get_parameter("FUNC_GREEN_EN", False, bool)` turned the now-absent key into `False`, reporting a cloud-enabled inverter as "disabled" after any successful local parameter refresh. The property now honors its documented `bool | None` contract: `None` when parameters aren't loaded **or** the loaded parameters don't carry the key (the EG4_OFFGRID local-read case); a present falsy value (`False`/raw `0`) remains a real "disabled". No other callers in src or downstream eg4_web_monitor.
- Tests: not-loaded → None, loaded-without-key → None, True → True, False/0 → False.
- Downstream counterpart: joyfulhouse/eg4_web_monitor#311 makes the Off-Grid Mode switch report `unknown` for the absent key.

**Suite: 2604 passed, 4 skipped.** mypy + ruff clean.
