### PR TITLE
fix: force every orchestrator progress poll past the idle cache

### DIFF
--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -650,15 +650,17 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             # keep polling within start_grace until the update becomes
             # visible (or grace expires: fast steps can genuinely complete
             # between polls, which the post-step version re-check resolves).
-            # The first poll is forced so a stale not-in-progress cache entry
-            # cannot end the wait early.
+            # EVERY poll is forced: get_firmware_update_progress caches a
+            # not-in-progress snapshot for 5 MINUTES, so unforced polls
+            # would replay the pre-registration idle snapshot for the whole
+            # grace window and the loop would abandon a genuinely running
+            # step as "no progress" (~2 API calls/min while installing —
+            # comparable to the portal's own polling).
             deadline = loop.time() + step_timeout
             grace_deadline = loop.time() + start_grace
             saw_in_progress = False
-            force_poll = True
             while True:
-                progress = await self.get_firmware_update_progress(force=force_poll)
-                force_poll = False
+                progress = await self.get_firmware_update_progress(force=True)
                 if progress.in_progress:
                     saw_in_progress = True
                 elif saw_in_progress or loop.time() >= grace_deadline:

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -80,10 +80,11 @@ class HybridInverter(GenericInverter):
             HOLD_AC_CHARGE_POWER_CMD,
         )
 
-        # Read function enable register for AC charge bit
-        func_params = await self.read_parameters(FUNC_EN_REGISTER, 1)
-        func_value = func_params.get(f"reg_{FUNC_EN_REGISTER}", 0)
-        ac_charge_enabled = bool(func_value & (1 << FUNC_EN_BIT_AC_CHARGE_EN))
+        # Read the AC charge enable bit via the transport/cloud-aware helper:
+        # the raw "reg_21" key shape exists only on the local transport path —
+        # cloud reads return named booleans (FUNC_AC_CHARGE), so the old raw
+        # lookup read enabled=False on every cloud call (post-beta.1 scan).
+        ac_charge_enabled = await self._get_register_bit(FUNC_EN_REGISTER, FUNC_EN_BIT_AC_CHARGE_EN)
 
         # Read AC charge parameters
         ac_params = await self.read_parameters(HOLD_AC_CHARGE_POWER_CMD, 8)

--- a/tests/unit/devices/inverters/test_hybrid.py
+++ b/tests/unit/devices/inverters/test_hybrid.py
@@ -50,9 +50,12 @@ class TestACChargeOperations:
             client=mock_client, serial_number="1234567890", model="FlexBOSS21"
         )
 
-        # Mock function enable register read
+        # Mock function enable register read — the REAL cloud shape is a named
+        # boolean (FUNC_AC_CHARGE), not a raw "reg_21" mask. The old fabricated
+        # local-shaped value masked a bug where cloud reads always returned
+        # enabled=False (post-beta.1 scan).
         mock_func_response = Mock()
-        mock_func_response.parameters = {"reg_21": 128}  # Bit 7 set (AC charge enabled)
+        mock_func_response.parameters = {"FUNC_AC_CHARGE": True}
 
         # Mock AC charge parameters read
         mock_ac_response = Mock()
@@ -2343,3 +2346,44 @@ class TestStopDischargeVoltageOperations:
         # And the transport map agrees with the canonical holding table.
         canonical = BY_ADDRESS[202]
         assert canonical[0].api_param_key == "_12K_HOLD_STOP_DISCHG_VOLT"
+
+
+class TestACChargeSettingsCloudShape:
+    """Regression pins for the cloud named-boolean enable read (post-beta.1 scan P2)."""
+
+    @pytest.mark.asyncio
+    async def test_cloud_disabled_reads_false(self, mock_client: LuxpowerClient) -> None:
+        """Cloud FUNC_AC_CHARGE=False reads enabled=False (and not via raw mask)."""
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+        func_resp = Mock()
+        func_resp.parameters = {"FUNC_AC_CHARGE": False}
+        ac_resp = Mock()
+        ac_resp.parameters = {
+            "HOLD_AC_CHARGE_POWER_CMD": 50,
+            "HOLD_AC_CHARGE_SOC_LIMIT": 100,
+            "HOLD_AC_CHARGE_ENABLE_1": 0,
+            "HOLD_AC_CHARGE_ENABLE_2": 0,
+        }
+        mock_client.api.control.read_parameters = AsyncMock(side_effect=[func_resp, ac_resp])
+
+        settings = await inverter.get_ac_charge_settings()
+
+        assert settings["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_cloud_missing_key_defaults_false(self, mock_client: LuxpowerClient) -> None:
+        """An absent FUNC_AC_CHARGE key fails safe to enabled=False."""
+        inverter = HybridInverter(
+            client=mock_client, serial_number="1234567890", model="FlexBOSS21"
+        )
+        func_resp = Mock()
+        func_resp.parameters = {}
+        ac_resp = Mock()
+        ac_resp.parameters = {"HOLD_AC_CHARGE_POWER_CMD": 0}
+        mock_client.api.control.read_parameters = AsyncMock(side_effect=[func_resp, ac_resp])
+
+        settings = await inverter.get_ac_charge_settings()
+
+        assert settings["enabled"] is False

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -318,3 +318,30 @@ async def test_converged_final_version_survives_up_to_date_sentinel() -> None:
 
     assert result.success and result.converged
     assert result.final_version == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_every_progress_poll_is_forced() -> None:
+    """Regression pin (post-beta.1 scan P1): get_firmware_update_progress
+    caches a not-in-progress snapshot for 5 MINUTES, so any unforced poll
+    inside the orchestrator would replay the pre-registration idle snapshot
+    for the whole start-grace window and abandon a genuinely running step
+    as "no progress". Every poll must bypass the cache."""
+    forced_flags: list[bool] = []
+
+    class ForceRecordingDevice(ScriptedDevice):
+        async def get_firmware_update_progress(self, force: bool = False) -> FirmwareUpdateInfo:
+            forced_flags.append(force)
+            return await super().get_firmware_update_progress(force)
+
+    installing = _info("ccaa-1E1414", "ccaa-1E1515", in_progress=True)
+    done = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=False)
+    device = ForceRecordingDevice(
+        checks=[STEP2_PENDING, UP_TO_DATE],
+        progresses=[installing, installing, done],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0)
+
+    assert result.success
+    assert forced_flags and all(forced_flags)


### PR DESCRIPTION
Post-beta.1 bug scan P1 (Fable): the orchestrator forced only its first progress poll, but `get_firmware_update_progress` caches a not-in-progress snapshot for 5 minutes — so the start-grace window replayed the pre-registration idle snapshot, never saw the update become visible, and abandoned genuinely running 20–40 min steps as "no progress" at ~7 minutes. Fail-closed but functionally broken for the primary 6000XP case; would have failed the #353 hardware validation.

Every poll now bypasses the cache (~2 API calls/min while installing). New regression test records the force flag on every poll (ScriptedDevice overrides the caching layer, which is why the existing suite missed it).

Codex's parallel scan is running; any further findings batch into this line before 0.9.38b2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)