### PR TITLE
feat: proven-capable transports never permanently latch coalescing off + re-probe logging (eg4_web_monitor#320)

### DIFF
--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -1012,7 +1012,12 @@ class RegisterDataMixin(_DataMixinBase):
                 block, f"short response ({len(values)}/{block.count} registers)"
             )
             raise _CoalescedReadFallback()
-        if block.coalesced:
+        # Only a read that actually EXCEEDED the conservative ~40-register cap
+        # proves large-read support: a <=40-register merge could succeed on
+        # old-cap firmware, so it must not count as proof.  (Today every real
+        # INPUT_REGISTER_GROUPS merge already spans >=48, so this gate is
+        # defense-in-depth against a future group-table edit, not the layout.)
+        if block.coalesced and block.count > DEFAULT_INPUT_BLOCK_SIZE:
             self._note_coalescing_proven()
         return values
 

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -837,15 +837,28 @@ class RegisterDataMixin(_DataMixinBase):
         has failed and latched the transport back (``eg4_web_monitor#254``),
         or during the post-mismatch cooldown (#320) — the plan is exactly one
         read per group, byte-identical to the pre-feature behavior.
+
+        When a cooldown expires the transport re-probes coalescing and logs it
+        once (the re-arm was previously silent), so operators can confirm the
+        connection returned to large-read mode (#320).
         """
         max_size = getattr(self, "_max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE)
-        in_cooldown = time.monotonic() < getattr(self, "_input_coalescing_retry_after", 0.0)
-        if (
-            max_size <= DEFAULT_INPUT_BLOCK_SIZE
-            or getattr(self, "_input_coalescing_latched_off", False)
-            or in_cooldown
+        if max_size <= DEFAULT_INPUT_BLOCK_SIZE or getattr(
+            self, "_input_coalescing_latched_off", False
         ):
             return self._plain_input_plan(groups)
+
+        retry_after = getattr(self, "_input_coalescing_retry_after", 0.0)
+        if retry_after:
+            if time.monotonic() < retry_after:
+                return self._plain_input_plan(groups)
+            # Cooldown elapsed: clear it and re-probe.  Clearing means this
+            # DEBUG line fires once at the re-arm, not every subsequent cycle.
+            self._input_coalescing_retry_after = 0.0
+            _LOGGER.debug(
+                "[%s] coalescing cooldown expired — re-probing large input reads",
+                self._serial,
+            )
         return coalesce_register_groups(groups, max_size)
 
     @staticmethod
@@ -871,8 +884,11 @@ class RegisterDataMixin(_DataMixinBase):
         (until the transport is recreated, e.g. on reload) instead of
         re-paying retries every poll cycle.  A short (truncated) frame trips
         the same latch.  Misrouted frames do NOT reach here — they fall back
-        for one cycle without latching (see :meth:`_read_block`, #320) — so
-        this warning always points at a genuine large-read refusal.
+        for one cycle without latching (see :meth:`_read_block`, #320).  Nor
+        does any failure once the transport has *proven* large-read support
+        (:meth:`_degrade_coalescing`), so this permanent latch is reserved for
+        a transport that has NEVER completed a coalesced read — the genuine
+        old-firmware signal.
         """
         self._input_coalescing_latched_off = True
         _LOGGER.warning(
@@ -891,6 +907,58 @@ class RegisterDataMixin(_DataMixinBase):
             reason,
         )
 
+    def _start_coalescing_cooldown(self, block: _ReadBlock, reason: object, note: str) -> None:
+        """Fall back to plain reads for a cooldown window instead of latching.
+
+        Used both for a misrouted/unsolicited frame (never a firmware signal)
+        and for any failure once the transport has proven large-read support.
+        Either way the failure is transient, so coalescing re-probes after
+        :data:`COALESCING_MISMATCH_COOLDOWN` rather than latching permanently
+        (#320).  ``note`` names the cause in the log.
+        """
+        self._input_coalescing_retry_after = time.monotonic() + COALESCING_MISMATCH_COOLDOWN
+        _LOGGER.debug(
+            "[%s] Coalesced input-register read %d-%d %s (%s) — falling back to "
+            "grouped reads; coalescing re-probes in ~%d minutes (#320)",
+            self._serial,
+            block.start,
+            block.start + block.count - 1,
+            note,
+            reason,
+            int(COALESCING_MISMATCH_COOLDOWN // 60),
+        )
+
+    def _degrade_coalescing(self, block: _ReadBlock, reason: object) -> None:
+        """Degrade coalescing after a genuine failure (exception or short read).
+
+        Latch permanently only if this transport has NEVER completed a
+        coalesced read — the true old-firmware probe.  Once a coalesced read
+        has ever succeeded (:attr:`_input_coalescing_proven`) the firmware has
+        proven it serves large reads, so a later failure can't mean the
+        ~40-register cap; treat it as transient via the cooldown instead of a
+        permanent latch (#320, reporter ivanfmartinez).
+        """
+        if getattr(self, "_input_coalescing_proven", False):
+            self._start_coalescing_cooldown(
+                block, reason, "failed but large-read support was already proven"
+            )
+        else:
+            self._latch_input_coalescing_off(block, reason)
+
+    def _note_coalescing_proven(self) -> None:
+        """Record that a coalesced read succeeded; log once on first proof.
+
+        The log fires only on the False->True transition, so it is one line
+        per transport (at startup or after a cooldown re-probe) and doubles as
+        the operator's confirmation that large-read mode is active (#320).
+        """
+        if not getattr(self, "_input_coalescing_proven", False):
+            self._input_coalescing_proven = True
+            _LOGGER.debug(
+                "[%s] Coalesced input read succeeded — large-read support confirmed",
+                self._serial,
+            )
+
     async def _read_block(self, block: _ReadBlock) -> list[int]:
         """Read one planned block.
 
@@ -899,53 +967,53 @@ class RegisterDataMixin(_DataMixinBase):
         cycle with plain group reads.  Plain (single-group) reads propagate
         errors unchanged, preserving the existing per-group semantics.
 
-        The one coalesced error that does **not** latch is a
-        :class:`TransportResponseMismatchError` — a misrouted or interleaved
-        frame (the WiFi dongle proxies cloud traffic, so a response meant for
-        the cloud server can land on a local reader; an unsolicited heartbeat
-        counts too).  A misrouted frame says nothing about the firmware's
-        ability to serve large reads, so latching off it would wrongly disable
-        coalescing for the whole transport lifetime (eg4_web_monitor#320).
-        Instead it falls back to grouped reads and starts a short cooldown
-        (:data:`COALESCING_MISMATCH_COOLDOWN`) during which reads stay plain,
-        then re-probes coalescing once — bounding the retry cost under
-        persistent misrouting without a permanent latch.  The per-read dongle
-        transport already retries 3x, so an escaping mismatch is rare (no
-        strike counter needed).
+        Two coalesced errors do **not** latch:
+
+        * A :class:`TransportResponseMismatchError` — a misrouted or
+          interleaved frame (the WiFi dongle proxies cloud traffic, so a
+          response meant for the cloud server can land on a local reader; an
+          unsolicited heartbeat counts too).  It says nothing about large-read
+          support, so it starts a cooldown instead of latching.
+        * ANY failure once the transport has proven large-read support (a
+          coalesced read has completed at least once).  Proven capability
+          rules out the old ~40-register cap, so a later exception/short read
+          is transient and also uses the cooldown (:meth:`_degrade_coalescing`,
+          #320 reporter ivanfmartinez — his dongle served coalesced reads for
+          minutes, then one bad frame would have latched permanently).
+
+        An unproven transport keeps the permanent latch on a genuine
+        exception/short read — the true old-firmware probe.  During the
+        cooldown reads stay plain, then coalescing re-probes once.  The
+        per-read dongle transport already retries 3x, so an escaping mismatch
+        is rare (no strike counter needed).
         """
         try:
             values = await self._read_input_registers(block.start, block.count)
         except TransportResponseMismatchError as err:
             if block.coalesced:
-                self._input_coalescing_retry_after = time.monotonic() + COALESCING_MISMATCH_COOLDOWN
-                _LOGGER.debug(
-                    "[%s] Coalesced input-register read %d-%d hit a misrouted "
-                    "response (%s) — falling back to grouped reads; coalescing "
-                    "re-probes in ~%d minutes (#320)",
-                    self._serial,
-                    block.start,
-                    block.start + block.count - 1,
-                    err,
-                    int(COALESCING_MISMATCH_COOLDOWN // 60),
-                )
+                self._start_coalescing_cooldown(block, err, "hit a misrouted response")
                 raise _CoalescedReadFallback() from err
             raise
         except Exception as err:
             if block.coalesced:
-                self._latch_input_coalescing_off(block, err)
+                self._degrade_coalescing(block, err)
                 raise _CoalescedReadFallback() from err
             raise
         if block.coalesced and len(values) < block.count:
             # A short-but-well-formed response (matching serial/function/start
             # register, valid CRC, just fewer registers) is the classic
             # signature of the old ~40-register firmware cap this probe exists
-            # to detect — so it LATCHES, unlike a misrouted frame.  A misrouted
-            # frame passing all three identity checks *including* start register
-            # yet truncated is too narrow a coincidence to design around (#320).
-            self._latch_input_coalescing_off(
+            # to detect — so on an UNPROVEN transport it latches, unlike a
+            # misrouted frame.  A misrouted frame passing all three identity
+            # checks *including* start register yet truncated is too narrow a
+            # coincidence to design around (#320).  On a proven transport
+            # _degrade_coalescing treats it as transient (cooldown) instead.
+            self._degrade_coalescing(
                 block, f"short response ({len(values)}/{block.count} registers)"
             )
             raise _CoalescedReadFallback()
+        if block.coalesced:
+            self._note_coalescing_proven()
         return values
 
     async def _read_register_groups(

--- a/tests/unit/transports/test_input_block_coalescing.py
+++ b/tests/unit/transports/test_input_block_coalescing.py
@@ -545,6 +545,180 @@ class TestMisroutedFrameNoLatch:
 
 
 # ---------------------------------------------------------------------------
+# Proven-capable flag: once large reads work, a later failure never latches
+# (eg4_web_monitor#320, reporter ivanfmartinez)
+# ---------------------------------------------------------------------------
+
+
+class TestProvenCapableNoLatch:
+    """A transport that has ever completed a coalesced read never latches (#320).
+
+    A successful coalesced read proves the firmware serves large reads, so no
+    later failure (exception, timeout, short frame) can mean the old
+    ~40-register cap.  Proven transports degrade transiently (cooldown), only
+    an UNPROVEN transport keeps the permanent latch (the true old-firmware
+    probe).  This is the reporter's scenario: coalesced reads worked for
+    minutes, then one bad frame — which under the prior code would have
+    latched permanently for a non-mismatch error.
+    """
+
+    @staticmethod
+    def _reg_values(start: int, count: int) -> list[int]:
+        vals = [0] * count
+        for reg, value in ((4, _VOLTAGE_RAW), (5, _SOC_SOH_PACKED)):
+            if start <= reg < start + count:
+                vals[reg - start] = value
+        return vals
+
+    @pytest.mark.asyncio
+    async def test_proven_transport_generic_error_uses_cooldown_not_latch(self) -> None:
+        transport = _transport(max_input_block_size=120)
+        state = {"fail": False}
+        calls: list[tuple[int, int]] = []
+
+        async def fake_read(start: int, count: int) -> list[int]:
+            calls.append((start, count))
+            if (start, count) == (0, 113) and state["fail"]:
+                raise TransportReadError("transient CRC error after minutes of success")
+            return self._reg_values(start, count)
+
+        mock_time = MagicMock()
+        with (
+            patch.object(_register_data, "time", mock_time),
+            patch.object(transport, "_read_input_registers", side_effect=fake_read),
+        ):
+            # Cycle 1 @ t=1000: coalesced read succeeds -> transport is proven.
+            mock_time.monotonic.return_value = 1000.0
+            await transport.read_all_input_data()
+            assert transport._input_coalescing_proven is True
+            assert calls == _COALESCED_READS_120
+
+            # Cycle 2 @ t=1050: coalesced read fails with a generic (non-mismatch)
+            # error.  Proven -> NO permanent latch; cooldown stamped; plain fallback.
+            state["fail"] = True
+            calls.clear()
+            mock_time.monotonic.return_value = 1050.0
+            await transport.read_all_input_data()
+            assert transport._input_coalescing_latched_off is False
+            assert transport._input_coalescing_retry_after == pytest.approx(
+                1050.0 + COALESCING_MISMATCH_COOLDOWN
+            )
+            assert calls == [(0, 113), *_GROUPED_READS]
+
+            # Cycle 3 inside the cooldown: stays plain.
+            calls.clear()
+            mock_time.monotonic.return_value = 1050.0 + COALESCING_MISMATCH_COOLDOWN - 1.0
+            await transport.read_all_input_data()
+            assert calls == _GROUPED_READS
+
+            # Cycle 4 past the cooldown, error cleared: coalescing re-probes.
+            state["fail"] = False
+            calls.clear()
+            mock_time.monotonic.return_value = 1050.0 + COALESCING_MISMATCH_COOLDOWN + 1.0
+            await transport.read_all_input_data()
+            assert calls == _COALESCED_READS_120
+
+    @pytest.mark.asyncio
+    async def test_proven_transport_short_read_uses_cooldown_not_latch(self) -> None:
+        transport = _transport(max_input_block_size=120)
+        state = {"short": False}
+        calls: list[tuple[int, int]] = []
+
+        async def fake_read(start: int, count: int) -> list[int]:
+            calls.append((start, count))
+            if (start, count) == (0, 113) and state["short"]:
+                return [0] * 5  # truncated coalesced frame
+            return self._reg_values(start, count)
+
+        mock_time = MagicMock()
+        with (
+            patch.object(_register_data, "time", mock_time),
+            patch.object(transport, "_read_input_registers", side_effect=fake_read),
+        ):
+            mock_time.monotonic.return_value = 1000.0
+            await transport.read_all_input_data()
+            assert transport._input_coalescing_proven is True
+
+            state["short"] = True
+            calls.clear()
+            mock_time.monotonic.return_value = 1100.0
+            await transport.read_all_input_data()
+
+            assert transport._input_coalescing_latched_off is False
+            assert transport._input_coalescing_retry_after == pytest.approx(
+                1100.0 + COALESCING_MISMATCH_COOLDOWN
+            )
+            assert calls == [(0, 113), *_GROUPED_READS]
+
+    @pytest.mark.asyncio
+    async def test_unproven_transport_generic_error_latches(self) -> None:
+        """An UNPROVEN transport keeps the permanent latch (old-firmware probe)."""
+        transport = _transport(max_input_block_size=120)
+
+        async def fake_read(start: int, count: int) -> list[int]:
+            if (start, count) == (0, 113):  # fails on the very first coalesced read
+                raise TransportReadError("old firmware: large read unsupported")
+            return self._reg_values(start, count)
+
+        with patch.object(transport, "_read_input_registers", side_effect=fake_read):
+            await transport.read_all_input_data()
+
+        assert transport._input_coalescing_latched_off is True
+        assert getattr(transport, "_input_coalescing_proven", False) is False
+
+    @pytest.mark.asyncio
+    async def test_proven_confirmation_logged_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The False->True proven transition logs exactly once per transport."""
+        transport = _transport(max_input_block_size=120)
+        fake = _make_fake_read()
+
+        with (
+            caplog.at_level(logging.DEBUG, logger="pylxpweb.transports._register_data"),
+            patch.object(transport, "_read_input_registers", side_effect=fake),
+        ):
+            await transport.read_all_input_data()
+            await transport.read_all_input_data()  # second success, already proven
+
+        confirmations = [r for r in caplog.records if "large-read support confirmed" in r.message]
+        assert len(confirmations) == 1
+        assert transport._input_coalescing_proven is True
+
+    @pytest.mark.asyncio
+    async def test_cooldown_expiry_logs_reprobe_once(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Cooldown expiry logs the re-probe once (re-arm was previously silent)."""
+        transport = _transport(max_input_block_size=120)
+        raised = {"done": False}
+
+        async def fake_read(start: int, count: int) -> list[int]:
+            if (start, count) == (0, 113) and not raised["done"]:
+                raised["done"] = True
+                raise TransportResponseMismatchError("misrouted cloud frame")
+            return self._reg_values(start, count)
+
+        mock_time = MagicMock()
+        with (
+            caplog.at_level(logging.DEBUG, logger="pylxpweb.transports._register_data"),
+            patch.object(_register_data, "time", mock_time),
+            patch.object(transport, "_read_input_registers", side_effect=fake_read),
+        ):
+            # Mismatch stamps the cooldown at t=1000.
+            mock_time.monotonic.return_value = 1000.0
+            await transport.read_all_input_data()
+
+            # Past the cooldown: the re-probe fires the DEBUG line...
+            mock_time.monotonic.return_value = 1000.0 + COALESCING_MISMATCH_COOLDOWN + 1.0
+            await transport.read_all_input_data()
+            # ...and does NOT repeat on the following cycle (retry_after cleared).
+            await transport.read_all_input_data()
+
+        reprobes = [r for r in caplog.records if "coalescing cooldown expired" in r.message]
+        assert len(reprobes) == 1
+        assert transport._input_coalescing_retry_after == 0.0
+
+
+# ---------------------------------------------------------------------------
 # TransportConfig plumbing (hybrid attach path)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/transports/test_input_block_coalescing.py
+++ b/tests/unit/transports/test_input_block_coalescing.py
@@ -32,6 +32,7 @@ from pylxpweb.transports._register_data import (
     DEFAULT_INPUT_BLOCK_SIZE,
     INPUT_REGISTER_GROUPS,
     MAX_INPUT_BLOCK_SIZE,
+    _ReadBlock,
     coalesce_register_groups,
 )
 from pylxpweb.transports.config import TransportConfig, TransportType
@@ -682,6 +683,28 @@ class TestProvenCapableNoLatch:
         confirmations = [r for r in caplog.records if "large-read support confirmed" in r.message]
         assert len(confirmations) == 1
         assert transport._input_coalescing_proven is True
+
+    @pytest.mark.asyncio
+    async def test_proof_requires_span_above_conservative_cap(self) -> None:
+        """Only a merged read wider than the ~40-register cap counts as proof.
+
+        A <=40-register merge could succeed on old-cap firmware, so it must not
+        prove large-read support — otherwise a future group-table edit that
+        produced a small merge could wrongly disarm the old-firmware latch.
+        """
+        transport = _transport(max_input_block_size=120)
+
+        async def ok_read(start: int, count: int) -> list[int]:
+            return [0] * count
+
+        with patch.object(transport, "_read_input_registers", side_effect=ok_read):
+            # A 40-register (== cap) coalesced read succeeds but does NOT prove.
+            await transport._read_block(_ReadBlock(("a", "b"), 0, DEFAULT_INPUT_BLOCK_SIZE))
+            assert getattr(transport, "_input_coalescing_proven", False) is False
+
+            # A 41-register (> cap) coalesced read proves large-read support.
+            await transport._read_block(_ReadBlock(("a", "b"), 0, DEFAULT_INPUT_BLOCK_SIZE + 1))
+            assert transport._input_coalescing_proven is True
 
     @pytest.mark.asyncio
     async def test_cooldown_expiry_logs_reprobe_once(


### PR DESCRIPTION
## Background

Follow-up to #211 (b25) for joyfulhouse/eg4_web_monitor#320. Reporter **@ivanfmartinez** (HYBRID, WiFi dongle, Fast block-size mode) tested the shipped fix and suggested two enhancements in the same code area.

## 1. Proven-capable flag (reporter's suggestion)

Once a coalesced input read has **ever** succeeded on a transport, the firmware has proven it supports large reads — so no later failure can mean the old ~40-register firmware cap, and the permanent latch is never the right response.

- `_read_block` sets `_input_coalescing_proven` on a successful coalesced read.
- The failure paths (generic exception **and** short response) now route through `_degrade_coalescing`, which — when the transport is proven — stamps the existing ~5-minute cooldown instead of latching, logging at DEBUG that large-read support was already proven so the failure is treated as transient.
- The permanent latch remains **only** for a transport that has never completed a coalesced read — the true old-firmware probe.

This fixes the reporter's exact scenario: his dongle served coalesced reads for ~4 minutes, then hit one misrouted frame. Under b25 a *non-mismatch* error at that point (CRC, timeout, short read) would still have latched permanently despite proven capability. Now it degrades transiently and re-probes.

## 2. Re-probe observability

The reporter asked "how do I confirm it returned to 120-register mode?" — the re-arm was silent.

- `_plan_input_reads` logs one DEBUG line when the cooldown expires and coalescing is re-probed (`coalescing cooldown expired — re-probing large input reads`), clearing `retry_after` so it fires once at the re-arm, not every cycle.
- The first successful coalesced read after startup or a cooldown logs once on the False→True proven transition (`coalesced input read succeeded — large-read support confirmed`), doubling as the operator's confirmation that large-read mode is active.

## Unchanged

Short-but-well-formed responses still latch on an **unproven** transport — that truncated-frame signature is exactly what the old-firmware probe exists to detect. Only a proven transport reclassifies them as transient.

## Tests

- Proven transport + generic error → no latch, cooldown stamped, plain fallback for the cycle, re-probe after cooldown.
- Proven transport + short read → cooldown, not latch.
- Unproven transport + generic error → permanent latch (unchanged old-firmware probe).
- Proven-confirmation and cooldown-expiry DEBUG lines each fire exactly once.

Gates: `ruff` clean, `.venv/bin/mypy src/pylxpweb` clean (94 files), full suite **2664 passed**.

Credit: enhancement suggested by @ivanfmartinez on joyfulhouse/eg4_web_monitor#320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)