### PR TITLE
feat: quick charge paired-frame start over local transport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.38b2"
+version = "0.9.38b3"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -3465,22 +3465,25 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         can be active alongside Normal or Standby operating modes.
 
         With a local transport (Modbus/Dongle, including HYBRID — which
-        prefers local) this sets the quick-charge enable bit (register 233
-        bit 0) only. The firmware starts the timed charge at its default
-        length and rejects writes to register 234 while quick charge is off,
-        so the duration is NOT pre-written here — adjust it live afterwards
-        with :meth:`set_quick_charge_minute` (register 234 doubles as the
-        live remaining-minutes countdown). Without a transport it uses the
+        prefers local) this writes the quick-charge activation to holding
+        register 233 bit 0. When ``minute`` is given, the duration (register
+        234) is written together with the activation in one contiguous
+        Modbus frame — the portal-equivalent start sequence (a live
+        active-vs-idle register capture on FlexBOSS21 + 18kPV showed a
+        portal-started session as reg 233 bit 0 + reg 234 = duration). The
+        firmware rejects a reg-234 write that arrives ALONE while quick
+        charge is off (eg4_web_monitor#251), so if the paired frame is
+        rejected the start falls back to the proven bit-only write (firmware
+        default length) followed by a best-effort live reg-234 write, which
+        IS accepted while a charge runs. Without a transport it uses the
         cloud Quick Charge start endpoint.
 
         Args:
-            minute: Optional charge duration in minutes for the cloud start
-                endpoint. Newer EG4 firmware supports a fixed-duration quick
-                charge; omitting it preserves the legacy behaviour (charge
-                until manually stopped). Ignored on the local transport path
-                (the firmware starts at its default length and the duration is
-                set live via register 234). Must be a positive integer when
-                provided.
+            minute: Optional charge duration in minutes. Newer EG4 firmware
+                supports a fixed-duration quick charge; omitting it preserves
+                the legacy behaviour (charge until manually stopped, or the
+                firmware default length on the local path). Must be a
+                positive integer when provided.
 
         Returns:
             True if successful
@@ -3500,12 +3503,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             raise ValueError(f"minute must be a positive integer, got {minute!r}")
 
         if self._transport is not None:
-            # LOCAL/HYBRID: set only the enable bit (reg 233 bit 0). The
-            # firmware starts the timed charge at its default length and
-            # rejects reg 234 writes while quick charge is off, so the duration
-            # is adjusted live afterwards via set_quick_charge_minute(); the
-            # `minute` argument is honoured only on the cloud fallback below.
-            if await self.write_transport_bit(233, 0, True):
+            if await self._enable_quick_charge_local(minute):
                 return True
             # Local write failed. HYBRID (real cloud client) falls back to the
             # cloud endpoint; local-only (client is None) fails honestly.
@@ -3520,6 +3518,59 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             self.serial_number, minute=minute
         )
         return result.success
+
+    async def _enable_quick_charge_local(self, minute: int | None) -> bool:
+        """Start quick charge over the local transport.
+
+        With a requested duration the activation bit (reg 233 bit 0, upper
+        bits preserved via read-modify-write — the 0x1000 flag observed live
+        is sticky config of unconfirmed meaning) and the duration (reg 234)
+        are written as ONE contiguous frame; the firmware rejects reg 234
+        alone while idle (eg4_web_monitor#251). If the paired frame fails,
+        fall back to the bit-only start and then apply the duration live.
+        """
+        transport = self._transport
+        if transport is None:
+            return False
+        if minute is None:
+            return await self.write_transport_bit(233, 0, True)
+
+        reg: int | None = None
+        try:
+            current = await transport.read_parameters(233, 1)
+            reg = current.get(233)
+        except Exception as err:
+            _LOGGER.debug(
+                "Quick charge start: could not read register 233 for %s (%s); "
+                "trying the bit-only start",
+                self.serial_number,
+                err,
+            )
+        if reg is not None:
+            try:
+                if await transport.write_parameters({233: reg | 0x1, 234: minute}):
+                    self._parameters_cache_time = None
+                    return True
+            except Exception as err:
+                _LOGGER.debug(
+                    "Paired quick-charge start frame (regs 233+234) rejected "
+                    "for %s (%s); falling back to the bit-only start",
+                    self.serial_number,
+                    err,
+                )
+
+        # Bit-only start (proven path), then apply the requested duration
+        # live — reg 234 accepts writes while a charge is running.
+        if not await self.write_transport_bit(233, 0, True):
+            return False
+        if not await self.write_transport_register(234, minute):
+            _LOGGER.warning(
+                "Quick charge started for %s but the %d-minute duration could "
+                "not be applied; the firmware default length is running",
+                self.serial_number,
+                minute,
+            )
+        return True
 
     async def disable_quick_charge(self) -> bool:
         """Disable quick charge function.

--- a/tests/unit/devices/inverters/test_quick_charge_local.py
+++ b/tests/unit/devices/inverters/test_quick_charge_local.py
@@ -55,18 +55,86 @@ def _inverter(mock_client: LuxpowerClient, *, with_transport: bool) -> _Inverter
 
 
 @pytest.mark.asyncio
-async def test_enable_local_with_minute_only_sets_bit_ignores_duration(mock_client):
-    """LOCAL enable sets only reg 233 bit 0; the firmware rejects reg 234 writes
-    while quick charge is off, so `minute` is ignored on the local path (the
-    duration is adjusted live via set_quick_charge_minute afterwards)."""
+async def test_enable_local_with_minute_writes_paired_frame(mock_client):
+    """LOCAL enable with a duration writes the activation bit and reg 234
+    together as ONE contiguous frame (the portal-equivalent sequence from the
+    2026-07-11 live capture); reg 234 alone is rejected while idle (#251)."""
     inv = _inverter(mock_client, with_transport=True)
 
     ok = await inv.enable_quick_charge(minute=30)
 
     assert ok is True
+    inv._transport.write_parameters.assert_awaited_once_with({233: 1, 234: 30})
+    mock_client.api.control.start_quick_charge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enable_local_paired_frame_preserves_sticky_upper_bits(mock_client):
+    """The 0x1000 flag observed live is sticky config of unconfirmed meaning —
+    the activation must read-modify-write bit 0, never blind-write 0x0001."""
+    inv = _inverter(mock_client, with_transport=True)
+    inv._transport.read_parameters = AsyncMock(return_value={233: 0x1000})
+
+    ok = await inv.enable_quick_charge(minute=30)
+
+    assert ok is True
+    inv._transport.write_parameters.assert_awaited_once_with({233: 0x1001, 234: 30})
+
+
+@pytest.mark.asyncio
+async def test_enable_local_paired_frame_rejected_falls_back_bit_only_plus_live(
+    mock_client,
+):
+    """A rejected paired frame (unproven on non-PV families) falls back to the
+    proven bit-only start, then applies the duration live (reg 234 accepts
+    writes while a charge runs)."""
+    from pylxpweb.transports.exceptions import TransportWriteError
+
+    inv = _inverter(mock_client, with_transport=True)
+    inv._transport.write_parameters = AsyncMock(
+        side_effect=[TransportWriteError("NAK"), True, True]
+    )
+
+    ok = await inv.enable_quick_charge(minute=30)
+
+    assert ok is True
     writes = [c.args[0] for c in inv._transport.write_parameters.call_args_list]
-    assert {233: 1} in writes  # enable bit set (RMW on 0x0000)
-    assert all(234 not in w for w in writes)  # duration NOT pre-written
+    assert writes == [{233: 1, 234: 30}, {233: 1}, {234: 30}]
+    mock_client.api.control.start_quick_charge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enable_local_reg233_read_failure_falls_back_bit_only_plus_live(
+    mock_client,
+):
+    """If reg 233 cannot be read for the RMW, the paired frame is skipped
+    (never blind-write 0x0001) and the bit-only start path runs instead."""
+    from pylxpweb.transports.exceptions import TransportReadError
+
+    inv = _inverter(mock_client, with_transport=True)
+    inv._transport.read_parameters = AsyncMock(side_effect=[TransportReadError("boom"), {233: 0}])
+
+    ok = await inv.enable_quick_charge(minute=30)
+
+    assert ok is True
+    writes = [c.args[0] for c in inv._transport.write_parameters.call_args_list]
+    assert writes == [{233: 1}, {234: 30}]
+
+
+@pytest.mark.asyncio
+async def test_enable_local_fallback_duration_write_failure_still_starts(mock_client):
+    """Bit-only fallback started the charge; a failed live reg-234 write means
+    the firmware default length runs — the start itself still reports True."""
+    from pylxpweb.transports.exceptions import TransportWriteError
+
+    inv = _inverter(mock_client, with_transport=True)
+    inv._transport.write_parameters = AsyncMock(
+        side_effect=[TransportWriteError("NAK"), True, TransportWriteError("NAK")]
+    )
+
+    ok = await inv.enable_quick_charge(minute=30)
+
+    assert ok is True
     mock_client.api.control.start_quick_charge.assert_not_called()
 
 

--- a/tests/unit/devices/inverters/test_quick_charge_local.py
+++ b/tests/unit/devices/inverters/test_quick_charge_local.py
@@ -15,6 +15,7 @@ import pytest
 from pylxpweb import LuxpowerClient
 from pylxpweb.devices.inverters.base import BaseInverter
 from pylxpweb.models import QuickChargeStatus, SuccessResponse
+from pylxpweb.transports.exceptions import TransportReadError, TransportWriteError
 
 
 class _Inverter(BaseInverter):
@@ -82,17 +83,24 @@ async def test_enable_local_paired_frame_preserves_sticky_upper_bits(mock_client
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "final_reg234_effect",
+    [
+        pytest.param(True, id="duration-applied-live"),
+        # A failed live reg-234 write means the firmware default length
+        # runs — the start itself still reports True.
+        pytest.param(TransportWriteError("NAK"), id="duration-write-fails"),
+    ],
+)
 async def test_enable_local_paired_frame_rejected_falls_back_bit_only_plus_live(
-    mock_client,
+    mock_client, final_reg234_effect
 ):
     """A rejected paired frame (unproven on non-PV families) falls back to the
     proven bit-only start, then applies the duration live (reg 234 accepts
     writes while a charge runs)."""
-    from pylxpweb.transports.exceptions import TransportWriteError
-
     inv = _inverter(mock_client, with_transport=True)
     inv._transport.write_parameters = AsyncMock(
-        side_effect=[TransportWriteError("NAK"), True, True]
+        side_effect=[TransportWriteError("NAK"), True, final_reg234_effect]
     )
 
     ok = await inv.enable_quick_charge(minute=30)
@@ -109,8 +117,6 @@ async def test_enable_local_reg233_read_failure_falls_back_bit_only_plus_live(
 ):
     """If reg 233 cannot be read for the RMW, the paired frame is skipped
     (never blind-write 0x0001) and the bit-only start path runs instead."""
-    from pylxpweb.transports.exceptions import TransportReadError
-
     inv = _inverter(mock_client, with_transport=True)
     inv._transport.read_parameters = AsyncMock(side_effect=[TransportReadError("boom"), {233: 0}])
 
@@ -122,19 +128,34 @@ async def test_enable_local_reg233_read_failure_falls_back_bit_only_plus_live(
 
 
 @pytest.mark.asyncio
-async def test_enable_local_fallback_duration_write_failure_still_starts(mock_client):
-    """Bit-only fallback started the charge; a failed live reg-234 write means
-    the firmware default length runs — the start itself still reports True."""
-    from pylxpweb.transports.exceptions import TransportWriteError
-
+async def test_enable_hybrid_all_local_writes_raise_falls_back_to_cloud(mock_client):
+    """Concrete Modbus/Dongle transports raise TransportWriteError rather than
+    returning False — when the paired frame AND the bit-only start both raise,
+    HYBRID must still reach the cloud start endpoint."""
     inv = _inverter(mock_client, with_transport=True)
-    inv._transport.write_parameters = AsyncMock(
-        side_effect=[TransportWriteError("NAK"), True, TransportWriteError("NAK")]
-    )
+    inv._transport.write_parameters = AsyncMock(side_effect=TransportWriteError("NAK"))
 
-    ok = await inv.enable_quick_charge(minute=30)
+    ok = await inv.enable_quick_charge(minute=20)
 
     assert ok is True
+    # Paired frame attempted, then the bit-only start (write_transport_bit
+    # swallows the raise into False) — no live reg-234 attempt after a
+    # failed start.
+    writes = [c.args[0] for c in inv._transport.write_parameters.call_args_list]
+    assert writes == [{233: 1, 234: 20}, {233: 1}]
+    mock_client.api.control.start_quick_charge.assert_awaited_once_with("1234567890", minute=20)
+
+
+@pytest.mark.asyncio
+async def test_enable_local_only_all_writes_raise_returns_false(mock_client):
+    """LOCAL-only (no cloud client): raising transport writes fail honestly."""
+    inv = _inverter(mock_client, with_transport=True)
+    inv._client = None
+    inv._transport.write_parameters = AsyncMock(side_effect=TransportWriteError("NAK"))
+
+    ok = await inv.enable_quick_charge(minute=20)
+
+    assert ok is False
     mock_client.api.control.start_quick_charge.assert_not_called()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.38b2"
+version = "0.9.38b3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- \`enable_quick_charge(minute=N)\` with a local transport now writes the reg 233 bit-0 activation (read-modify-write, preserving the sticky 0x1000 flag) **together with the reg 234 duration in one contiguous Modbus frame** — the portal-equivalent start sequence, live-validated on FlexBOSS21 2026-07-12 (started at the requested 5 min, INPUT 210 counting down; early stop zeroes reg 234; a local start is per-inverter, unlike group-wide portal starts).
- Fallback chain on paired-frame failure: bit-only start (proven path) + best-effort live reg-234 write → cloud endpoint (HYBRID) / honest False (LOCAL-only).
- Version 0.9.38b3 — the eg4_web_monitor integration pins this as the paired-start floor.

## Review gate
- codex gpt-5.6-sol adversarial: round 1 BLOCKED (P2: exception-path test coverage) → fixed → verification CLEAR TO MERGE
- DRY scan + code-simplifier: no blocking findings; fallback-test parametrize applied
- 2771 tests, mypy --strict clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)