### PR TITLE
fix: firmware version prefix preservation + multi-step update orchestrator (eg4_web_monitor#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`run_firmware_update_to_completion()` multi-step firmware orchestrator**
+  ([eg4_web_monitor#353](https://github.com/joyfulhouse/eg4_web_monitor/issues/353)):
+  some devices (6000XP) require `standardUpdate/run` once per firmware
+  component — the portal/mobile app chain the calls, but a single
+  `start_firmware_update()` left the device on a partial version
+  (`ccaa-1E1415` instead of `ccaa-1E1515`). The new
+  `FirmwareUpdateMixin.run_firmware_update_to_completion()` loops
+  check → eligibility → start → poll → re-check until the device converges,
+  bounded by a step budget (5, the API's `needRunStep5` maximum), a per-step
+  timeout, and a no-version-progress abort so a stuck chain never loops
+  writes. Returns the new `FirmwareUpdateRunResult` model (success,
+  converged, steps_run, message, final_version).
+
 ### Fixed
+
+- **Firmware "latest version" dropped leading prefix bytes on 3-component
+  versions** ([eg4_web_monitor#353](https://github.com/joyfulhouse/eg4_web_monitor/issues/353)):
+  `FirmwareUpdateInfo.from_api_response` built the update target as
+  `{code.split('-')[0]}-{lastV1}{lastV2}`, which truncated 6000XP-class codes
+  carrying a third leading version byte (`ccaa-1E1415` showed the target as
+  `ccaa-1515` instead of `ccaa-1E1515`). The current `v1`/`v2` hex pair is
+  now verified to occupy the trailing 4 characters and exactly those are
+  replaced, preserving any prefix; unverified layouts keep the legacy
+  construction.
 
 - **Legacy cloud bitfield writes silently no-opped** ([#223](https://github.com/joyfulhouse/pylxpweb/issues/223)):
   `set_standby_mode` (reg 21), `set_ac_charge` (reg 21) and

--- a/src/pylxpweb/__init__.py
+++ b/src/pylxpweb/__init__.py
@@ -82,6 +82,7 @@ from .models import (
     DatalogListResponse,
     DongleStatus,
     FirmwareUpdateInfo,
+    FirmwareUpdateRunResult,
     MonthlyEnergyHistory,
     OperatingMode,
 )
@@ -121,6 +122,7 @@ __all__ = [
     "DatalogListResponse",
     "DongleStatus",
     "FirmwareUpdateInfo",
+    "FirmwareUpdateRunResult",
     "MonthlyEnergyHistory",
     # Enums
     "OperatingMode",

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pylxpweb import LuxpowerClient
-    from pylxpweb.models import FirmwareUpdateInfo
+    from pylxpweb.models import FirmwareUpdateInfo, FirmwareUpdateRunResult
 
     class _FirmwareMixinBase:
         """Typed stubs so mypy sees attributes provided by the host class."""
@@ -513,3 +513,141 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
 
         eligibility = await client.api.firmware.check_update_eligibility(serial)
         return eligibility.is_allowed
+
+    async def run_firmware_update_to_completion(
+        self,
+        *,
+        try_fast_mode: bool = False,
+        poll_interval: float = 30.0,
+        max_steps: int = 5,
+        step_timeout: float = 3600.0,
+    ) -> FirmwareUpdateRunResult:
+        """Run firmware updates until the device converges on the latest version.
+
+        ⚠️ CRITICAL WARNING - WRITE OPERATION (potentially long-running)
+
+        Some devices require ``standardUpdate/run`` once per firmware
+        component: the portal and mobile app chain these calls automatically,
+        but a single :meth:`start_firmware_update` call leaves such a device
+        on a partial version — e.g. a 6000XP asked to go to ``ccaa-1E1515``
+        lands on ``ccaa-1E1415`` (eg4_web_monitor#353). The check response
+        advertises the chain via ``needRunStep2``..``needRunStep5``.
+
+        This orchestrator loops: check → start → poll to completion →
+        re-check, until no update remains, a step makes no version progress
+        (fail-safe against server-side loops), the step budget is exhausted,
+        or a step times out. Each iteration re-verifies eligibility before
+        issuing the next run.
+
+        Args:
+            try_fast_mode: Attempt fast update mode on each run.
+            poll_interval: Seconds between progress polls while a step is
+                installing.
+            max_steps: Upper bound on ``standardUpdate/run`` invocations
+                (the API defines steps 2-5, so 5 covers every known chain).
+            step_timeout: Seconds to wait for a single step to finish
+                installing before aborting.
+
+        Returns:
+            FirmwareUpdateRunResult describing convergence, steps run, and a
+            human-readable outcome message.
+
+        Raises:
+            LuxpowerAuthError: If authentication fails.
+            LuxpowerAPIError: If an API call fails outright.
+            LuxpowerConnectionError: If connection fails.
+        """
+        # Import here to avoid circular imports
+        from pylxpweb.models import FirmwareUpdateRunResult
+
+        def _versions(info: FirmwareUpdateInfo) -> tuple[int | None, int | None]:
+            return (info.app_version_current, info.param_version_current)
+
+        info = await self.check_firmware_updates(force=True)
+        if not info.update_available:
+            return FirmwareUpdateRunResult(
+                success=True,
+                converged=True,
+                steps_run=0,
+                message="Firmware already up to date",
+                final_version=info.installed_version,
+            )
+
+        steps_run = 0
+        loop = asyncio.get_running_loop()
+        for _ in range(max_steps):
+            before = _versions(info)
+
+            if not await self.check_update_eligibility():
+                return FirmwareUpdateRunResult(
+                    success=False,
+                    converged=False,
+                    steps_run=steps_run,
+                    message=("Device not eligible for update (another update may be in progress)"),
+                    final_version=info.installed_version,
+                )
+
+            started = await self.start_firmware_update(try_fast_mode=try_fast_mode)
+            steps_run += 1
+            if not started:
+                return FirmwareUpdateRunResult(
+                    success=False,
+                    converged=False,
+                    steps_run=steps_run,
+                    message="API refused to start the firmware update",
+                    final_version=info.installed_version,
+                )
+
+            # Poll the step to completion. The first poll is forced so a
+            # stale not-in-progress cache entry cannot end the wait early.
+            deadline = loop.time() + step_timeout
+            force_poll = True
+            while True:
+                progress = await self.get_firmware_update_progress(force=force_poll)
+                force_poll = False
+                if not progress.in_progress:
+                    break
+                if loop.time() >= deadline:
+                    return FirmwareUpdateRunResult(
+                        success=False,
+                        converged=False,
+                        steps_run=steps_run,
+                        message=(
+                            f"Firmware update step {steps_run} did not finish "
+                            f"within {int(step_timeout)}s"
+                        ),
+                        final_version=info.installed_version,
+                    )
+                await asyncio.sleep(poll_interval)
+
+            info = await self.check_firmware_updates(force=True)
+            if not info.update_available:
+                return FirmwareUpdateRunResult(
+                    success=True,
+                    converged=True,
+                    steps_run=steps_run,
+                    message=(f"Firmware update complete after {steps_run} step(s)"),
+                    final_version=info.installed_version,
+                )
+
+            if _versions(info) == before:
+                # A run completed but neither component advanced — do not
+                # keep issuing writes against an unresponsive chain.
+                return FirmwareUpdateRunResult(
+                    success=False,
+                    converged=False,
+                    steps_run=steps_run,
+                    message=(
+                        f"No firmware version progress after step {steps_run}; "
+                        "stopping (update may need to be run from the portal)"
+                    ),
+                    final_version=info.installed_version,
+                )
+
+        return FirmwareUpdateRunResult(
+            success=False,
+            converged=False,
+            steps_run=steps_run,
+            message=(f"Update still available after {steps_run} steps; stopping at step budget"),
+            final_version=info.installed_version,
+        )

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -514,6 +514,23 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         eligibility = await client.api.firmware.check_update_eligibility(serial)
         return eligibility.is_allowed
 
+    async def _update_step_reported_failed(self) -> bool:
+        """Whether ``remoteUpdate/info`` reports this device's update as FAILED.
+
+        Consulted by the run-to-completion orchestrator after each step ends:
+        the aggregated progress conversion collapses every non-installing
+        state to ``in_progress=False``, so the terminal FAILED status must be
+        read from the raw status row.
+        """
+        client: LuxpowerClient = self._client
+        serial: str = self.serial_number
+        status = await client.api.firmware.get_firmware_update_status()
+        row = next(
+            (item for item in status.deviceInfos if item.inverterSn == serial),
+            None,
+        )
+        return row is not None and row.is_failed
+
     async def run_firmware_update_to_completion(
         self,
         *,
@@ -522,6 +539,8 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         max_steps: int = 5,
         step_timeout: float = 3600.0,
         start_grace: float = 300.0,
+        settle_checks: int = 3,
+        settle_interval: float = 30.0,
     ) -> FirmwareUpdateRunResult:
         """Run firmware updates until the device converges on the latest version.
 
@@ -553,6 +572,10 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 server registers an accepted run in ``remoteUpdate/info``
                 asynchronously — without this grace, an early poll seeing
                 idle status would be mistaken for instant completion.
+            settle_checks: Extra post-step version re-checks before an
+                unchanged version is declared "no progress" (the check
+                endpoint can lag the status endpoint's terminal state).
+            settle_interval: Seconds between those settle re-checks.
 
         Returns:
             FirmwareUpdateRunResult describing convergence, steps run, and a
@@ -566,8 +589,19 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         # Import here to avoid circular imports
         from pylxpweb.models import FirmwareUpdateRunResult
 
-        def _versions(info: FirmwareUpdateInfo) -> tuple[int | None, int | None]:
-            return (info.app_version_current, info.param_version_current)
+        def _progress_key(
+            info: FirmwareUpdateInfo,
+        ) -> tuple[str | None, int | None, int | None]:
+            # The full installed code is the primary progress signal: it
+            # also captures prefix-byte movement (ccaa-1D.. -> ccaa-1E..)
+            # that the trailing v1/v2 pair cannot see (lastV3 does not
+            # exist in the API). The pair rides along for layouts where
+            # the code string is empty.
+            return (
+                info.installed_version or None,
+                info.app_version_current,
+                info.param_version_current,
+            )
 
         info = await self.check_firmware_updates(force=True)
         if not info.update_available:
@@ -580,9 +614,13 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             )
 
         steps_run = 0
+        # The converged version to report: once the device is up to date the
+        # check endpoint answers with the bare "already latest" sentinel
+        # (empty fwCodeBeforeUpload), so remember the target we converged to.
+        last_target = info.latest_version or None
         loop = asyncio.get_running_loop()
         for _ in range(max_steps):
-            before = _versions(info)
+            before = _progress_key(info)
 
             if not await self.check_update_eligibility():
                 return FirmwareUpdateRunResult(
@@ -636,18 +674,43 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     )
                 await asyncio.sleep(poll_interval)
 
-            info = await self.check_firmware_updates(force=True)
-            if not info.update_available:
+            # A step that ended in FAILED must stop the chain: firing another
+            # run against a device whose previous step failed is exactly the
+            # class of blind write this orchestrator exists to prevent.
+            if await self._update_step_reported_failed():
                 return FirmwareUpdateRunResult(
-                    success=True,
-                    converged=True,
+                    success=False,
+                    converged=False,
                     steps_run=steps_run,
-                    message=(f"Firmware update complete after {steps_run} step(s)"),
+                    message=(
+                        f"Firmware update step {steps_run} reported FAILED by "
+                        "the server; not issuing further update commands"
+                    ),
                     final_version=info.installed_version,
                 )
 
-            if _versions(info) == before:
-                # A run completed but neither component advanced — do not
+            # Post-step re-check with a bounded settle window: the check
+            # endpoint's version data can lag the status endpoint's terminal
+            # state (cloud eventual consistency), and a single immediate
+            # re-check could mistake that lag for a dead chain.
+            for settle in range(settle_checks + 1):
+                if settle:
+                    await asyncio.sleep(settle_interval)
+                info = await self.check_firmware_updates(force=True)
+                if info.latest_version:
+                    last_target = info.latest_version
+                if not info.update_available:
+                    return FirmwareUpdateRunResult(
+                        success=True,
+                        converged=True,
+                        steps_run=steps_run,
+                        message=(f"Firmware update complete after {steps_run} step(s)"),
+                        final_version=info.installed_version or last_target,
+                    )
+                if _progress_key(info) != before:
+                    break  # component advanced — continue the chain
+            else:
+                # No version movement across the settle window — do not
                 # keep issuing writes against an unresponsive chain.
                 return FirmwareUpdateRunResult(
                     success=False,

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -521,6 +521,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         poll_interval: float = 30.0,
         max_steps: int = 5,
         step_timeout: float = 3600.0,
+        start_grace: float = 300.0,
     ) -> FirmwareUpdateRunResult:
         """Run firmware updates until the device converges on the latest version.
 
@@ -547,6 +548,11 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 (the API defines steps 2-5, so 5 covers every known chain).
             step_timeout: Seconds to wait for a single step to finish
                 installing before aborting.
+            start_grace: Seconds to keep polling for the update to become
+                visible (``in_progress=True``) after an accepted start. The
+                server registers an accepted run in ``remoteUpdate/info``
+                asynchronously — without this grace, an early poll seeing
+                idle status would be mistaken for instant completion.
 
         Returns:
             FirmwareUpdateRunResult describing convergence, steps run, and a
@@ -598,14 +604,24 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     final_version=info.installed_version,
                 )
 
-            # Poll the step to completion. The first poll is forced so a
-            # stale not-in-progress cache entry cannot end the wait early.
+            # Poll the step to completion in two phases. The server registers
+            # an accepted run in remoteUpdate/info asynchronously, so an idle
+            # status straight after start does NOT mean the step finished —
+            # keep polling within start_grace until the update becomes
+            # visible (or grace expires: fast steps can genuinely complete
+            # between polls, which the post-step version re-check resolves).
+            # The first poll is forced so a stale not-in-progress cache entry
+            # cannot end the wait early.
             deadline = loop.time() + step_timeout
+            grace_deadline = loop.time() + start_grace
+            saw_in_progress = False
             force_poll = True
             while True:
                 progress = await self.get_firmware_update_progress(force=force_poll)
                 force_poll = False
-                if not progress.in_progress:
+                if progress.in_progress:
+                    saw_in_progress = True
+                elif saw_in_progress or loop.time() >= grace_deadline:
                     break
                 if loop.time() >= deadline:
                     return FirmwareUpdateRunResult(
@@ -639,7 +655,9 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     steps_run=steps_run,
                     message=(
                         f"No firmware version progress after step {steps_run}; "
-                        "stopping (update may need to be run from the portal)"
+                        "stopping to avoid repeated update commands (if the "
+                        "device is still installing, wait for it to finish "
+                        "before retrying)"
                     ),
                     final_version=info.installed_version,
                 )

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -394,6 +394,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             app_version_latest=self._firmware_update_info.app_version_latest,
             param_version_current=self._firmware_update_info.param_version_current,
             param_version_latest=self._firmware_update_info.param_version_latest,
+            needs_run_steps=self._firmware_update_info.needs_run_steps,
         )
 
         # Update cache with progress data
@@ -482,6 +483,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     app_version_latest=self._firmware_update_info.app_version_latest,
                     param_version_current=self._firmware_update_info.param_version_current,
                     param_version_latest=self._firmware_update_info.param_version_latest,
+                    needs_run_steps=self._firmware_update_info.needs_run_steps,
                 )
                 # Update timestamp so next progress call uses 10-second cache
                 self._firmware_update_cache_time = datetime.now()
@@ -678,6 +680,11 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             # run against a device whose previous step failed is exactly the
             # class of blind write this orchestrator exists to prevent.
             if await self._update_step_reported_failed():
+                # Re-check so the reported version reflects any partial
+                # advance the failed step made before stopping.
+                info = await self.check_firmware_updates(force=True)
+                if info.latest_version:
+                    last_target = info.latest_version
                 return FirmwareUpdateRunResult(
                     success=False,
                     converged=False,

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -1420,6 +1420,11 @@ class FirmwareUpdateInfo(BaseModel):
     param_version_latest: int | None = None  # lastV2 from API
     app_filename: str | None = None  # lastV1FileName from API
     param_filename: str | None = None  # lastV2FileName from API
+    # Multi-step chain advertisement (needRunStep2..5 from API). Diagnostic:
+    # the orchestrator's re-run decision is driven by the post-step re-check
+    # (an update remaining available), not these flags — their exact firmware
+    # semantics are unverified, so they must not gate writes either way.
+    needs_run_steps: list[int] = []
 
     @property
     def update_available(self) -> bool:
@@ -1549,6 +1554,16 @@ class FirmwareUpdateInfo(BaseModel):
             param_version_latest=details.lastV2,
             app_filename=details.lastV1FileName,
             param_filename=details.lastV2FileName,
+            needs_run_steps=[
+                step
+                for step, needed in (
+                    (2, details.needRunStep2),
+                    (3, details.needRunStep3),
+                    (4, details.needRunStep4),
+                    (5, details.needRunStep5),
+                )
+                if needed
+            ],
         )
 
 

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -1487,20 +1487,28 @@ class FirmwareUpdateInfo(BaseModel):
         details = check.details
 
         # Construct latest version from lastV1/lastV2 (or use current if no updates)
-        # Format: {fwCode}-{v1_hex}{v2_hex} (e.g., "IAAB-1600" for v1=22, v2=0)
+        # Format: {prefix}{v1_hex}{v2_hex} where v1/v2 are always the LAST two
+        # bytes of the displayed code and the prefix is everything before them.
+        # The prefix is NOT always "{code}-": 6000XP-class devices carry a third
+        # leading version byte inside it (e.g. "ccaa-1E1415" -> prefix "ccaa-1E",
+        # v1=0x14, v2=0x15), while 18KPV-class codes are plain "fAAB-2122"
+        # (prefix "fAAB-"). Splitting on "-" dropped the extra byte and showed
+        # "ccaa-1515" as the update target (eg4_web_monitor#353).
         # Note: API returns decimal values, but firmware versions use hexadecimal
         if details.has_app_update or details.has_parameter_update:
             # Use lastV1/lastV2 if there's an actual update, otherwise use current
             latest_v1 = details.lastV1 if details.has_app_update else details.v1
             latest_v2 = details.lastV2 if details.has_parameter_update else details.v2
-            # Extract firmware code (e.g., "IAAB" from "IAAB-1300")
-            fw_code = (
-                details.fwCodeBeforeUpload.split("-")[0]
-                if "-" in details.fwCodeBeforeUpload
-                else details.fwCodeBeforeUpload[:4]
-            )
-            # Convert to 2-digit hex (uppercase to match API format)
-            latest_version = f"{fw_code}-{latest_v1:02X}{latest_v2:02X}"
+            code = details.fwCodeBeforeUpload
+            current_suffix = f"{details.v1:02X}{details.v2:02X}"
+            if len(code) > 4 and code[-4:].upper() == current_suffix:
+                # Verified layout: current v1/v2 occupy the trailing 4 hex
+                # chars, so replacing exactly those preserves any prefix bytes.
+                latest_version = f"{code[:-4]}{latest_v1:02X}{latest_v2:02X}"
+            else:
+                # Unverified layout — legacy fallback (2-byte suffix assumed).
+                fw_code = code.split("-")[0] if "-" in code else code[:4]
+                latest_version = f"{fw_code}-{latest_v1:02X}{latest_v2:02X}"
         else:
             # No updates available
             latest_version = details.fwCodeBeforeUpload
@@ -1542,6 +1550,34 @@ class FirmwareUpdateInfo(BaseModel):
             app_filename=details.lastV1FileName,
             param_filename=details.lastV2FileName,
         )
+
+
+class FirmwareUpdateRunResult(BaseModel):
+    """Outcome of a run-to-completion firmware update orchestration.
+
+    Some devices (e.g. 6000XP) require the ``standardUpdate/run`` call to be
+    issued once per firmware component — the portal/mobile app chains these
+    automatically, but a single call leaves the device on a partial version
+    (eg4_web_monitor#353). ``run_firmware_update_to_completion()`` re-checks
+    and re-runs until the device converges on the latest version, and reports
+    the outcome here.
+
+    Attributes:
+        success: True only if the device converged on the latest firmware
+            (no update remains available after the final step).
+        converged: Same signal as success for completed runs; False when the
+            run stopped early (start refused, timeout, no progress, or step
+            budget exhausted).
+        steps_run: Number of ``standardUpdate/run`` invocations issued.
+        message: Human-readable outcome summary (safe to surface in UI/logs).
+        final_version: The device's firmware code after the run, when known.
+    """
+
+    success: bool
+    converged: bool
+    steps_run: int
+    message: str
+    final_version: str | None = None
 
 
 # Dongle Connection Status Models

--- a/tests/unit/test_firmware_update_info.py
+++ b/tests/unit/test_firmware_update_info.py
@@ -354,3 +354,32 @@ class TestLatestVersionPrefixPreservation:
         info = FirmwareUpdateInfo.from_api_response(check, title="T")
 
         assert info.latest_version == "IAAB-0E00"
+
+    def test_gridboss_iaab_prefix_unchanged(self) -> None:
+        """GridBOSS IAAB codes keep the classic construction."""
+        check = _create_firmware_check("IAAB", v1=0x13, v2=0x00, last_v1=0x16, last_v2=None)
+
+        info = FirmwareUpdateInfo.from_api_response(check, title="GridBOSS Firmware")
+
+        assert info.latest_version == "IAAB-1600"
+
+    def test_eg4_iaab_build_prefix_preserved(self) -> None:
+        """EG4-branded GridBOSS builds (EG4_IAAB-xxxx) keep the full prefix
+        including the underscore segment."""
+        details = _create_firmware_details("IAAB", v1=0x13, v2=0x00, last_v1=0x16, last_v2=None)
+        details = details.model_copy(update={"fwCodeBeforeUpload": "EG4_IAAB-1300"})
+        check = FirmwareUpdateCheck(success=True, details=details, infoForwardUrl=None)
+
+        info = FirmwareUpdateInfo.from_api_response(check, title="GridBOSS Firmware")
+
+        assert info.latest_version == "EG4_IAAB-1600"
+
+    def test_needs_run_steps_threaded_through(self) -> None:
+        """needRunStep2..5 flags surface as needs_run_steps for diagnostics."""
+        details = _create_firmware_details("IAAB", v1=0x13, v2=0x00, last_v1=0x16, last_v2=None)
+        details = details.model_copy(update={"needRunStep2": True, "needRunStep4": True})
+        check = FirmwareUpdateCheck(success=True, details=details, infoForwardUrl=None)
+
+        info = FirmwareUpdateInfo.from_api_response(check, title="T")
+
+        assert info.needs_run_steps == [2, 4]

--- a/tests/unit/test_firmware_update_info.py
+++ b/tests/unit/test_firmware_update_info.py
@@ -292,3 +292,65 @@ class TestFirmwareUpdateInfoFromAPIResponse:
 
         # Should show hex values, not decimal
         assert info_both.release_summary == "App firmware: v13 → v16; Parameter firmware: v00 → v01"
+
+
+class TestLatestVersionPrefixPreservation:
+    """Regression tests for eg4_web_monitor#353 version-prefix truncation."""
+
+    def test_three_byte_version_keeps_extra_prefix_byte(self) -> None:
+        """6000XP-class codes carry a third leading byte (ccaa-1E1415):
+        the constructed latest must keep 'ccaa-1E', not truncate to 'ccaa'."""
+        details = FirmwareUpdateDetails.model_construct(
+            serialNum="1234567890",
+            deviceType=6,
+            standard="ccaa",
+            firmwareType="",
+            fwCodeBeforeUpload="ccaa-1E1415",
+            v1=0x14,
+            v2=0x15,
+            v3Value=0x1E,
+            lastV1=0x15,
+            lastV2=0x15,
+            lastV1FileName=None,
+            lastV2FileName=None,
+            m3Version=0,
+            pcs1UpdateMatch=True,
+            pcs2UpdateMatch=False,
+            pcs3UpdateMatch=False,
+            needRunStep2=True,
+            needRunStep3=False,
+            needRunStep4=False,
+            needRunStep5=False,
+            midbox=False,
+            lowVoltBattery=True,
+            type6=True,
+        )
+        check = FirmwareUpdateCheck(success=True, details=details, infoForwardUrl=None)
+
+        info = FirmwareUpdateInfo.from_api_response(check, title="6000XP Firmware")
+
+        # app update only: lastV1 (0x15) + current v2 (0x15)
+        assert info.latest_version == "ccaa-1E1515"
+        assert info.installed_version == "ccaa-1E1415"
+        assert info.update_available is True
+
+    def test_two_byte_version_unchanged(self) -> None:
+        """Standard 2-byte codes (fAAB-2122) produce the same string as the
+        legacy construction — prefix 'fAAB-' is preserved via suffix strip."""
+        check = _create_firmware_check("fAAB", v1=0x21, v2=0x22, last_v1=0x25, last_v2=0x25)
+
+        info = FirmwareUpdateInfo.from_api_response(check, title="18kPV Firmware")
+
+        assert info.latest_version == "fAAB-2525"
+
+    def test_unverified_suffix_falls_back_to_legacy_split(self) -> None:
+        """If the code's trailing 4 chars don't match current v1/v2 hex, the
+        legacy dash-split construction is used (unknown layout safety net)."""
+        details = _create_firmware_details("IAAB", v1=13, v2=0, last_v1=14, last_v2=None)
+        # Corrupt the code so the suffix (0D00) is absent
+        details = details.model_copy(update={"fwCodeBeforeUpload": "IAAB-XYZ"})
+        check = FirmwareUpdateCheck(success=True, details=details, infoForwardUrl=None)
+
+        info = FirmwareUpdateInfo.from_api_response(check, title="T")
+
+        assert info.latest_version == "IAAB-0E00"

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -249,7 +249,9 @@ async def test_failed_step_stops_the_chain() -> None:
     advanced partially, firing another run against a failed chain is the
     blind-write class this orchestrator exists to prevent (codex P1)."""
     device = ScriptedDevice(
-        checks=[STEP1_PENDING],
+        # Post-FAILED re-check shows a partial advance (1414 -> 1415): the
+        # result must report the actual current version, not the pre-step one.
+        checks=[STEP1_PENDING, STEP2_PENDING],
         failed_statuses=[True],
     )
 
@@ -259,6 +261,7 @@ async def test_failed_step_stops_the_chain() -> None:
     assert result.steps_run == 1
     assert device.start_calls == 1
     assert "FAILED" in result.message
+    assert result.final_version == "ccaa-1E1415"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -85,7 +85,7 @@ STEP2_PENDING = _info("ccaa-1E1415", "ccaa-1E1515", app_current=0x14, param_curr
 async def test_already_up_to_date_runs_nothing() -> None:
     device = ScriptedDevice(checks=[UP_TO_DATE])
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0)
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert result.success and result.converged
     assert result.steps_run == 0
@@ -97,7 +97,7 @@ async def test_already_up_to_date_runs_nothing() -> None:
 async def test_single_step_convergence() -> None:
     device = ScriptedDevice(checks=[STEP2_PENDING, UP_TO_DATE])
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0)
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert result.success and result.converged
     assert result.steps_run == 1
@@ -109,7 +109,7 @@ async def test_multi_step_chain_converges() -> None:
     """The #353 scenario: step 1 advances param only; step 2 finishes app."""
     device = ScriptedDevice(checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE])
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0)
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert result.success and result.converged
     assert result.steps_run == 2
@@ -121,7 +121,7 @@ async def test_multi_step_chain_converges() -> None:
 async def test_start_refused_reports_failure() -> None:
     device = ScriptedDevice(checks=[STEP1_PENDING], start_results=[False])
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0)
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert not result.success and not result.converged
     assert result.steps_run == 1
@@ -132,7 +132,7 @@ async def test_start_refused_reports_failure() -> None:
 async def test_not_eligible_reports_failure_without_write() -> None:
     device = ScriptedDevice(checks=[STEP1_PENDING], eligibility=[False])
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0)
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert not result.success
     assert device.start_calls == 0
@@ -144,7 +144,7 @@ async def test_no_progress_after_step_aborts() -> None:
     """A completed run with no version delta must stop, not loop writes."""
     device = ScriptedDevice(checks=[STEP1_PENDING, STEP1_PENDING])
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0)
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert not result.success
     assert result.steps_run == 1
@@ -161,7 +161,9 @@ async def test_step_budget_exhaustion() -> None:
     ]
     device = ScriptedDevice(checks=checks)
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0, max_steps=2)
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, max_steps=2, start_grace=0
+    )
 
     assert not result.success
     assert result.steps_run == 2
@@ -179,7 +181,7 @@ async def test_polls_installing_step_until_done() -> None:
         progresses=[installing, installing, idle],
     )
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0)
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert result.success
     assert not device._progresses  # all scripted progress states consumed
@@ -193,10 +195,43 @@ async def test_step_timeout_aborts() -> None:
         progresses=[installing] * 50,
     )
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0, step_timeout=0.0)
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, step_timeout=0.0, start_grace=0
+    )
 
     assert not result.success
     assert "did not finish" in result.message
+
+
+@pytest.mark.asyncio
+async def test_idle_polls_within_grace_do_not_end_the_wait() -> None:
+    """The server registers an accepted run asynchronously: idle progress
+    polls straight after start must NOT be read as instant completion while
+    the visibility grace is open (the mid-flash false-abort race)."""
+    idle = _info("ccaa-1E1414", "ccaa-1E1515", in_progress=False)
+    installing = _info("ccaa-1E1414", "ccaa-1E1515", in_progress=True)
+    done = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=False)
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, UP_TO_DATE],
+        progresses=[idle, idle, installing, done],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+
+    assert result.success and result.converged
+    assert not device._progresses  # idle polls were tolerated, wait continued
+
+
+@pytest.mark.asyncio
+async def test_grace_expiry_with_completed_fast_step_still_converges() -> None:
+    """A step that genuinely finishes between polls (update never became
+    visible before grace expiry) is resolved by the post-step re-check."""
+    device = ScriptedDevice(checks=[STEP2_PENDING, UP_TO_DATE])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+    assert result.success and result.converged
+    assert result.steps_run == 1
 
 
 def test_scripted_device_is_mixin() -> None:

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -1,0 +1,207 @@
+"""Unit tests for run_firmware_update_to_completion (eg4_web_monitor#353).
+
+Some devices (6000XP) need standardUpdate/run issued once per firmware
+component. The orchestrator loops check → start → poll → re-check until the
+device converges; these tests script the device responses to pin every exit
+path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pylxpweb.devices._firmware_update_mixin import FirmwareUpdateMixin
+from pylxpweb.models import FirmwareUpdateInfo
+
+
+def _info(
+    installed: str,
+    latest: str,
+    *,
+    in_progress: bool = False,
+    app_current: int | None = None,
+    param_current: int | None = None,
+) -> FirmwareUpdateInfo:
+    return FirmwareUpdateInfo(
+        installed_version=installed,
+        latest_version=latest,
+        title="Test Firmware",
+        release_summary=None,
+        release_url=None,
+        in_progress=in_progress,
+        update_percentage=None,
+        app_version_current=app_current,
+        param_version_current=param_current,
+    )
+
+
+class ScriptedDevice(FirmwareUpdateMixin):
+    """Mixin host with scripted firmware API responses."""
+
+    def __init__(
+        self,
+        *,
+        checks: list[FirmwareUpdateInfo],
+        progresses: list[FirmwareUpdateInfo] | None = None,
+        start_results: list[bool] | None = None,
+        eligibility: list[bool] | None = None,
+    ) -> None:
+        self._init_firmware_update_cache()
+        self._checks = checks
+        self._progresses = progresses or []
+        self._start_results = start_results or []
+        self._eligibility = eligibility or []
+        self.start_calls = 0
+        self.check_calls = 0
+
+    # Scripted overrides -------------------------------------------------
+    async def check_firmware_updates(self, force: bool = False) -> FirmwareUpdateInfo:
+        self.check_calls += 1
+        return self._checks.pop(0)
+
+    async def get_firmware_update_progress(self, force: bool = False) -> FirmwareUpdateInfo:
+        if self._progresses:
+            return self._progresses.pop(0)
+        return _info("X-0000", "X-0000")
+
+    async def start_firmware_update(self, try_fast_mode: bool = False) -> bool:
+        self.start_calls += 1
+        if self._start_results:
+            return self._start_results.pop(0)
+        return True
+
+    async def check_update_eligibility(self) -> bool:
+        if self._eligibility:
+            return self._eligibility.pop(0)
+        return True
+
+
+UP_TO_DATE = _info("ccaa-1E1515", "ccaa-1E1515", app_current=0x15, param_current=0x15)
+STEP1_PENDING = _info("ccaa-1E1414", "ccaa-1E1515", app_current=0x14, param_current=0x14)
+STEP2_PENDING = _info("ccaa-1E1415", "ccaa-1E1515", app_current=0x14, param_current=0x15)
+
+
+@pytest.mark.asyncio
+async def test_already_up_to_date_runs_nothing() -> None:
+    device = ScriptedDevice(checks=[UP_TO_DATE])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0)
+
+    assert result.success and result.converged
+    assert result.steps_run == 0
+    assert device.start_calls == 0
+    assert result.final_version == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_single_step_convergence() -> None:
+    device = ScriptedDevice(checks=[STEP2_PENDING, UP_TO_DATE])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0)
+
+    assert result.success and result.converged
+    assert result.steps_run == 1
+    assert device.start_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_multi_step_chain_converges() -> None:
+    """The #353 scenario: step 1 advances param only; step 2 finishes app."""
+    device = ScriptedDevice(checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0)
+
+    assert result.success and result.converged
+    assert result.steps_run == 2
+    assert device.start_calls == 2
+    assert result.final_version == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_start_refused_reports_failure() -> None:
+    device = ScriptedDevice(checks=[STEP1_PENDING], start_results=[False])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0)
+
+    assert not result.success and not result.converged
+    assert result.steps_run == 1
+    assert "refused" in result.message
+
+
+@pytest.mark.asyncio
+async def test_not_eligible_reports_failure_without_write() -> None:
+    device = ScriptedDevice(checks=[STEP1_PENDING], eligibility=[False])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0)
+
+    assert not result.success
+    assert device.start_calls == 0
+    assert "not eligible" in result.message
+
+
+@pytest.mark.asyncio
+async def test_no_progress_after_step_aborts() -> None:
+    """A completed run with no version delta must stop, not loop writes."""
+    device = ScriptedDevice(checks=[STEP1_PENDING, STEP1_PENDING])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0)
+
+    assert not result.success
+    assert result.steps_run == 1
+    assert "No firmware version progress" in result.message
+
+
+@pytest.mark.asyncio
+async def test_step_budget_exhaustion() -> None:
+    """Distinct-but-never-converging versions stop at max_steps."""
+    checks: list[FirmwareUpdateInfo] = [
+        _info("X-0001", "X-9999", app_current=1, param_current=1),
+        _info("X-0002", "X-9999", app_current=2, param_current=2),
+        _info("X-0003", "X-9999", app_current=3, param_current=3),
+    ]
+    device = ScriptedDevice(checks=checks)
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, max_steps=2)
+
+    assert not result.success
+    assert result.steps_run == 2
+    assert "step budget" in result.message
+
+
+@pytest.mark.asyncio
+async def test_polls_installing_step_until_done() -> None:
+    """in_progress=True progress responses are polled through before the
+    post-step re-check runs."""
+    installing = _info("ccaa-1E1414", "ccaa-1E1515", in_progress=True)
+    idle = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=False)
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, UP_TO_DATE],
+        progresses=[installing, installing, idle],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0)
+
+    assert result.success
+    assert not device._progresses  # all scripted progress states consumed
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_aborts() -> None:
+    installing = _info("ccaa-1E1414", "ccaa-1E1515", in_progress=True)
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING],
+        progresses=[installing] * 50,
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, step_timeout=0.0)
+
+    assert not result.success
+    assert "did not finish" in result.message
+
+
+def test_scripted_device_is_mixin() -> None:
+    """Guard: the scripted host really exercises the production mixin method."""
+    assert (
+        ScriptedDevice.run_firmware_update_to_completion
+        is FirmwareUpdateMixin.run_firmware_update_to_completion
+    )

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -45,12 +45,14 @@ class ScriptedDevice(FirmwareUpdateMixin):
         progresses: list[FirmwareUpdateInfo] | None = None,
         start_results: list[bool] | None = None,
         eligibility: list[bool] | None = None,
+        failed_statuses: list[bool] | None = None,
     ) -> None:
         self._init_firmware_update_cache()
         self._checks = checks
         self._progresses = progresses or []
         self._start_results = start_results or []
         self._eligibility = eligibility or []
+        self._failed_statuses = failed_statuses or []
         self.start_calls = 0
         self.check_calls = 0
 
@@ -74,6 +76,11 @@ class ScriptedDevice(FirmwareUpdateMixin):
         if self._eligibility:
             return self._eligibility.pop(0)
         return True
+
+    async def _update_step_reported_failed(self) -> bool:
+        if self._failed_statuses:
+            return self._failed_statuses.pop(0)
+        return False
 
 
 UP_TO_DATE = _info("ccaa-1E1515", "ccaa-1E1515", app_current=0x15, param_current=0x15)
@@ -144,7 +151,9 @@ async def test_no_progress_after_step_aborts() -> None:
     """A completed run with no version delta must stop, not loop writes."""
     device = ScriptedDevice(checks=[STEP1_PENDING, STEP1_PENDING])
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
 
     assert not result.success
     assert result.steps_run == 1
@@ -162,7 +171,7 @@ async def test_step_budget_exhaustion() -> None:
     device = ScriptedDevice(checks=checks)
 
     result = await device.run_firmware_update_to_completion(
-        poll_interval=0, max_steps=2, start_grace=0
+        poll_interval=0, max_steps=2, start_grace=0, settle_checks=0
     )
 
     assert not result.success
@@ -234,9 +243,75 @@ async def test_grace_expiry_with_completed_fast_step_still_converges() -> None:
     assert result.steps_run == 1
 
 
+@pytest.mark.asyncio
+async def test_failed_step_stops_the_chain() -> None:
+    """A step the server reports as FAILED must abort — even if versions
+    advanced partially, firing another run against a failed chain is the
+    blind-write class this orchestrator exists to prevent (codex P1)."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING],
+        failed_statuses=[True],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+    assert not result.success and not result.converged
+    assert result.steps_run == 1
+    assert device.start_calls == 1
+    assert "FAILED" in result.message
+
+
+@pytest.mark.asyncio
+async def test_settle_window_recovers_lagging_check_data() -> None:
+    """The check endpoint can lag the status endpoint: an unchanged version
+    on the immediate re-check must retry within the settle window instead of
+    declaring no progress (codex P2)."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=2, settle_interval=0
+    )
+
+    assert result.success and result.converged
+    assert result.steps_run == 2  # lagging first re-check did not abort step 1
+
+
+@pytest.mark.asyncio
+async def test_prefix_only_progress_is_progress() -> None:
+    """A step that advances only the leading prefix byte (ccaa-1D -> ccaa-1E)
+    with unchanged trailing v1/v2 counts as progress — the comparison uses
+    the full installed code, not just the (v1, v2) pair (codex P1)."""
+    before = _info("ccaa-1D1415", "ccaa-1E1515", app_current=0x14, param_current=0x15)
+    after = _info("ccaa-1E1415", "ccaa-1E1515", app_current=0x14, param_current=0x15)
+    device = ScriptedDevice(checks=[before, after, UP_TO_DATE])
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert result.steps_run == 2
+
+
 def test_scripted_device_is_mixin() -> None:
     """Guard: the scripted host really exercises the production mixin method."""
     assert (
         ScriptedDevice.run_firmware_update_to_completion
         is FirmwareUpdateMixin.run_firmware_update_to_completion
     )
+
+
+@pytest.mark.asyncio
+async def test_converged_final_version_survives_up_to_date_sentinel() -> None:
+    """When the post-step check answers with the bare 'already latest'
+    sentinel (empty version strings), the result reports the target we
+    converged to, not an empty string (agy review finding)."""
+    sentinel = _info("", "")  # create_up_to_date shape: both fields empty
+    device = ScriptedDevice(checks=[STEP2_PENDING, sentinel])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+    assert result.success and result.converged
+    assert result.final_version == "ccaa-1E1515"


### PR DESCRIPTION
## Summary
Fixes the two pylxpweb-side halves of [eg4_web_monitor#353](https://github.com/joyfulhouse/eg4_web_monitor/issues/353) (6000XP firmware update: wrong displayed target + partial multi-step update).

**1. Version prefix truncation.** `from_api_response` built the update target as `{code.split('-')[0]}-{lastV1}{lastV2}`, which dropped the third leading version byte on 6000XP-class codes: installed `ccaa-1E1415` displayed target `ccaa-1515` instead of `ccaa-1E1515`. Now the current `v1`/`v2` hex pair is verified to occupy the trailing 4 characters and exactly those are replaced, preserving any prefix (`fAAB-`, `IAAB-`, `EG4_IAAB-`, `ccaa-1E`); unverified layouts keep the legacy construction.

**2. Multi-step orchestration.** New `FirmwareUpdateMixin.run_firmware_update_to_completion()`: some devices need `standardUpdate/run` once per firmware component (the portal/app chain the calls; `needRunStep2..5` advertise it). The loop runs check → eligibility → start → poll → re-check until convergence, with defense in depth:
- **step budget** (5 = the API's `needRunStep5` maximum)
- **per-step timeout** and **start-visibility grace** (accepted runs register in `remoteUpdate/info` asynchronously — an early idle poll is not completion)
- **FAILED terminal detection** from the raw status row (the aggregated conversion collapses every non-installing state to `in_progress=False`) — a failed step aborts the chain immediately
- **no-progress abort** keyed on the full installed code (prefix-byte movement counts; `lastV3` doesn't exist so the `(v1,v2)` pair alone is blind) with a bounded settle window for check-endpoint lag
- returns the new `FirmwareUpdateRunResult` (success/converged/steps_run/message/final_version, with sentinel-safe final version)

`needRunStep2..5` also surface as `FirmwareUpdateInfo.needs_run_steps` for diagnostics — deliberately not used to gate writes until their semantics are hardware-verified (the #353 reporter's retained second inverter is the validation case).

## Reviews
Codex gpt-5.6-sol + Antigravity adversarial round: FAILED-step handling, full-code progress key, settle window, sentinel final_version all found-and-fixed in-round; the start-visibility race was self-found and fixed before the reviews landed. All findings test-pinned.

## Testing
2762 passed; 16 orchestrator exit-path tests via a scripted mixin host (with an identity guard that the production method is exercised); prefix regressions for 3-byte, 2-byte, IAAB, EG4_IAAB, and unverified-layout fallback; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)