### PR TITLE
docs: add JoyfulHouse Discord community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ uv run mypy
 
 ## Support
 
+- Join the [JoyfulHouse Discord](https://discord.gg/gc4eTPwxjJ) for support and discussion across all JoyfulHouse Home Assistant integrations and libraries.
 - **Issues:** <https://github.com/joyfulhouse/pylxpweb/issues>
 - **PyPI:** <https://pypi.org/project/pylxpweb/>
 


### PR DESCRIPTION
Adds the JoyfulHouse community Discord invite to the README.