### PR TITLE
fix: cloud raw-register writes + write-result checking (0.9.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.37] - 2026-07-07
+
+### Fixed
+
+- **Cloud raw-register writes never reached the inverter**
+  ([eg4_web_monitor#48](https://github.com/joyfulhouse/eg4_web_monitor/issues/48) voltage-limit
+  controls, historical `DATAFRAME_TIMEOUT`-style cloud write failures):
+  `control.write_parameters(sn, {register: raw})` form-encoded a nested dict,
+  which aiohttp serialises as `data=<reg>&data=<reg>` — the VALUES were
+  dropped and the server rejected or ignored the malformed body. Rewritten to
+  the portal's named singular write (`holdParam`/`valueText`): register
+  addresses resolve to their cloud parameter names via
+  `REGISTER_TO_PARAM_KEYS` with `ScaleFactor`-based value conversion (e.g.
+  raw 595 → `"59.5"`). Bitfield and unmapped registers now raise `ValueError`
+  instead of silently sending a bad body. Live-validated 2026-07-07 on a
+  FlexBOSS21 (delta write → readback → restore on registers 228 and 158).
+- **Registers 158/159 cloud write name corrected**: the server rejects
+  `HOLD_AC_CHARGE_START/END_VOLTAGE` with HTTP 400; the accepted name is the
+  read name `HOLD_AC_CHARGE_START/END_BATTERY_VOLTAGE` (live-validated).
+- **Cloud schedule writes report partial failures**: `_set_schedule` ignored
+  every write result except the last, so a failed start-boundary write
+  followed by a successful end write returned success with a half-applied
+  window. Both the `writeTime` and classic four-parameter paths now stop at
+  the first failed write and return it.
+- **Local schedule writes report failures**: `HybridInverter._set_schedule`
+  ignored the boolean results of its two register writes and returned `True`
+  unconditionally, masking firmware NAKs and link drops. It now returns
+  `False` on the first failed write without touching the end register.
+- **Dongle write ACK: empty acknowledgement no longer passes as success**:
+  `_write_holding_registers` skipped echo validation entirely when the ACK
+  payload was empty (for both FC06 and FC16), reporting success on a frame
+  that confirmed nothing. Empty ACKs now raise `TransportWriteError`.
+- **AC charge voltage limits use volts, not decivolts** (cloud API):
+  `set_ac_charge_voltage_limits` wrote `str(voltage * 10)` (e.g. `"400"` for
+  40 V) and `get_ac_charge_voltage_limits` divided the read by 10 — both wrong.
+  Live-verified 2026-07-07 on a FlexBOSS21: the cloud takes and returns whole
+  volts (`"40.5"` → readback 40.5 V). The setter now writes `f"{voltage:g}"`
+  and the getter parses the reading as a float and returns volts unchanged
+  (`get_ac_charge_voltage_limits` now returns `dict[str, float]`); the old
+  `int(...) // 10` truncated whole-volt reads to a tenth and raised on
+  fractional strings.
+
+## [0.9.36] - 2026-07-06
+
+_First stable release of the 0.9.36 line, consolidating 0.9.36b1–b28. The
+entries below were accumulated during the beta cycle._
+
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.36"
+version = "0.9.37"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -996,6 +996,23 @@ LOCAL_PARAM_SCALE_DIV10: frozenset[str] = frozenset(
 )
 
 
+# Value registers whose canonical HoldingRegisterDefinition scale is NONE but
+# whose CLOUD named-write endpoint expects engineering units (raw ÷ 10), so a
+# register→named cloud write must divide by 10 to match the portal.  These are
+# NOT in LOCAL_PARAM_SCALE_DIV10 (that set is keyed by the _12K_* peak-shaving
+# param NAMES used by local reads); this set is keyed by register ADDRESS for
+# the cloud write path.  Evidence:
+#   - 202 _12K_HOLD_STOP_DISCHG_VOLT: raw decivolts, cloud float volts [40, 56].
+#   - 66 HOLD_AC_CHARGE_POWER_CMD, 74 HOLD_FORCED_CHG_POWER_CMD,
+#     82 HOLD_FORCED_DISCHG_POWER_CMD, 103 HOLD_FEED_IN_GRID_POWER_PERCENT:
+#     raw 100 W units, cloud kW (raw 120 -> "12"); see the reg-74/66 100W-unit
+#     findings (eg4_web_monitor PV-charge-power reg74 + Grid Sell Back #274).
+# The peak-shaving power regs 206/232 (raw deci-kW, cloud kW) are already
+# covered by LOCAL_PARAM_SCALE_DIV10 via their _12K_* names (pylxpweb#158 live
+# PS tests, eg4_web_monitor#328), so they are intentionally omitted here.
+CLOUD_WRITE_DIV10_REGISTERS: frozenset[int] = frozenset({202, 66, 74, 82, 103})
+
+
 def format_deci_as_cloud_string(raw: int) -> str:
     """Render a deci-unit raw register value the way the EG4 cloud does.
 

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -1844,9 +1844,22 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                 return False
         else:
             # Use HTTP API
-            response = await self._client.api.control.write_parameters(
-                self.serial_number, parameters
-            )
+            try:
+                response = await self._client.api.control.write_parameters(
+                    self.serial_number, parameters
+                )
+            except ValueError as err:
+                # Bitfield/unmapped registers have no cloud parameter name to
+                # write (control.write_parameters raises rather than sending a
+                # malformed body). Keep this method's documented bool contract
+                # — mirroring the transport branch's catch-and-False — so
+                # callers like set_standby_mode degrade instead of crashing.
+                _LOGGER.error(
+                    "Cannot write parameters via cloud for %s: %s",
+                    self.serial_number,
+                    err,
+                )
+                return False
 
             # Invalidate parameter cache on successful write
             if response.success:

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -460,9 +460,12 @@ class HybridInverter(GenericInverter):
 
         # Write each register individually — inverter rejects FC16 (write
         # multiple) for schedule registers, only FC06 (write single) works.
-        await self.write_parameters({start_reg: pack_time(start_hour, start_minute)})
-        await self.write_parameters({end_reg: pack_time(end_hour, end_minute)})
-        return True
+        # write_parameters returns False (rather than raising) on failure, so
+        # check the start write before touching the end register to avoid a
+        # half-applied window, and surface either failure to the caller.
+        if not await self.write_parameters({start_reg: pack_time(start_hour, start_minute)}):
+            return False
+        return await self.write_parameters({end_reg: pack_time(end_hour, end_minute)})
 
     async def _get_schedule(self, schedule_type: ScheduleType, period: int) -> dict[str, int]:
         """Read a time period schedule (generic helper, transport or cloud).

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -22,6 +22,17 @@ from pylxpweb.models import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Holding-register addresses occupied by the packed-time schedule families
+# (each config spans 2 * periods registers from its base). These are writable
+# only via the schedule setters (_set_schedule / write_time_parameter); a raw
+# single-register cloud write of a packed value would not round-trip, so
+# write_parameters rejects them. Derived once from SCHEDULE_CONFIGS.
+_SCHEDULE_REGISTER_ADDRESSES: frozenset[int] = frozenset(
+    address
+    for config in SCHEDULE_CONFIGS.values()
+    for address in range(config.base_register, config.base_register + 2 * config.periods)
+)
+
 
 class ControlEndpoints(BaseEndpoint):
     """Device control endpoints for parameters, functions, and quick charge."""
@@ -231,48 +242,158 @@ class ControlEndpoints(BaseEndpoint):
         parameters: dict[int, int],
         client_type: str = "WEB",
     ) -> SuccessResponse:
-        """Write multiple configuration parameters to the inverter.
+        """Write multiple configuration parameters to the inverter by register.
 
          WARNING: This changes device configuration!
 
-        This is a convenience method that writes register values directly.
-        For named parameters, use write_parameter() instead.
+        Each ``{address: raw_value}`` pair is translated to the server's NAMED
+        singular write (``write_parameter`` holdParam/valueText) — the only
+        cloud write format the portal accepts. The register address is resolved
+        to its cloud param name via ``REGISTER_TO_PARAM_KEYS`` (first key only,
+        for pure value registers) and the raw value is scaled to the cloud's
+        string form using the canonical ``HoldingRegisterDefinition`` table
+        (``ScaleFactor.NONE`` → ``str(raw)``; ``DIV_10`` → ``raw / 10``, etc.).
+
+        The previous implementation form-encoded a nested ``data={reg: val}``
+        dict, which serialised as ``data=<reg>&data=<reg>`` with the values
+        dropped — a malformed body the server rejected as a no-op. Only pure
+        value registers can be written this way; bitfield registers (which pack
+        several named FUNC_/BIT_ params into one address) and unmapped
+        registers raise ``ValueError`` rather than silently sending a bad body.
 
         Args:
             inverter_sn: Inverter serial number
-            parameters: Dict mapping register addresses to values
+            parameters: Dict mapping register addresses to raw register values
             client_type: Client type (WEB/APP)
 
         Returns:
-            SuccessResponse: Operation result
+            SuccessResponse: Result of the last write, or the first failed
+                write (remaining writes are not attempted after a failure).
+
+        Raises:
+            ValueError: If any address is a bitfield register or is not mapped
+                to a single cloud parameter name.
+
+        Live validation (2026-07-07, FlexBOSS21 52842P0581):
+            Named writes with these exact names were delta-tested
+            (write → readback → restore): HOLD_SYSTEM_CHARGE_VOLT_LIMIT
+            (reg 228, 59.5 → 59.4 → 59.5 confirmed) and
+            HOLD_AC_CHARGE_START_BATTERY_VOLTAGE (reg 158, 40 → 40.5 → 40
+            confirmed, readback via reg-158 remoteRead). No-op writes were
+            accepted for HOLD_ON_GRID_EOD_VOLTAGE (169),
+            HOLD_LEAD_ACID_DISCHARGE_CUT_OFF_VOLT (100) and
+            HOLD_AC_CHARGE_END_BATTERY_VOLTAGE (159).
 
         Example:
-            # Set multiple registers at once
-            await client.control.write_parameters(
-                "1234567890",
-                {21: 512, 66: 50, 67: 100}  # Register addresses and values
-            )
+            # Set the system charge voltage limit (reg 228, ÷10 → "59.5")
+            await client.control.write_parameters("1234567890", {228: 595})
         """
         if not parameters:
             return SuccessResponse(success=True)
 
-        await self.client._ensure_authenticated()
+        # Resolve every (holdParam, valueText) pair BEFORE writing anything, so a
+        # bad register in the batch raises ValueError without a partial write.
+        resolved = [
+            self._resolve_named_write(address, raw_value)
+            for address, raw_value in parameters.items()
+        ]
 
-        data = {
-            "inverterSn": inverter_sn,
-            "data": {str(reg): val for reg, val in parameters.items()},
-            "clientType": client_type,
-        }
-
-        response = await self.client._request(
-            "POST", "/WManage/web/maintain/remoteSet/write", data=data
-        )
-        result = SuccessResponse.model_validate(response)
-
-        if result.success:
-            self.client.invalidate_cache_for_device(inverter_sn)
-
+        result = SuccessResponse(success=True)
+        for hold_param, value_text in resolved:
+            result = await self.write_parameter(
+                inverter_sn, hold_param, value_text, client_type=client_type
+            )
+            if not result.success:
+                return result
         return result
+
+    @staticmethod
+    def _resolve_named_write(address: int, raw_value: int) -> tuple[str, str]:
+        """Resolve a raw register write to its (holdParam, valueText) named form.
+
+        Args:
+            address: Modbus holding register address
+            raw_value: Raw 16-bit register value to write
+
+        Returns:
+            Tuple of (cloud param name, cloud value string)
+
+        Raises:
+            ValueError: If the address is a bitfield register (packs multiple
+                named params), is a packed-time schedule register, or is not
+                mapped to a cloud parameter name.
+        """
+        from pylxpweb.constants.registers import (
+            CLOUD_WRITE_DIV10_REGISTERS,
+            LOCAL_PARAM_SCALE_DIV10,
+            REGISTER_TO_PARAM_KEYS,
+        )
+        from pylxpweb.registers import HOLDING_BY_ADDRESS
+        from pylxpweb.registers.inverter_input import ScaleFactor
+
+        # Packed-time schedule registers only exist for LOCAL packed reads; the
+        # cloud schedule write path is per-field (_set_schedule) or the atomic
+        # writeTime endpoint, never a single raw register value.
+        if address in _SCHEDULE_REGISTER_ADDRESSES:
+            raise ValueError(
+                f"Register {address} is a packed-time schedule register; write "
+                "schedules via _set_schedule / write_time_parameter, not "
+                "write_parameters"
+            )
+
+        param_keys = REGISTER_TO_PARAM_KEYS.get(address)
+        if not param_keys:
+            raise ValueError(
+                f"Register {address} is not mapped to a cloud parameter name; "
+                "cannot write it as a named parameter"
+            )
+        if len(param_keys) > 1:
+            raise ValueError(
+                f"Register {address} is a bitfield ({len(param_keys)} named "
+                "params share it); write its individual FUNC_/BIT_ params via "
+                "control_function/control_bit_param instead of write_parameters"
+            )
+
+        definitions = HOLDING_BY_ADDRESS.get(address, ())
+        if any(d.bit_position is not None for d in definitions):
+            raise ValueError(
+                f"Register {address} is a bitfield register; write its "
+                "individual FUNC_/BIT_ params instead of write_parameters"
+            )
+
+        param_key = param_keys[0]
+
+        # Signed registers: the cloud's wire format for negative values is
+        # UNVALIDATED (no mapped signed register exists today — an invariant
+        # test enforces that). Refuse rather than guess whether the server
+        # wants "-1" or 65535.
+        if any(d.signed for d in definitions):
+            raise ValueError(
+                f"Register {address} is signed; its cloud negative-value "
+                "format is unvalidated — write it via a dedicated named "
+                "setter instead of write_parameters"
+            )
+
+        # Cloud write divisor: the canonical table's ScaleFactor wins when it is
+        # not NONE; otherwise fall back to the two known-DIV10 sources — the
+        # _12K_* peak-shaving names (keyed by param name) and the explicit
+        # cloud-write DIV10 register set (keyed by address). Both map raw
+        # register units to the engineering units the portal expects.
+        scale = ScaleFactor.NONE
+        for d in definitions:
+            if d.bit_position is None:
+                scale = d.scale
+                break
+
+        if scale != ScaleFactor.NONE:
+            divisor = scale.value
+        elif param_key in LOCAL_PARAM_SCALE_DIV10 or address in CLOUD_WRITE_DIV10_REGISTERS:
+            divisor = 10
+        else:
+            divisor = 1
+
+        value_text = str(raw_value) if divisor == 1 else f"{raw_value / divisor:g}"
+        return param_key, value_text
 
     async def control_function(
         self,
@@ -1427,13 +1548,18 @@ class ControlEndpoints(BaseEndpoint):
         suffix = config.period_suffixes[period]
 
         if config.write_via_time_api:
-            await self.write_time_parameter(
+            # Write the start boundary first; if it fails, return that failure
+            # immediately without writing the end boundary (which would leave a
+            # half-applied schedule window).
+            start_result = await self.write_time_parameter(
                 inverter_sn,
                 f"{prefix}_START_TIME{suffix}",
                 start_hour,
                 start_minute,
                 client_type=client_type,
             )
+            if not start_result.success:
+                return start_result
             return await self.write_time_parameter(
                 inverter_sn,
                 f"{prefix}_END_TIME{suffix}",
@@ -1442,24 +1568,32 @@ class ControlEndpoints(BaseEndpoint):
                 client_type=client_type,
             )
 
-        await self.write_parameter(
+        # Classic four-param path: stop at the first failed write so we don't
+        # push later fields over a schedule that was only partially accepted.
+        start_hour_result = await self.write_parameter(
             inverter_sn,
             f"{prefix}_START_HOUR{suffix}",
             str(start_hour),
             client_type=client_type,
         )
-        await self.write_parameter(
+        if not start_hour_result.success:
+            return start_hour_result
+        start_minute_result = await self.write_parameter(
             inverter_sn,
             f"{prefix}_START_MINUTE{suffix}",
             str(start_minute),
             client_type=client_type,
         )
-        await self.write_parameter(
+        if not start_minute_result.success:
+            return start_minute_result
+        end_hour_result = await self.write_parameter(
             inverter_sn,
             f"{prefix}_END_HOUR{suffix}",
             str(end_hour),
             client_type=client_type,
         )
+        if not end_hour_result.success:
+            return end_hour_result
         return await self.write_parameter(
             inverter_sn,
             f"{prefix}_END_MINUTE{suffix}",
@@ -2179,37 +2313,51 @@ class ControlEndpoints(BaseEndpoint):
         if not 48 <= end_voltage <= 59:
             raise ValueError(f"end_voltage must be 48-59V, got {end_voltage}")
 
-        # Cloud API expects decivolts (×10)
-        await self.write_parameter(
+        # Cloud API expects VOLTS, not decivolts — live-refuted 2026-07-07 on a
+        # FlexBOSS21: "40.5" written to HOLD_AC_CHARGE_START_BATTERY_VOLTAGE read
+        # back as 40.5V, so "400" would be garbage. Format with :g so a whole
+        # volt has no trailing ".0".
+        start_result = await self.write_parameter(
             inverter_sn,
             "HOLD_AC_CHARGE_START_BATTERY_VOLTAGE",
-            str(start_voltage * 10),
+            f"{start_voltage:g}",
             client_type=client_type,
         )
+        if not start_result.success:
+            # Don't write the end limit over a rejected start write — return
+            # the failure so callers see exactly what was (not) applied.
+            return start_result
         return await self.write_parameter(
             inverter_sn,
             "HOLD_AC_CHARGE_END_BATTERY_VOLTAGE",
-            str(end_voltage * 10),
+            f"{end_voltage:g}",
             client_type=client_type,
         )
 
-    async def get_ac_charge_voltage_limits(self, inverter_sn: str) -> dict[str, int]:
+    async def get_ac_charge_voltage_limits(self, inverter_sn: str) -> dict[str, float]:
         """Get AC charge start/stop voltage thresholds via cloud API.
 
         Returns:
-            Dictionary with start_voltage and end_voltage (whole volts)
+            Dictionary with start_voltage and end_voltage in VOLTS.
+
+        Note:
+            The cloud read returns volts (e.g. "40" or "40.5"), NOT decivolts —
+            so the value is parsed as a float and returned as-is with no ÷10
+            (live-verified 2026-07-07). The old ``int(...) // 10`` both truncated
+            whole-volt reads to a tenth of their value and raised on fractional
+            strings.
 
         Example:
             >>> limits = await client.control.get_ac_charge_voltage_limits("1234567890")
             >>> limits
-            {'start_voltage': 40, 'end_voltage': 58}
+            {'start_voltage': 40.0, 'end_voltage': 58.0}
         """
         params = await self.read_device_parameters_ranges(inverter_sn)
-        start_raw = int(params.get("HOLD_AC_CHARGE_START_BATTERY_VOLTAGE", 0))
-        end_raw = int(params.get("HOLD_AC_CHARGE_END_BATTERY_VOLTAGE", 0))
+        start_v = float(params.get("HOLD_AC_CHARGE_START_BATTERY_VOLTAGE", 0) or 0)
+        end_v = float(params.get("HOLD_AC_CHARGE_END_BATTERY_VOLTAGE", 0) or 0)
         return {
-            "start_voltage": start_raw // 10,
-            "end_voltage": end_raw // 10,
+            "start_voltage": start_v,
+            "end_voltage": end_v,
         }
 
     # ============================================================================

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -1199,7 +1199,12 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
     HoldingRegisterDefinition(
         address=158,
         canonical_name="ac_charge_start_voltage",
-        api_param_key="HOLD_AC_CHARGE_START_VOLTAGE",
+        # Write name is the READ name: the server rejects
+        # "HOLD_AC_CHARGE_START_VOLTAGE" for writes with HTTP 400, but accepts
+        # "HOLD_AC_CHARGE_START_BATTERY_VOLTAGE" (live-validated 2026-07-07 on
+        # FlexBOSS21 52842P0581, delta write→readback→restore 40→40.5→40). The
+        # legacy "_VOLTAGE" name stays reachable via PARAM_ALIASES.
+        api_param_key="HOLD_AC_CHARGE_START_BATTERY_VOLTAGE",
         scale=ScaleFactor.DIV_10,
         unit="V",
         min_value=38.4,
@@ -1210,7 +1215,10 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
     HoldingRegisterDefinition(
         address=159,
         canonical_name="ac_charge_end_voltage",
-        api_param_key="HOLD_AC_CHARGE_END_VOLTAGE",
+        # Write name is the READ name (see reg 158); the server rejects
+        # "HOLD_AC_CHARGE_END_VOLTAGE" for writes with HTTP 400 but accepts
+        # "HOLD_AC_CHARGE_END_BATTERY_VOLTAGE" (live-validated 2026-07-07).
+        api_param_key="HOLD_AC_CHARGE_END_BATTERY_VOLTAGE",
         scale=ScaleFactor.DIV_10,
         unit="V",
         min_value=48.0,

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -1209,18 +1209,34 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         # payload so a misrouted ACK for the same register cannot pass as a
         # confirmation of OUR value.
         if modbus_func == MODBUS_WRITE_SINGLE:
-            if ack and ack[0] != values[0]:
+            if not ack:
+                # An empty/short ACK carries no echoed value to confirm the
+                # write landed — treat it as a failure rather than silently
+                # reporting success.
+                raise TransportWriteError(
+                    f"Write ACK empty/short for register {address}: no echoed "
+                    "value to confirm the write"
+                )
+            if ack[0] != values[0]:
                 raise TransportWriteError(
                     f"Write ACK echo mismatch for register {address}: wrote "
                     f"{values[0]}, ACK echoed {ack[0]} — possible misrouted "
                     "response"
                 )
-        elif ack and len(ack) == 1 and ack[0] != len(values):
-            # FC16 ACK echoes the written register count.
-            raise TransportWriteError(
-                f"Write ACK count mismatch for register {address}: wrote "
-                f"{len(values)} registers, ACK echoed {ack[0]}"
-            )
+        else:
+            if not ack:
+                # FC16 ACK must echo the written register count; an empty/short
+                # ACK cannot confirm the multi-register write.
+                raise TransportWriteError(
+                    f"Write ACK empty/short for register {address}: no echoed "
+                    "register count to confirm the write"
+                )
+            if len(ack) == 1 and ack[0] != len(values):
+                # FC16 ACK echoes the written register count.
+                raise TransportWriteError(
+                    f"Write ACK count mismatch for register {address}: wrote "
+                    f"{len(values)} registers, ACK echoed {ack[0]}"
+                )
         return True
 
     # Data reading/writing methods (read_runtime, read_energy, read_battery,

--- a/src/pylxpweb/transports/http.py
+++ b/src/pylxpweb/transports/http.py
@@ -348,15 +348,26 @@ class HTTPTransport(BaseTransport):
 
         try:
             # Use the batch write_parameters method which takes dict[int, int]
-            await self._client.api.control.write_parameters(
+            result = await self._client.api.control.write_parameters(
                 self._serial,
                 parameters=parameters,
             )
+            if not result.success:
+                raise TransportWriteError(
+                    f"Cloud rejected parameter write for {self._serial}: "
+                    f"{result.message or 'success=false'}"
+                )
             return True
 
         except TimeoutError as err:
             _LOGGER.error("Timeout writing parameters for %s", self._serial)
             raise TransportTimeoutError(f"Timeout writing parameters for {self._serial}") from err
+        except ValueError as err:
+            # write_parameters raises ValueError for bitfield/unmapped
+            # registers (no cloud parameter name to write) — surface it under
+            # the transport error contract like every other write failure.
+            _LOGGER.error("Cannot write parameters for %s: %s", self._serial, err)
+            raise TransportWriteError(f"Cannot write parameters for {self._serial}: {err}") from err
         except (LuxpowerAPIError, LuxpowerDeviceError, LuxpowerConnectionError) as err:
             _LOGGER.error("Failed to write parameters for %s: %s", self._serial, err)
             raise TransportWriteError(

--- a/tests/unit/devices/inverters/test_base.py
+++ b/tests/unit/devices/inverters/test_base.py
@@ -729,6 +729,26 @@ class TestInverterControlOperations:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_write_parameters_cloud_value_error_returns_false(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """Bitfield/unmapped ValueError from the cloud endpoint degrades to
+        False (the method's bool contract, mirroring the transport branch)
+        instead of crashing callers like set_standby_mode."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+
+        mock_client.api.control = Mock()
+        mock_client.api.control.write_parameters = AsyncMock(
+            side_effect=ValueError("Register 21 is a bitfield")
+        )
+
+        result = await inverter.write_parameters({21: 512})
+
+        assert result is False
+
+    @pytest.mark.asyncio
     async def test_set_standby_mode_to_standby(self, mock_client: LuxpowerClient) -> None:
         """Test setting inverter to standby mode."""
         inverter = ConcreteInverter(

--- a/tests/unit/endpoints/test_control_helpers.py
+++ b/tests/unit/endpoints/test_control_helpers.py
@@ -258,26 +258,182 @@ class TestCacheInvalidation:
 
     @pytest.mark.asyncio
     async def test_write_parameters_invalidates_cache(self, api_client: Mock) -> None:
-        """Test that write_parameters invalidates cache on successful write."""
+        """A successful register write invalidates the device cache."""
         api_client._request = AsyncMock(return_value={"success": True})
         control = ControlEndpoints(api_client)
 
-        result = await control.write_parameters(SERIAL, {21: 512})
+        # Reg 67 = HOLD_AC_CHARGE_SOC_LIMIT (a pure value register, scale NONE).
+        result = await control.write_parameters(SERIAL, {67: 90})
 
         assert result.success is True
         api_client.invalidate_cache_for_device.assert_called_once_with(SERIAL)
 
     @pytest.mark.asyncio
-    async def test_write_parameters_sends_all_registers(self, api_client: Mock) -> None:
-        """Test that write_parameters sends all registers in data dict."""
+    async def test_write_parameters_translates_to_named_writes(self, api_client: Mock) -> None:
+        """Each register is sent as a NAMED holdParam/valueText write, never as
+        the old malformed nested ``data={reg: val}`` form field."""
         api_client._request = AsyncMock(return_value={"success": True})
         control = ControlEndpoints(api_client)
 
-        result = await control.write_parameters(SERIAL, {160: 20, 67: 100})
+        # 228 = HOLD_SYSTEM_CHARGE_VOLT_LIMIT (÷10 → "59.5"); 67 = SOC (1:1).
+        result = await control.write_parameters(SERIAL, {228: 595, 67: 90})
 
         assert result.success is True
-        call_data = api_client._request.call_args[1]["data"]
-        assert call_data["data"] == {"160": 20, "67": 100}
+        assert api_client._request.await_count == 2
+        sent = [call.kwargs["data"] for call in api_client._request.await_args_list]
+        # No call carries a dict-valued "data" form field anymore.
+        assert all(isinstance(d.get("valueText"), str) for d in sent)
+        assert all(not isinstance(d.get("data"), dict) for d in sent)
+        assert {
+            "inverterSn": SERIAL,
+            "holdParam": "HOLD_SYSTEM_CHARGE_VOLT_LIMIT",
+            "valueText": "59.5",
+            "clientType": "WEB",
+            "remoteSetType": "NORMAL",
+        } in sent
+        assert {
+            "inverterSn": SERIAL,
+            "holdParam": "HOLD_AC_CHARGE_SOC_LIMIT",
+            "valueText": "90",
+            "clientType": "WEB",
+            "remoteSetType": "NORMAL",
+        } in sent
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("register", "raw", "expected_name", "expected_value"),
+        [
+            # Decivolt (DIV_10) registers via the canonical table.
+            (228, 595, "HOLD_SYSTEM_CHARGE_VOLT_LIMIT", "59.5"),
+            (158, 400, "HOLD_AC_CHARGE_START_BATTERY_VOLTAGE", "40"),
+            (159, 480, "HOLD_AC_CHARGE_END_BATTERY_VOLTAGE", "48"),
+            (169, 485, "HOLD_ON_GRID_EOD_VOLTAGE", "48.5"),
+            (100, 480, "HOLD_LEAD_ACID_DISCHARGE_CUT_OFF_VOLT", "48"),
+            # CLOUD_WRITE_DIV10_REGISTERS: table scale is NONE but the cloud
+            # named-write expects engineering units (raw ÷ 10).
+            (202, 480, "_12K_HOLD_STOP_DISCHG_VOLT", "48"),
+            (202, 505, "_12K_HOLD_STOP_DISCHG_VOLT", "50.5"),
+            (66, 120, "HOLD_AC_CHARGE_POWER_CMD", "12"),
+            (74, 120, "HOLD_FORCED_CHG_POWER_CMD", "12"),
+            (82, 120, "HOLD_FORCED_DISCHG_POWER_CMD", "12"),
+            (103, 120, "HOLD_FEED_IN_GRID_POWER_PERCENT", "12"),
+            # LOCAL_PARAM_SCALE_DIV10 peak-shaving power regs (raw deci-kW).
+            (206, 120, "_12K_HOLD_GRID_PEAK_SHAVING_POWER", "12"),
+            (232, 41, "_12K_HOLD_GRID_PEAK_SHAVING_POWER_2", "4.1"),
+            # 1:1 (NONE) registers pass the raw value straight through.
+            (67, 90, "HOLD_AC_CHARGE_SOC_LIMIT", "90"),
+        ],
+    )
+    async def test_write_parameters_scaling(
+        self,
+        register: int,
+        raw: int,
+        expected_name: str,
+        expected_value: str,
+    ) -> None:
+        """Register raw values scale to the cloud's string form by divisor."""
+        name, value = ControlEndpoints._resolve_named_write(register, raw)
+        assert name == expected_name
+        assert value == expected_value
+
+    def test_cloud_write_div10_registers_all_covered(self) -> None:
+        """Every register in CLOUD_WRITE_DIV10_REGISTERS resolves with a ÷10
+        divisor (guards against the set drifting out of sync with the resolver)."""
+        from pylxpweb.constants.registers import CLOUD_WRITE_DIV10_REGISTERS
+
+        for register in CLOUD_WRITE_DIV10_REGISTERS:
+            _, value = ControlEndpoints._resolve_named_write(register, 120)
+            assert value == "12", f"register {register} did not scale ÷10"
+
+    @pytest.mark.asyncio
+    async def test_write_parameters_pre_validates_atomically(self, api_client: Mock) -> None:
+        """A bad register anywhere in the batch raises BEFORE any write, so a
+        valid earlier register is NOT written (all-or-nothing resolution)."""
+        api_client._request = AsyncMock(return_value={"success": True})
+        control = ControlEndpoints(api_client)
+
+        # 67 is valid; 21 is a bitfield. Insertion order writes 67 first, but
+        # resolution happens up front so nothing is sent.
+        with pytest.raises(ValueError, match="bitfield"):
+            await control.write_parameters(SERIAL, {67: 90, 21: 128})
+        api_client._request.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "register",
+        [68, 76, 84, 152, 209, 256, 269],  # one per schedule family base.
+        ids=[
+            "ac_charge",
+            "forced_chg",
+            "forced_dischg",
+            "ac_first",
+            "peak_shaving",
+            "gen",
+            "offgrid",
+        ],
+    )
+    async def test_write_parameters_rejects_schedule_register(
+        self, api_client: Mock, register: int
+    ) -> None:
+        """Packed-time schedule registers raise, directing to the schedule setters."""
+        api_client._request = AsyncMock(return_value={"success": True})
+        control = ControlEndpoints(api_client)
+
+        with pytest.raises(ValueError, match="schedule register"):
+            await control.write_parameters(SERIAL, {register: 1})
+        api_client._request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_parameters_stops_on_first_failure(self, api_client: Mock) -> None:
+        """A failed write returns immediately; later registers are not written."""
+        failure = {"success": False}
+        api_client._request = AsyncMock(return_value=failure)
+        control = ControlEndpoints(api_client)
+
+        # dict preserves insertion order: 228 is attempted first and fails.
+        result = await control.write_parameters(SERIAL, {228: 595, 67: 90})
+
+        assert result.success is False
+        api_client._request.assert_awaited_once()
+        assert api_client._request.await_args.kwargs["data"]["holdParam"] == (
+            "HOLD_SYSTEM_CHARGE_VOLT_LIMIT"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "register",
+        [21, 110],  # register 21 / 110 pack many FUNC_ bits.
+        ids=["reg21_bitfield", "reg110_bitfield"],
+    )
+    async def test_write_parameters_rejects_bitfield(self, api_client: Mock, register: int) -> None:
+        """Bitfield registers raise ValueError instead of a malformed write."""
+        api_client._request = AsyncMock(return_value={"success": True})
+        control = ControlEndpoints(api_client)
+
+        with pytest.raises(ValueError, match="bitfield"):
+            await control.write_parameters(SERIAL, {register: 1})
+        api_client._request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_parameters_rejects_unmapped(self, api_client: Mock) -> None:
+        """An unmapped register raises ValueError, never a silent no-op body."""
+        api_client._request = AsyncMock(return_value={"success": True})
+        control = ControlEndpoints(api_client)
+
+        with pytest.raises(ValueError, match="not mapped"):
+            await control.write_parameters(SERIAL, {9999: 1})
+        api_client._request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_parameters_empty_is_noop_success(self, api_client: Mock) -> None:
+        """An empty dict is a successful no-op with no requests sent."""
+        api_client._request = AsyncMock(return_value={"success": True})
+        control = ControlEndpoints(api_client)
+
+        result = await control.write_parameters(SERIAL, {})
+
+        assert result.success is True
+        api_client._request.assert_not_called()
 
 
 class TestSystemChargeSocLimit:
@@ -375,6 +531,44 @@ class TestACChargeScheduleCloud:
         control.write_parameter.assert_any_call(
             SERIAL, "HOLD_AC_CHARGE_END_MINUTE_1", "0", client_type="WEB"
         )
+
+    @pytest.mark.asyncio
+    async def test_set_ac_charge_schedule_stops_on_first_write_failure(
+        self, control: ControlEndpoints
+    ) -> None:
+        """Legacy four-param path returns the first failed write and stops.
+
+        If HOLD_AC_CHARGE_START_HOUR is rejected, the remaining three params
+        must not be written (no half-applied schedule window).
+        """
+        failure = SuccessResponse(success=False)
+        control.write_parameter = AsyncMock(return_value=failure)
+
+        result = await control.set_ac_charge_schedule(SERIAL, 0, 23, 0, 7, 0)
+
+        assert result is failure
+        control.write_parameter.assert_called_once_with(
+            SERIAL, "HOLD_AC_CHARGE_START_HOUR", "23", client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_ac_charge_schedule_stops_on_later_write_failure(
+        self, control: ControlEndpoints
+    ) -> None:
+        """A failure on the third write stops before the final END_MINUTE."""
+        results = [
+            SuccessResponse(success=True),
+            SuccessResponse(success=True),
+            SuccessResponse(success=False),
+            SuccessResponse(success=True),
+        ]
+        control.write_parameter = AsyncMock(side_effect=results)
+
+        result = await control.set_ac_charge_schedule(SERIAL, 0, 23, 0, 7, 0)
+
+        assert result.success is False
+        # START_HOUR, START_MINUTE, END_HOUR only — END_MINUTE skipped.
+        assert control.write_parameter.call_count == 3
 
     @pytest.mark.asyncio
     async def test_set_ac_charge_schedule_invalid_period(self, control: ControlEndpoints) -> None:
@@ -569,17 +763,18 @@ class TestACChargeVoltageLimitsCloud:
 
     @pytest.mark.asyncio
     async def test_set_ac_charge_voltage_limits(self, control: ControlEndpoints) -> None:
-        """Test setting AC charge voltage limits (decivolts conversion)."""
+        """The cloud API takes VOLTS, not decivolts (live-verified 2026-07-07):
+        40V is sent as "40", never "400"."""
         control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
 
         result = await control.set_ac_charge_voltage_limits(SERIAL, 40, 58)
 
         assert result.success is True
         control.write_parameter.assert_any_call(
-            SERIAL, "HOLD_AC_CHARGE_START_BATTERY_VOLTAGE", "400", client_type="WEB"
+            SERIAL, "HOLD_AC_CHARGE_START_BATTERY_VOLTAGE", "40", client_type="WEB"
         )
         control.write_parameter.assert_any_call(
-            SERIAL, "HOLD_AC_CHARGE_END_BATTERY_VOLTAGE", "580", client_type="WEB"
+            SERIAL, "HOLD_AC_CHARGE_END_BATTERY_VOLTAGE", "58", client_type="WEB"
         )
 
     @pytest.mark.asyncio
@@ -592,13 +787,53 @@ class TestACChargeVoltageLimitsCloud:
 
     @pytest.mark.asyncio
     async def test_get_ac_charge_voltage_limits(self, control: ControlEndpoints) -> None:
-        """Test getting AC charge voltage limits (decivolts conversion)."""
+        """The cloud read returns VOLTS; parse as float, no ÷10.
+
+        A whole-volt read ("40") must come back as 40.0V, not 4V.
+        """
         control.read_device_parameters_ranges = AsyncMock(
             return_value={
-                "HOLD_AC_CHARGE_START_BATTERY_VOLTAGE": 400,
-                "HOLD_AC_CHARGE_END_BATTERY_VOLTAGE": 580,
+                "HOLD_AC_CHARGE_START_BATTERY_VOLTAGE": "40",
+                "HOLD_AC_CHARGE_END_BATTERY_VOLTAGE": "58",
             }
         )
 
         limits = await control.get_ac_charge_voltage_limits(SERIAL)
-        assert limits == {"start_voltage": 40, "end_voltage": 58}
+        assert limits == {"start_voltage": 40.0, "end_voltage": 58.0}
+
+    @pytest.mark.asyncio
+    async def test_get_ac_charge_voltage_limits_fractional(self, control: ControlEndpoints) -> None:
+        """A fractional-volt read ("40.5") parses as 40.5, not a ValueError."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "HOLD_AC_CHARGE_START_BATTERY_VOLTAGE": "40.5",
+                "HOLD_AC_CHARGE_END_BATTERY_VOLTAGE": "58",
+            }
+        )
+
+        limits = await control.get_ac_charge_voltage_limits(SERIAL)
+        assert limits == {"start_voltage": 40.5, "end_voltage": 58.0}
+
+
+class TestSignedRegisterInvariant:
+    """No signed holding register may be silently writable via write_parameters.
+
+    The cloud wire format for negative values is unvalidated; the resolver
+    refuses signed registers. This invariant test forces an explicit decision
+    if a signed register is ever added to REGISTER_TO_PARAM_KEYS.
+    """
+
+    def test_no_mapped_register_is_signed(self) -> None:
+        from pylxpweb.constants.registers import REGISTER_TO_PARAM_KEYS
+        from pylxpweb.registers import HOLDING_BY_ADDRESS
+
+        signed_mapped = [
+            addr
+            for addr in REGISTER_TO_PARAM_KEYS
+            if any(d.signed for d in HOLDING_BY_ADDRESS.get(addr, ()))
+        ]
+        assert signed_mapped == [], (
+            f"Signed registers {signed_mapped} are mapped in "
+            "REGISTER_TO_PARAM_KEYS; validate their cloud negative-value "
+            "format before allowing them through write_parameters"
+        )

--- a/tests/unit/test_schedule_families_gen_offgrid_peakshaving.py
+++ b/tests/unit/test_schedule_families_gen_offgrid_peakshaving.py
@@ -243,6 +243,20 @@ class TestCloudWrites:
         )
 
     @pytest.mark.asyncio
+    async def test_write_time_start_failure_skips_end(self, control: ControlEndpoints) -> None:
+        """writeTime path: a failed start boundary returns immediately and the
+        end boundary is never written (no half-applied window)."""
+        failure = SuccessResponse(success=False)
+        control.write_time_parameter = AsyncMock(return_value=failure)
+
+        result = await control.set_gen_charge_schedule(SERIAL, 0, 16, 0, 20, 59)
+
+        assert result is failure
+        control.write_time_parameter.assert_called_once_with(
+            SERIAL, "HOLD_GEN_START_TIME_1", 16, 0, client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
     async def test_off_grid_period_out_of_range_for_two_window(
         self, control: ControlEndpoints
     ) -> None:
@@ -367,6 +381,32 @@ class TestModbusWrites:
 
         transport.write_parameters.assert_any_await({209: pack_time(16, 0)})
         transport.write_parameters.assert_any_await({210: pack_time(20, 59)})
+
+    @pytest.mark.asyncio
+    async def test_local_start_write_failure_skips_end(self, mock_client: LuxpowerClient) -> None:
+        """A False start-register write returns False without writing the end
+        register (BaseInverter.write_parameters returns False on failure)."""
+        inverter, transport = self._local_inverter(mock_client)
+        transport.write_parameters = AsyncMock(return_value=False)
+
+        result = await inverter.set_gen_charge_schedule(0, 16, 0, 20, 59)
+
+        assert result is False
+        # Only the start-register write is attempted; the end register (259/258)
+        # is never written.
+        assert transport.write_parameters.await_count == 1
+        transport.write_parameters.assert_awaited_once_with({256: pack_time(16, 0)})
+
+    @pytest.mark.asyncio
+    async def test_local_end_write_failure_returns_false(self, mock_client: LuxpowerClient) -> None:
+        """A False end-register write propagates as False."""
+        inverter, transport = self._local_inverter(mock_client)
+        transport.write_parameters = AsyncMock(side_effect=[True, False])
+
+        result = await inverter.set_gen_charge_schedule(0, 16, 0, 20, 59)
+
+        assert result is False
+        assert transport.write_parameters.await_count == 2
 
     @pytest.mark.asyncio
     async def test_gen_charge_local_period_out_of_range(self, mock_client: LuxpowerClient) -> None:

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -1775,6 +1775,30 @@ class TestWriteAckEchoValidation:
             await transport._write_holding_registers(110, [1, 2])
 
     @pytest.mark.asyncio
+    async def test_fc06_empty_ack_raises(self) -> None:
+        """An empty FC06 ACK carries no echoed value — must raise, not pass."""
+        transport = self._connected_transport()
+        transport._send_receive = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        with (
+            patch("asyncio.sleep", AsyncMock()),
+            pytest.raises(TransportWriteError, match="empty/short"),
+        ):
+            await transport._write_holding_registers(110, [0x0100])
+
+    @pytest.mark.asyncio
+    async def test_fc16_empty_ack_raises(self) -> None:
+        """An empty FC16 ACK carries no echoed count — must raise, not pass."""
+        transport = self._connected_transport()
+        transport._send_receive = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        with (
+            patch("asyncio.sleep", AsyncMock()),
+            pytest.raises(TransportWriteError, match="empty/short"),
+        ):
+            await transport._write_holding_registers(110, [1, 2])
+
+    @pytest.mark.asyncio
     async def test_write_timeout_propagates_without_inner_resend(self) -> None:
         """Write timeout tears down and raises — NO request-level resend.
 
@@ -1875,7 +1899,10 @@ class TestDongleForceReconnect:
         transport = _make_write_test_transport(write_step_delay=0.05, verify_writes=False)
 
         mock_read = AsyncMock(return_value=[0x0000])
-        mock_send = AsyncMock(return_value=[])
+        # FUNC_EPS_EN is register 21 bit 0: enabling from 0x0000 writes value 1,
+        # and the FC06 ACK echoes the written value. A non-empty echo is now
+        # required — an empty ACK raises TransportWriteError.
+        mock_send = AsyncMock(return_value=[1])
         sleep_mock = AsyncMock()
 
         with (

--- a/tests/unit/transports/test_http.py
+++ b/tests/unit/transports/test_http.py
@@ -473,3 +473,38 @@ class TestHTTPTransport:
 
         with pytest.raises(TransportWriteError, match="Failed to write parameters"):
             await transport.write_parameters({0: 100})
+
+    @pytest.mark.asyncio
+    async def test_write_parameters_success_false_raises(self) -> None:
+        """A cloud success=false reply raises instead of returning True."""
+        from pylxpweb.models import SuccessResponse
+        from pylxpweb.transports.exceptions import TransportWriteError
+
+        client = MagicMock()
+        client.login = AsyncMock()
+        client.api.control.write_parameters = AsyncMock(
+            return_value=SuccessResponse(success=False, message="REMOTE_SET_ERROR")
+        )
+
+        transport = HTTPTransport(client, serial="CE12345678")
+        await transport.connect()
+
+        with pytest.raises(TransportWriteError, match="REMOTE_SET_ERROR"):
+            await transport.write_parameters({228: 595})
+
+    @pytest.mark.asyncio
+    async def test_write_parameters_value_error_wrapped(self) -> None:
+        """A bitfield/unmapped-register ValueError surfaces as TransportWriteError."""
+        from pylxpweb.transports.exceptions import TransportWriteError
+
+        client = MagicMock()
+        client.login = AsyncMock()
+        client.api.control.write_parameters = AsyncMock(
+            side_effect=ValueError("Register 21 is a bitfield")
+        )
+
+        transport = HTTPTransport(client, serial="CE12345678")
+        await transport.connect()
+
+        with pytest.raises(TransportWriteError, match="Register 21 is a bitfield"):
+            await transport.write_parameters({21: 512})

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.36"
+version = "0.9.37"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release-gating bugfixes for **0.9.37**, found during the eg4_web_monitor 3.4.0-final adversarial review (Codex GPT-5.5 + Gemini 3.1 Pro + Claude, three rounds).

### The headline bug
`control.write_parameters(sn, {register: raw})` — the cloud raw-register write — **never worked**: the nested dict form-encoded as `data=<reg>&data=<reg>`, dropping every value on the wire (empirically reproduced with aiohttp). This is the root cause of the historical param-specific cloud write failures, and it made eg4_web_monitor 3.4.0's five voltage-limit number entities silently unable to write in pure-CLOUD mode.

**Fix (live-validated 2026-07-07 on a FlexBOSS21, write→readback→restore on regs 228 and 158):** each register now resolves to the portal's named singular write (`holdParam`/`valueText`) with proper raw→engineering-unit conversion (canonical `ScaleFactor`, `LOCAL_PARAM_SCALE_DIV10`, and a new evidence-documented `CLOUD_WRITE_DIV10_REGISTERS` set). Bitfield, signed, packed-schedule, and unmapped registers raise `ValueError` (atomically, before any write is sent) instead of sending a malformed body.

### Also fixed
- Regs 158/159 `api_param_key` → `HOLD_AC_CHARGE_*_BATTERY_VOLTAGE` (server HTTP-400s the `*_VOLTAGE` names; live-tested).
- `set_ac_charge_voltage_limits` wrote decivolts ("400" for 40 V) against a volts-taking server; getter divided reads by 10. Both corrected; start-write failure now returned before writing the end limit.
- `_set_schedule` (cloud writeTime + classic paths, and the local Modbus path) stop at the first failed write instead of returning success over a half-applied window.
- Dongle write ACKs: an empty ACK payload no longer bypasses echo validation (FC06 + FC16) — raises `TransportWriteError`.
- `HTTPTransport.write_parameters` raises on `success=false` and wraps resolver `ValueError` in `TransportWriteError`; `BaseInverter.write_parameters` cloud branch degrades `ValueError` to `False` per its bool contract.

### Known/accepted (follow-up issue to come)
Legacy cloud raw-bitfield callers (`set_standby_mode`, `set_ac_charge`, `set_ac_charge_type`) were already broken in cloud mode (they computed values from named-read misses and sent the malformed body); they now fail loudly (`False`/`ValueError`-wrapped) instead of silently. eg4_web_monitor calls none of them. Refactoring them onto `control_function` is deferred.

## Test plan
- Full suite: **2726 passed** (baseline 2686; +40 new tests covering scaling per register, atomic pre-validation, first-failure stop for all schedule paths, empty-ACK, volts wire format, signed-register invariant).
- ruff + ruff format + mypy (strict): clean.
- Live hardware validation: no-op and delta write→readback→restore cycles via the rewritten path on FlexBOSS21 52842P0581; negative checks (bitfield reg 21, unmapped reg 9999) raise as designed.

## Review
- Codex GPT-5.5 @ xhigh: round-1 BLOCKER + HIGHs → fixed; round-2 findings → fixed/refuted with live-probe evidence; round 3: **NO BLOCKING ISSUES**.
- Gemini 3.1 Pro: round-1 HIGHs → fixed; round 2: **NO BLOCKING ISSUES**.
- Claude: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)