### PR TITLE
docs: document network serial bridge (proxy) URL ports (#180)

### DIFF
--- a/src/pylxpweb/transports/modbus_serial.py
+++ b/src/pylxpweb/transports/modbus_serial.py
@@ -47,6 +47,19 @@ class ModbusSerialTransport(BaseModbusTransport):
     This transport connects directly to the inverter via a USB-to-RS485
     serial adapter using Modbus RTU protocol.
 
+    Network Serial Bridges (Proxies)
+    --------------------------------
+    The ``port`` argument is passed straight through to pymodbus'
+    ``AsyncModbusSerialClient``, which opens it via pyserial's
+    ``serial.serial_for_url``. Any pyserial URL therefore works without code
+    changes, so a remote RS485 adapter can be reached over the network:
+
+        # Raw TCP serial bridge
+        transport = ModbusSerialTransport(port="socket://10.0.0.5:502", ...)
+
+        # RFC 2217 proxy (ESPHome, ser2net, etc.)
+        transport = ModbusSerialTransport(port="rfc2217://10.0.0.5:2217", ...)
+
     IMPORTANT: Single-Client Limitation
     ------------------------------------
     Serial ports support only ONE concurrent connection.
@@ -92,7 +105,12 @@ class ModbusSerialTransport(BaseModbusTransport):
         """Initialize Modbus serial transport.
 
         Args:
-            port: Serial port path (e.g., /dev/ttyUSB0, COM3, /dev/tty.usbserial)
+            port: Serial port path or pyserial URL. Local devices use a path
+                (e.g., /dev/ttyUSB0, COM3, /dev/tty.usbserial). Network serial
+                bridges use a pyserial URL that is passed through unchanged to
+                ``serial.serial_for_url`` (e.g., ``socket://10.0.0.5:502`` for a
+                raw TCP bridge, or ``rfc2217://10.0.0.5:2217`` for an RFC 2217
+                proxy such as ESPHome or ser2net). See #180.
             baudrate: Serial baud rate (default 19200 for EG4 inverters)
             bytesize: Data bits per byte (default 8)
             parity: Parity setting - 'N' (none), 'E' (even), 'O' (odd)


### PR DESCRIPTION
## Summary

Follows up the actionable, non-upstream-blocked part of #180: documenting that network serial bridges already work today.

`ModbusSerialTransport` passes `port` straight through to pymodbus' `AsyncModbusSerialClient`, which opens it via pyserial's `serial.serial_for_url` (`modbus_serial.py:163`). Any pyserial URL therefore reaches a remote RS485 adapter with **no code change** — this was noted by @uofm-matt and @btli on the issue but never documented in the code.

This PR adds that to the class docstring and the `port:` argument docstring, with concrete examples:
- `socket://host:port` — raw TCP serial bridge
- `rfc2217://host:port` — RFC 2217 proxy (ESPHome, ser2net, etc.)

## Scope / non-goals

- **Docstring-only, no behavior change.** The passthrough already existed.
- The upstream pymodbus `pyserial → serialx` migration (pymodbus#2928 / #2929) is still unreleased (latest 3.13.1 still uses pyserial). That dependency bump remains tracked in #180.
- The passthrough mechanism is confirmed by reading the code path; not yet exercised against live hardware. A confirmation from anyone running a real bridge is welcome.

## Checks

- `ruff check` / `ruff format` — pass
- `mypy --strict` — pass
- `pytest -k serial` — 85 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)