### PR TITLE
fix: demote transport read-failure logs from ERROR to DEBUG

### DIFF
--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -1081,7 +1081,12 @@ class RegisterDataMixin(_DataMixinBase):
             except _CoalescedReadFallback:
                 raise
             except Exception as e:
-                _LOGGER.error(
+                # DEBUG, not ERROR: the raised TransportReadError carries the
+                # same message and the device layer owns user-visible logging
+                # (per-poll DEBUG + one WARNING on the link-down transition).
+                # On a flaky dongle link the retries-exhausted case is routine
+                # and the next cycle self-heals off cached data.
+                _LOGGER.debug(
                     "Failed to read register group '%s': %s",
                     block.label,
                     e,
@@ -1506,7 +1511,11 @@ class RegisterDataMixin(_DataMixinBase):
                     await asyncio.sleep(self._inter_register_delay)
 
         except Exception as e:
-            _LOGGER.error("Failed to read MID input registers: %s", e)
+            # DEBUG, not ERROR: double-reporting — the raise carries the same
+            # message and mid_device.refresh() logs the failure at DEBUG with
+            # a single WARNING on the link-down transition. This fires ~15x/h
+            # on a GridBOSS dongle sharing its link with cloud traffic.
+            _LOGGER.debug("Failed to read MID input registers: %s", e)
             raise TransportReadError(f"Failed to read MID registers: {e}") from e
 
         # Smart port mode is stored as a bit-packed value in holding register 20

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.38b3"
+version = "0.9.38b4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Kills the recurring ERROR-level dongle noise (`Failed to read MID input registers: ... Empty response from dongle / misrouted cloud response`, ~15/h on a GridBOSS dongle whose link is shared with cloud traffic, plus its sibling `Failed to read register group`).

Both sites are log-and-raise double-reports: the raised `TransportReadError` carries the identical message, and the device layer already owns user-visible logging by design — `mid_device.refresh()`/BaseDevice log the failure at DEBUG per poll and emit exactly one WARNING on the link-down transition. The per-attempt retry logs were already DEBUG; only the retries-exhausted final log was ERROR, which is a routine, self-healing event on flaky dongle links (next 30s cycle serves from cache or succeeds).

No behavior change — log level only. 2777 tests, mypy --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)