### PR TITLE
fix: normalize battery-temperature 0x7F sentinel (eg4_web_monitor#348)

### DIFF
--- a/src/pylxpweb/devices/inverters/_runtime_properties.py
+++ b/src/pylxpweb/devices/inverters/_runtime_properties.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pylxpweb.constants import derive_pv_current, scale_runtime_value
+from pylxpweb.transports.data import BATTERY_TEMPERATURE_SENTINEL_C
 
 from ._features import InverterFamily
 
@@ -412,8 +413,18 @@ class InverterRuntimePropertiesMixin:
 
     @property
     def battery_temperature(self) -> int | None:
-        """Get battery temperature in Celsius."""
-        return self._raw_int("battery_temperature", "tBat")
+        """Get battery temperature in Celsius.
+
+        The 0x7F (127) "no reading" sentinel emitted by inverters without a
+        local battery temperature sensor (e.g. shared-battery secondaries,
+        reg 96 = 0) is normalized to None (eg4_web_monitor#348): on the
+        transport path via ``InverterRuntimeData.__post_init__``, and here for
+        the pure-cloud path where ``_runtime`` is the raw ``InverterRuntime``.
+        """
+        value = self._raw_int("battery_temperature", "tBat")
+        if value == BATTERY_TEMPERATURE_SENTINEL_C:
+            return None
+        return value
 
     @property
     def max_charge_current(self) -> float | None:

--- a/src/pylxpweb/devices/inverters/generic.py
+++ b/src/pylxpweb/devices/inverters/generic.py
@@ -158,7 +158,10 @@ class GenericInverter(BaseInverter):
                     )
                 )
 
-            if hasattr(self._runtime, "tBat"):
+            # Use the normalized property so the 0x7F (127 °C) "no reading"
+            # sentinel surfaces as unknown rather than a bogus reading
+            # (eg4_web_monitor#348).
+            if (battery_temp := self.battery_temperature) is not None:
                 entities.append(
                     Entity(
                         unique_id=f"{self.serial_number}_temp_battery",
@@ -166,7 +169,7 @@ class GenericInverter(BaseInverter):
                         device_class=DeviceClass.TEMPERATURE,
                         state_class=StateClass.MEASUREMENT,
                         unit_of_measurement="°C",
-                        value=self._runtime.tBat,
+                        value=battery_temp,
                     )
                 )
 

--- a/src/pylxpweb/transports/data.py
+++ b/src/pylxpweb/transports/data.py
@@ -59,6 +59,16 @@ _LOGGER = logging.getLogger(__name__)
 # and this canary agree on what "absurd" means.
 _MAX_LIFETIME_ENERGY_KWH = MAX_LIFETIME_KWH
 
+# Battery temperature "no reading" sentinel (input reg 67, unscaled °C).  An
+# inverter without a local battery temperature sensor (e.g. a shared-battery
+# secondary, reg 96 = 0) reports 0x7F (127) as an int8 placeholder rather than a
+# real reading.  Normalized to None on construction so the sensor reads unknown
+# and the value never trips the runtime temperature canary and rejects the whole
+# payload (eg4_web_monitor#348).  Only the EXACT sentinel is treated this way —
+# any other out-of-range temperature is left intact so is_corrupt() still
+# catches genuine register corruption (e.g. a 0xFFFF frame shift).
+BATTERY_TEMPERATURE_SENTINEL_C = 127.0
+
 # Fields on InverterRuntimeData that store raw int values (no ÷10/÷100 scaling).
 # Used by from_modbus_registers() to decide between read_raw() and read_scaled().
 _RUNTIME_INT_FIELDS: frozenset[str] = frozenset(
@@ -305,6 +315,10 @@ class InverterRuntimeData:
         self._raw_soh = self.battery_soh
         self.battery_soc = _clamp_percentage(self.battery_soc, "battery_soc")
         self.battery_soh = _clamp_percentage(self.battery_soh, "battery_soh")
+        # Normalize the battery-temperature "no reading" sentinel for every
+        # construction path (Modbus, cloud, direct) — see the constant above.
+        if self.battery_temperature == BATTERY_TEMPERATURE_SENTINEL_C:
+            self.battery_temperature = None
 
     @property
     def grid_power(self) -> float | None:
@@ -395,7 +409,11 @@ class InverterRuntimeData:
             if v is not None and v > 300:
                 _LOGGER.warning("Canary: %s=%.1f > 300V", label, v)
                 return True
-        # Temperatures: -40 to 100°C covers all operating conditions.
+        # Temperatures: -40 to 100°C covers all operating conditions.  The
+        # battery-temperature "no reading" sentinel (127 °C) is already None by
+        # this point (normalized in __post_init__, eg4_web_monitor#348), so it
+        # never trips this check — but a genuinely corrupt out-of-range read on
+        # any of the temperature registers below still rejects the frame.
         for label, t in (
             ("internal_temperature", self.internal_temperature),
             ("radiator_temperature_1", self.radiator_temperature_1),
@@ -488,7 +506,9 @@ class InverterRuntimeData:
             battery_soc=runtime.soc,
             battery_charge_power=_opt_power(runtime.pCharge),
             battery_discharge_power=_opt_power(runtime.pDisCharge),
-            battery_temperature=float(runtime.tBat or 0),
+            # Preserve None for an offline device (see comment above); the 0x7F
+            # sentinel is normalized to None in __post_init__ (eg4_web_monitor#348).
+            battery_temperature=_opt_power(runtime.tBat),
             # Grid
             grid_voltage_r=scale_runtime_value("vacr", runtime.vacr),
             grid_voltage_s=scale_runtime_value("vacs", runtime.vacs),
@@ -698,6 +718,9 @@ class InverterRuntimeData:
             if not kwargs.get("eps_apparent_power") and (eps_va_l1 or eps_va_l2):
                 kwargs["eps_apparent_power"] = eps_va_l1 + eps_va_l2
 
+        # The battery-temperature "no reading" sentinel (reg 67 = 0x7F) is
+        # normalized to None in __post_init__, shared with every construction
+        # path — no per-factory handling needed here (eg4_web_monitor#348).
         return cls(timestamp=datetime.now(), **kwargs)
 
 
@@ -1370,6 +1393,10 @@ class BatteryBankData:
             self.soc = _clamp_percentage(self.soc, "battery_bank_soc")
         if self.soh is not None:
             self.soh = _clamp_percentage(self.soh, "battery_bank_soh")
+        # Battery temperature "no reading" sentinel (reg 67 = 0x7F), same as the
+        # inverter runtime path (eg4_web_monitor#348).
+        if self.temperature == BATTERY_TEMPERATURE_SENTINEL_C:
+            self.temperature = None
 
     def is_corrupt(self) -> bool:
         """Check if battery bank data contains physically impossible values.

--- a/tests/unit/devices/inverters/test_runtime_properties.py
+++ b/tests/unit/devices/inverters/test_runtime_properties.py
@@ -229,6 +229,19 @@ class TestBatteryProperties:
         """Verify battery temperature has no scaling."""
         assert inverter_with_runtime.battery_temperature == 25
 
+    def test_battery_temperature_cloud_sentinel_is_none(self):
+        """Pure-cloud path: the raw InverterRuntime tBat=127 "no reading"
+        sentinel is normalized to None so a no-BMS secondary reads unknown
+        rather than a bogus 127°C (eg4_web_monitor#348)."""
+        inverter = GenericInverter(
+            client=MagicMock(), serial_number="1234567890", model="FlexBOSS21"
+        )
+        inverter._runtime = InverterRuntime.model_construct(tBat=127)
+        assert inverter.battery_temperature is None
+        # A real cloud reading is still surfaced.
+        inverter._runtime = InverterRuntime.model_construct(tBat=25)
+        assert inverter.battery_temperature == 25
+
     def test_battery_currents_scaled_correctly(self, inverter_with_runtime):
         """Verify battery currents use ÷100 scaling."""
         assert inverter_with_runtime.max_charge_current == 100.0

--- a/tests/unit/transports/test_data.py
+++ b/tests/unit/transports/test_data.py
@@ -208,8 +208,10 @@ class TestInverterRuntimeData:
         assert data.inverter_power is None
         assert data.eps_power is None
         assert data.device_status is None
-        # Fields the offline payload DOES carry still convert.
+        # Fields the offline payload DOES carry still convert (offline devices
+        # still report temperatures — tBat is a required field).
         assert data.internal_temperature == 33.0  # tinner present
+        assert data.battery_temperature == 5.0  # tBat present in this payload
 
     def test_from_http_response_omitted_pv3_is_none(self) -> None:
         """A 2-string payload omitting vpv3/ppv3 → pv3 stays None, not 0.

--- a/tests/unit/transports/test_data_corruption.py
+++ b/tests/unit/transports/test_data_corruption.py
@@ -38,6 +38,36 @@ class TestInverterRuntimeDataCorruption:
         )
         assert data.is_corrupt() is False
 
+    def test_battery_temperature_sentinel_from_registers_is_none(self) -> None:
+        """A shared-battery secondary (reg 96 = 0, no local BMS) reports reg 67 =
+        0x7F (127 C) as "no reading".  from_modbus_registers() must map that
+        sentinel to None so the sensor reads unknown rather than a bogus 127 C
+        (eg4_web_monitor#348)."""
+        input_regs: dict[int, int] = {
+            1: 5100,  # PV1 voltage
+            2: 5050,  # PV2 voltage
+            7: 1000,  # PV1 power
+            8: 1500,  # PV2 power
+            15: 5998,  # Grid frequency 59.98 Hz
+            64: 25,  # Internal temp (valid)
+            65: 40,  # Radiator temp 1 (valid)
+            66: 38,  # Radiator temp 2 (valid)
+            67: 127,  # Battery temp sentinel (0x7F "no reading")
+        }
+        data = InverterRuntimeData.from_modbus_registers(input_regs)
+        assert data.battery_temperature is None
+        # The lone battery-temp sentinel must NOT invalidate the whole runtime.
+        assert data.is_corrupt() is False
+        assert data.pv1_voltage == 510.0
+        assert data.internal_temperature == 25.0
+
+    def test_battery_temperature_valid_reading_preserved(self) -> None:
+        """A real battery temperature is unaffected by the sentinel handling."""
+        input_regs: dict[int, int] = {67: 25}  # 25 C
+        data = InverterRuntimeData.from_modbus_registers(input_regs)
+        assert data.battery_temperature == 25.0
+        assert data.is_corrupt() is False
+
     def test_raw_soc_above_100_is_corrupt(self) -> None:
         """is_corrupt() returns True when _raw_soc > 100 (e.g. battery_soc=144)."""
         data = InverterRuntimeData(battery_soc=144)
@@ -277,6 +307,13 @@ class TestBatteryBankDataCorruption:
         """is_corrupt() returns False for empty batteries list with valid bank SoC/SoH."""
         data = BatteryBankData(soc=85, soh=95, batteries=[])
         assert data.is_corrupt() is False
+
+    def test_battery_temperature_sentinel_normalized(self) -> None:
+        """The 127°C "no reading" sentinel is normalized to None on the bank path
+        too, so a no-BMS secondary never surfaces a bogus 127°C
+        (eg4_web_monitor#348)."""
+        assert BatteryBankData(soc=85, soh=95, temperature=127.0).temperature is None
+        assert BatteryBankData(soc=85, soh=95, temperature=22.0).temperature == 22.0
 
     def test_battery_count_above_20_is_corrupt(self) -> None:
         """is_corrupt() returns True when battery_count exceeds physical maximum."""
@@ -520,6 +557,20 @@ class TestInverterTemperatureCanary:
     def test_bms_cell_temperature_below_minus40_is_corrupt(self) -> None:
         """BMS cell temperature < -40°C triggers corruption."""
         data = InverterRuntimeData(bms_min_cell_temperature=-50.0)
+        assert data.is_corrupt() is True
+
+    def test_battery_temperature_sentinel_normalized_not_fatal(self) -> None:
+        """The exact 127°C sentinel is normalized to None (any construction
+        path), so it never trips the canary (eg4_web_monitor#348)."""
+        data = InverterRuntimeData(battery_temperature=127.0)
+        assert data.battery_temperature is None
+        assert data.is_corrupt() is False
+
+    def test_battery_temperature_genuine_corruption_still_fatal(self) -> None:
+        """A non-sentinel out-of-range battery temperature is still treated as
+        corruption — only the exact 127°C sentinel is excused."""
+        data = InverterRuntimeData(battery_temperature=150.0)
+        assert data.battery_temperature == 150.0
         assert data.is_corrupt() is True
 
     def test_none_temperatures_bypass_check(self) -> None:


### PR DESCRIPTION
## Bug

eg4_web_monitor#348 — in a LOCAL (Modbus TCP) system with three parallel FlexBOSS21 inverters, **one** inverter reported *unknown* for **every** sensor after the 3.4 update. The device still appeared with the correct serial/PV, but all runtime sensors were blank.

## Root cause

The affected inverter is a **shared-battery secondary** (reg 96 = 0, no local BMS), so it has no battery-temperature sensor and reports input **register 67 as `0x7F` (127 °C)** — an int8 "no reading" placeholder. The runtime corruption canary `InverterRuntimeData.is_corrupt()` treats any temperature > 100 °C as corruption and **rejects the entire runtime payload** (`"Corrupt runtime in combined read"`), which blanks every sensor on that device. The other two inverters reported valid battery temps, so only one of three was affected. Confirmed from the reporter's debug log (canary tripped identically with `battery_temperature=127.0` on all 26 poll cycles).

## Fix

Normalize the **exact** `127.0` sentinel to `None` on every read path, so the sensor reads *unknown* and the value never reaches the canary:

- `InverterRuntimeData.__post_init__` — transport (Modbus) + direct construction
- `BatteryBankData.__post_init__` — battery-bank aggregate (same reg 67)
- `BaseInverter.battery_temperature` property — pure-cloud path (raw `InverterRuntime`, bypasses `__post_init__`)
- `from_http_response` / `generic.to_entities()` — surfacing paths

The `is_corrupt()` canary is **unchanged**: all six temperature fields stay fatal, so a *genuinely* corrupt out-of-range reading (e.g. a `0xFFFF` frame shift → thousands of °C) is still rejected. Only the exact `0x7F` sentinel is excused (127 °C is well past thermal runaway), and it is `None` before the canary runs.

## Test plan

- `uv run pytest` — **2732 passed**
- New regression tests: transport `from_modbus_registers` sentinel→None; direct-construct sentinel→None; **genuine corruption (150 °C) still fatal**; battery-bank sentinel→None; cloud-property `tBat=127`→None; offline `from_http_response` present-temp converts.
- `ruff check` / `ruff format` / `mypy` clean.

## Review

Tri-vendor adversarial review (Claude + Codex GPT-5.5/xhigh + Gemini 3.1 Pro), 4 rounds:
- Round 1 caught that broad range-nulling + demoting temps from the canary would **mask genuine corruption** → revised to exact-sentinel + canary kept intact.
- Round 2/3 caught the pure-cloud property + `to_entities()` bypass paths → fixed.
- Risk-accepted / dismissed with rationale: `from_http_response` `tBat or 0` (tBat is a **required** field, so `None`-collapse is unreachable; changed to `_opt_power` for consistency anyway); `BatteryBankData.is_corrupt()` lacking a temperature canary (redundant — a corrupt reg 67 is already rejected frame-wide by the runtime canary in `_fetch_combined_input_data` before the bank is assigned); `to_entities()` being cloud-only (pre-existing library method, not used by the HA integration).

## Downstream

Resolving the user's issue also needs a pylxpweb release + an eg4_web_monitor pin bump to the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)