### PR TITLE
feat: expose epsLoadPower as eps_load_power property (eg4#335)

### DIFF
--- a/src/pylxpweb/devices/inverters/_runtime_properties.py
+++ b/src/pylxpweb/devices/inverters/_runtime_properties.py
@@ -724,6 +724,31 @@ class InverterRuntimePropertiesMixin:
             return None
         return self._runtime.gridLoadPower
 
+    @property
+    def eps_load_power(self) -> int | None:
+        """Get EPS-loads output power in watts.
+
+        Cloud-only field (``epsLoadPower``): the EPS-loads subset of the
+        backup-path output. Distinct from the COMBINED backup figures — ``peps``
+        / ``pEpsL1N`` / ``pEpsL2N`` (and their Modbus counterparts, input
+        registers 129/130) carry the combined backup output, verified as the
+        summed legs in eg4_web_monitor#335. On the EG4 Off-Grid family the cloud
+        splits that combined output into ``smartLoadPower`` (GEN port) +
+        ``epsLoadPower`` (EPS loads) + ``gridLoadPower``, the same identity that
+        feeds :attr:`consumption_power` (live-confirmed on a 6000XP: peps
+        3371 W = smartLoadPower 2999 W + epsLoadPower 365 W, GH
+        eg4_web_monitor#222). There is therefore no validated local register for
+        the EPS-loads subset alone, so this reads the HTTP runtime even in
+        HYBRID mode — mirroring :attr:`smart_load_power` / :attr:`grid_load_power`.
+
+        Returns:
+            EPS load power in watts, or None when cloud runtime data is
+            unavailable (for example pure-LOCAL operation).
+        """
+        if self._runtime is None:
+            return None
+        return self._runtime.epsLoadPower
+
     # ===========================================
     # Status & Info Properties
     # ===========================================

--- a/tests/unit/devices/inverters/test_runtime_properties.py
+++ b/tests/unit/devices/inverters/test_runtime_properties.py
@@ -464,13 +464,16 @@ class TestSmartLoadProperties:
         inverter = inverter_with_runtime
         inverter._runtime.smartLoadPower = 2999
         inverter._runtime.gridLoadPower = 0
+        inverter._runtime.epsLoadPower = 365
         assert inverter.smart_load_power == 2999
         assert inverter.grid_load_power == 0
+        assert inverter.eps_load_power == 365
 
     def test_none_without_runtime(self, inverter_without_runtime):
         """No cloud runtime → None (sensor unavailable, not a false 0)."""
         assert inverter_without_runtime.smart_load_power is None
         assert inverter_without_runtime.grid_load_power is None
+        assert inverter_without_runtime.eps_load_power is None
 
     def test_hybrid_transport_does_not_mask_cloud_value(self, inverter_with_transport):
         """HYBRID: attached transport must NOT short-circuit the cloud read.
@@ -488,6 +491,7 @@ class TestSmartLoadProperties:
         )
         assert inverter.smart_load_power == 2999
         assert inverter.grid_load_power == 0
+        assert inverter.eps_load_power == 365
 
     def test_hybrid_transport_without_cloud_is_none(self, inverter_with_transport):
         """Transport attached but no cloud runtime yet → None, not 0."""
@@ -495,6 +499,7 @@ class TestSmartLoadProperties:
         inverter._runtime = None
         assert inverter.smart_load_power is None
         assert inverter.grid_load_power is None
+        assert inverter.eps_load_power is None
 
 
 class TestConsumptionPowerCloudFallback:


### PR DESCRIPTION
## Summary

Adds an `eps_load_power` runtime property to `_runtime_properties.py`, mirroring the #222 siblings `smart_load_power` / `grid_load_power`. The EG4 integration's `eps_load_power` sensor (eg4_web_monitor#335/#336) resolves this via its property map; until the property existed the sensor was absent.

```python
@property
def eps_load_power(self) -> int | None:
    if self._runtime is None:
        return None
    return self._runtime.epsLoadPower
```

## Semantics (documented in the docstring)

- **Cloud-only field** (`epsLoadPower`): the EPS-loads subset of the backup-path output. No transport-runtime source.
- Input registers **129/130** (`peps` / `pEpsL1N` / `pEpsL2N`) carry the **COMBINED** backup output — verified as the summed legs in eg4_web_monitor#335 — so they are *not* the EPS-loads subset.
- On the EG4 Off-Grid family the cloud splits the combined backup output into `smartLoadPower` (GEN port) + `epsLoadPower` (EPS loads) + `gridLoadPower`, the same identity that feeds `consumption_power` (live-confirmed on a 6000XP: peps 3371 W = smartLoadPower 2999 W + epsLoadPower 365 W, eg4_web_monitor#222).
- Therefore it reads the HTTP runtime even in HYBRID mode (returns `None`, never a false 0, in pure-LOCAL), exactly like `smart_load_power` / `grid_load_power`.

## Export-list check

`smart_load_power`'s only reference outside the property file is a **transport input-register** artifact — input reg 232 is RE-named `smart_load_power` in `inverter_input.py` and mapped to `None` (read-but-drop) in `_field_mappings.py`'s completeness contract. The true cloud-only sibling `grid_load_power` has **no** such entry. `eps_load_power` (also cloud-only, no register) correctly needs none — nothing to mirror there.

## Tests

Extended the existing `TestSmartLoadProperties` cases (`test_runtime_properties.py`) to assert `eps_load_power` alongside its siblings: cloud runtime present → 365; no runtime → None; HYBRID transport + cloud runtime → 365; transport-only (no cloud) → None.

## Gates

- `ruff check src/ tests/ --fix` — passed; `ruff format` — clean (210 files)
- `.venv/bin/mypy src/pylxpweb` — Success, no issues (94 files)
- `pytest tests/` — 2686 passed, 80 deselected

Note: eg4_web_monitor's `KNOWN_SEAM_GAPS` staleness guard will force removal of the seam-gap entry once this ships — expected.

Refs eg4_web_monitor#335, #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)