### PR TITLE
fix: accept single-tick daily energy increments (#346)

### DIFF
--- a/src/pylxpweb/validation.py
+++ b/src/pylxpweb/validation.py
@@ -175,6 +175,15 @@ MAX_ELAPSED_HOURS = 24.0
 # would reject the smallest possible real increment.
 MIN_DAILY_DELTA = 0.1
 
+# Floating-point tolerance (kWh) for the delta-vs-bound comparison.  Register
+# deltas are exact multiples of 0.1 kWh, but IEEE-754 subtraction does not
+# preserve that: e.g. ``4.4 - 4.3 == 0.10000000000000053``, which spuriously
+# exceeds a 0.1 bound and rejected valid single ticks on low-usage inverters
+# (#346).  This tolerance absorbs representation error only; it is ~5 orders
+# of magnitude below the 0.1 resolution, so genuine corrupt spikes (which are
+# orders of magnitude *above* the bound) remain rejected.
+DELTA_FLOAT_TOLERANCE = 1e-6
+
 
 def validate_daily_energy_bounds(
     curr_values: dict[str, float | None],
@@ -248,7 +257,7 @@ def validate_daily_energy_bounds(
             prev = prev_values.get(key)
             if prev is not None and curr > prev:
                 delta = curr - prev
-                if delta > delta_bound:
+                if delta > delta_bound + DELTA_FLOAT_TOLERANCE:
                     _LOGGER.warning(
                         "%s daily energy spike rejected: %s jumped "
                         "%.1f -> %.1f (delta %.1f > %.1f max, "

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -488,6 +488,30 @@ class TestMinDailyDelta:
             prev_values=prev,
         )
 
+    def test_single_tick_accepted_despite_float_error(self) -> None:
+        """A single 0.1 kWh tick must be accepted for every base value.
+
+        Regression for #346: ``curr - prev`` for one register tick is not
+        exactly 0.1 in IEEE-754 (e.g. ``4.4 - 4.3 == 0.10000000000000053``),
+        so a bare ``delta > 0.1`` floor rejected valid minimum increments on
+        low-usage inverters.  These are the exact pairs from the bug report
+        plus others whose float subtraction overshoots 0.1.
+        """
+        for prev_val, curr_val in [
+            (4.3, 4.4),
+            (6.1, 6.2),
+            (8.7, 8.8),
+            (0.1, 0.2),
+            (2.6, 2.7),
+        ]:
+            assert validate_daily_energy_bounds(
+                {"load_energy_today": curr_val},
+                "test_dev",
+                rated_power_kw=10.0,
+                elapsed_seconds=4.1,
+                prev_values={"load_energy_today": prev_val},
+            ), f"single tick {prev_val} -> {curr_val} should be accepted"
+
     def test_floor_value(self) -> None:
         """MIN_DAILY_DELTA matches energy register resolution (0.1 kWh)."""
         assert MIN_DAILY_DELTA == 0.1


### PR DESCRIPTION
## Problem

Low-usage inverters logged valid daily-energy increments being rejected as spikes:

```
daily energy spike rejected: load_energy_today jumped 4.3 -> 4.4 (delta 0.1 > 0.1 max, 10 kW × 4.1s elapsed × 2x margin)
```

Reported in joyfulhouse/eg4_web_monitor#346. Every rejected value is exactly **one 0.1 kWh register tick** — the smallest physically possible increment.

## Root cause

`validate_daily_energy_bounds` floors the delta bound at `MIN_DAILY_DELTA` (0.1 kWh) precisely so a single tick always passes. But the comparison used raw IEEE-754 subtraction:

```python
>>> 4.4 - 4.3
0.10000000000000053   # > 0.1  → falsely rejected
>>> 5.1 - 5.0
0.09999999999999964   # < 0.1  → happened to pass
```

So ~half of all single-tick values (depending on the base value) overshoot the 0.1 floor and get rejected. The existing floor test passed only by luck — it used `5.0 → 5.1`, which rounds *down*.

## Fix

Add `DELTA_FLOAT_TOLERANCE = 1e-6` kWh to the delta-vs-bound comparison. It absorbs representation error only — ~5 orders of magnitude below the 0.1 kWh resolution — so genuine corrupt spikes (orders of magnitude *above* the bound) are still rejected. The existing `test_corrupt_spike_still_rejected` (6549 kWh in 5s) confirms this.

## Tests

- New `test_single_tick_accepted_despite_float_error` covers the exact pairs from the bug report (4.3→4.4, 6.1→6.2, 8.7→8.8) plus others that overshoot 0.1. Fails on `main`, passes with the fix.
- Full suite: 2727 passed. Lint + mypy clean.

Ships to the eg4 integration on the next pylxpweb release + pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)