### PR TITLE
fix: tolerate WAITING/unknown firmware statuses + harden multi-step busy handling (#353)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.38"
+version = "0.9.39b1"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -589,6 +589,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             LuxpowerConnectionError: If connection fails.
         """
         # Import here to avoid circular imports
+        from pylxpweb.exceptions import LuxpowerAPIError
         from pylxpweb.models import FirmwareUpdateRunResult
 
         def _progress_key(
@@ -604,6 +605,23 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 info.app_version_current,
                 info.param_version_current,
             )
+
+        def _is_device_busy_error(err: LuxpowerAPIError) -> bool:
+            # A start/eligibility call can lose a TOCTOU race and come back busy
+            # under any of the API's busy-ish codes, not just the observed
+            # ``deviceBusy``. Match on two stems that cover the whole family:
+            #   - ``busy``: ``deviceBusy`` / ``device_busy`` / ``DEVICE_BUSY`` /
+            #     bare ``BUSY`` (the transport transient code).
+            #   - ``updating``: the eligibility enum codes ``deviceUpdating`` /
+            #     ``parallelGroupUpdating`` AND the ``standardUpdate/run`` prose
+            #     variants ("Device is already updating", "Another device in the
+            #     parallel group is updating"). A non-busy start error ("no
+            #     update available", bad serial, etc.) does not contain either
+            #     stem, so it still propagates.
+            # Treat all busy-ish responses as transient so the bounded
+            # busy-retry tolerates the race instead of escaping raw.
+            message = str(err).casefold()
+            return "busy" in message or "updating" in message
 
         info = await self.check_firmware_updates(force=True)
         if not info.update_available:
@@ -621,19 +639,92 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         # (empty fwCodeBeforeUpload), so remember the target we converged to.
         last_target = info.latest_version or None
         loop = asyncio.get_running_loop()
+        # Smallest wait between busy/eligibility re-polls. Floors poll_interval
+        # so a degenerate poll_interval=0 cannot hot-loop eligibility/start
+        # calls at the API; never exceeds the time left in the budget.
+        retry_backoff = poll_interval if poll_interval > 0 else 0.05
+
+        def _budget_spent(
+            step_index: int, installed_version: str | None
+        ) -> FirmwareUpdateRunResult:
+            return FirmwareUpdateRunResult(
+                success=False,
+                converged=False,
+                steps_run=step_index,
+                message=(
+                    "Device remained busy; firmware update step "
+                    f"{step_index + 1} could not start within the retry budget"
+                ),
+                final_version=installed_version,
+            )
+
         for _ in range(max_steps):
             before = _progress_key(info)
 
-            if not await self.check_update_eligibility():
-                return FirmwareUpdateRunResult(
-                    success=False,
-                    converged=False,
-                    steps_run=steps_run,
-                    message=("Device not eligible for update (another update may be in progress)"),
-                    final_version=info.installed_version,
-                )
+            # Become eligible and start the next component, tolerating a
+            # transient busy race. After a component finishes uploading, the
+            # device can still be settling/rebooting, so both the eligibility
+            # gate AND the start call may briefly report the device busy — the
+            # multi-step chain (issue #353) must not abort in that window.
+            # First step: a not-eligible result is a genuine pre-flight
+            # rejection (fail fast, no write). Later steps, or once a start has
+            # already raced busy: treat not-eligible/deviceBusy as "still
+            # working" and re-poll within a bounded budget. A non-busy API
+            # error still propagates. Bounded by min(start_grace, step_timeout).
+            busy_deadline = loop.time() + min(start_grace, step_timeout)
 
-            started = await self.start_firmware_update(try_fast_mode=try_fast_mode)
+            started = False
+            saw_busy = False
+            attempted = False
+            while True:
+                # Never issue a RETRY start write once the budget is spent
+                # (checked before the attempt; the first genuine try is exempt
+                # so a zero/expired start_grace still gets one shot).
+                if attempted and loop.time() >= busy_deadline:
+                    return _budget_spent(steps_run, info.installed_version)
+                first_attempt = not attempted
+                attempted = True
+
+                # The eligibility probe is itself a network call that can come
+                # back busy (transport BUSY / deviceUpdating / parallelGroup);
+                # treat that as "still working" and retry within budget rather
+                # than letting it escape raw and abort the chain. A non-busy
+                # API error still propagates.
+                try:
+                    eligible = await self.check_update_eligibility()
+                    busy = False
+                except LuxpowerAPIError as err:
+                    if not _is_device_busy_error(err):
+                        raise
+                    eligible = False
+                    busy = True
+                    saw_busy = True
+
+                if eligible:
+                    # The eligibility call can straddle the deadline; never fire
+                    # a RETRY write past it (the first genuine try is exempt).
+                    if not first_attempt and loop.time() >= busy_deadline:
+                        return _budget_spent(steps_run, info.installed_version)
+                    try:
+                        started = await self.start_firmware_update(try_fast_mode=try_fast_mode)
+                        break
+                    except LuxpowerAPIError as err:
+                        if not _is_device_busy_error(err):
+                            raise
+                        saw_busy = True
+                elif not busy and steps_run == 0 and not saw_busy:
+                    # Genuine pre-flight rejection on the very first step.
+                    return FirmwareUpdateRunResult(
+                        success=False,
+                        converged=False,
+                        steps_run=steps_run,
+                        message=(
+                            "Device not eligible for update (another update may be in progress)"
+                        ),
+                        final_version=info.installed_version,
+                    )
+                await asyncio.sleep(min(retry_backoff, max(0.0, busy_deadline - loop.time())))
+
             steps_run += 1
             if not started:
                 return FirmwareUpdateRunResult(

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -1164,9 +1164,15 @@ class UpdateStatus(StrEnum):
 
     READY = "READY"
     UPLOADING = "UPLOADING"
+    WAITING = "WAITING"
     COMPLETE = "COMPLETE"
     SUCCESS = "SUCCESS"
     FAILED = "FAILED"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def _missing_(cls, _value: object) -> UpdateStatus:
+        return cls.UNKNOWN
 
 
 class UpdateEligibilityMessage(StrEnum):
@@ -1177,6 +1183,17 @@ class UpdateEligibilityMessage(StrEnum):
     PARALLEL_GROUP_UPDATING = "parallelGroupUpdating"
     NOT_ALLOWED_IN_PARALLEL = "notAllowedInParallel"
     WARN_PARALLEL = "warnParallel"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, _value: object) -> UpdateEligibilityMessage:
+        # The firmware API emits undocumented eligibility strings on some
+        # devices (e.g. a literal ``deviceBusy`` observed on the 6000XP during
+        # a multi-step update, eg4_web_monitor#353). Fall back to UNKNOWN so an
+        # unrecognized value never crashes a live update via ValidationError;
+        # UNKNOWN is not ALLOW_TO_UPDATE, so ``is_allowed`` stays False (the
+        # device is treated as not-yet-eligible, the safe default).
+        return cls.UNKNOWN
 
 
 class FirmwareUpdateDetails(BaseModel):
@@ -1308,9 +1325,10 @@ class FirmwareDeviceInfo(BaseModel):
         """Check if update is currently in progress.
 
         Uses multiple indicators for reliable detection:
-        - updateStatus must be UPLOADING or READY
+        - updateStatus must be UPLOADING, READY, or WAITING
         - isSendEndUpdate must be False (not completed yet)
-        - isSendStartUpdate should be True (update has started)
+        - isSendStartUpdate must be True for UPLOADING/READY
+        - WAITING is busy even before the start flag is visible
 
         This ensures we accurately detect active updates and avoid
         false positives from completed or failed updates.
@@ -1318,10 +1336,12 @@ class FirmwareDeviceInfo(BaseModel):
         Returns:
             True if update is actively in progress, False otherwise
         """
-        return (
-            (self.updateStatus == UpdateStatus.UPLOADING or self.updateStatus == UpdateStatus.READY)
-            and not self.isSendEndUpdate
-            and self.isSendStartUpdate
+        return not self.isSendEndUpdate and (
+            (
+                self.updateStatus in (UpdateStatus.UPLOADING, UpdateStatus.READY)
+                and self.isSendStartUpdate
+            )
+            or self.updateStatus == UpdateStatus.WAITING
         )
 
     @property

--- a/tests/unit/test_firmware_device_info.py
+++ b/tests/unit/test_firmware_device_info.py
@@ -2,7 +2,37 @@
 
 from __future__ import annotations
 
-from pylxpweb.models import FirmwareDeviceInfo, UpdateStatus
+from pylxpweb.models import (
+    FirmwareDeviceInfo,
+    FirmwareUpdateStatus,
+    UpdateEligibilityMessage,
+    UpdateEligibilityStatus,
+    UpdateStatus,
+)
+
+
+def _firmware_status_payload(update_status: str) -> dict[str, object]:
+    """Build a validated firmware status response with one device row."""
+    return {
+        "receiving": False,
+        "progressing": True,
+        "fileReady": True,
+        "deviceInfos": [
+            {
+                "inverterSn": "1234567890",
+                "startTime": "",
+                "stopTime": "",
+                "standardUpdate": True,
+                "firmware": "IAAB-0E00",
+                "firmwareType": "PCS",
+                "updateStatus": update_status,
+                "isSendStartUpdate": False,
+                "isSendEndUpdate": False,
+                "packageIndex": 0,
+                "updateRate": "0% - 0 / 561",
+            }
+        ],
+    }
 
 
 class TestFirmwareDeviceInfoIsInProgress:
@@ -43,6 +73,26 @@ class TestFirmwareDeviceInfoIsInProgress:
         )
 
         assert device_info.is_in_progress is True
+
+    def test_waiting_validates_as_in_progress_before_start_flag(self) -> None:
+        """WAITING is a queued busy state even before start is acknowledged."""
+        status = FirmwareUpdateStatus.model_validate(_firmware_status_payload("WAITING"))
+
+        device_info = status.deviceInfos[0]
+        assert device_info.updateStatus is UpdateStatus.WAITING
+        assert device_info.is_in_progress is True
+        assert device_info.is_complete is False
+        assert device_info.is_failed is False
+
+    def test_unknown_status_validates_as_neutral(self) -> None:
+        """Future status strings must not crash firmware status validation."""
+        status = FirmwareUpdateStatus.model_validate(_firmware_status_payload("SOMETHING_NEW"))
+
+        device_info = status.deviceInfos[0]
+        assert device_info.updateStatus is UpdateStatus.UNKNOWN
+        assert device_info.is_in_progress is False
+        assert device_info.is_complete is False
+        assert device_info.is_failed is False
 
     def test_is_in_progress_false_when_update_ended(self) -> None:
         """Test is_in_progress returns False when isSendEndUpdate is True."""
@@ -363,3 +413,23 @@ class TestFirmwareDeviceInfoEdgeCases:
         assert failed.is_in_progress is False
         assert failed.is_complete is False
         assert failed.is_failed is True
+
+
+class TestUpdateEligibilityMessageTolerance:
+    """The eligibility ``msg`` enum must tolerate undocumented values.
+
+    ``check_update_eligibility`` runs inside the firmware orchestrator, so an
+    unknown ``msg`` (e.g. a ``deviceBusy`` observed on the 6000XP) must NOT raise
+    a ValidationError mid-update — it must coerce to UNKNOWN and read as
+    not-eligible (the safe default). eg4_web_monitor#353.
+    """
+
+    def test_known_allow_value_is_allowed(self) -> None:
+        status = UpdateEligibilityStatus.model_validate({"success": True, "msg": "allowToUpdate"})
+        assert status.msg is UpdateEligibilityMessage.ALLOW_TO_UPDATE
+        assert status.is_allowed is True
+
+    def test_unknown_message_coerces_to_unknown_and_not_allowed(self) -> None:
+        status = UpdateEligibilityStatus.model_validate({"success": True, "msg": "deviceBusy"})
+        assert status.msg is UpdateEligibilityMessage.UNKNOWN
+        assert status.is_allowed is False

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -8,9 +8,12 @@ path.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from pylxpweb.devices._firmware_update_mixin import FirmwareUpdateMixin
+from pylxpweb.exceptions import LuxpowerAPIError
 from pylxpweb.models import FirmwareUpdateInfo
 
 
@@ -43,8 +46,8 @@ class ScriptedDevice(FirmwareUpdateMixin):
         *,
         checks: list[FirmwareUpdateInfo],
         progresses: list[FirmwareUpdateInfo] | None = None,
-        start_results: list[bool] | None = None,
-        eligibility: list[bool] | None = None,
+        start_results: list[bool | LuxpowerAPIError] | None = None,
+        eligibility: list[bool | LuxpowerAPIError] | None = None,
         failed_statuses: list[bool] | None = None,
     ) -> None:
         self._init_firmware_update_cache()
@@ -69,12 +72,18 @@ class ScriptedDevice(FirmwareUpdateMixin):
     async def start_firmware_update(self, try_fast_mode: bool = False) -> bool:
         self.start_calls += 1
         if self._start_results:
-            return self._start_results.pop(0)
+            result = self._start_results.pop(0)
+            if isinstance(result, LuxpowerAPIError):
+                raise result
+            return result
         return True
 
     async def check_update_eligibility(self) -> bool:
         if self._eligibility:
-            return self._eligibility.pop(0)
+            result = self._eligibility.pop(0)
+            if isinstance(result, LuxpowerAPIError):
+                raise result
+            return result
         return True
 
     async def _update_step_reported_failed(self) -> bool:
@@ -144,6 +153,169 @@ async def test_not_eligible_reports_failure_without_write() -> None:
     assert not result.success
     assert device.start_calls == 0
     assert "not eligible" in result.message
+
+
+@pytest.mark.asyncio
+async def test_transient_device_busy_rechecks_eligibility_and_retries() -> None:
+    """A start race with the previous component must not abort the chain."""
+    installing = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=True)
+    done = _info("ccaa-1E1515", "ccaa-1E1515", in_progress=False)
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, UP_TO_DATE],
+        progresses=[installing, done],
+        start_results=[LuxpowerAPIError("deviceBusy"), True],
+        eligibility=[True, False, True],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+
+    assert result.success and result.converged
+    assert result.steps_run == 1
+    assert device.start_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_inter_step_eligibility_busy_does_not_abort_chain() -> None:
+    """A device still settling between components reports not-eligible at the
+    inter-step gate; the chain must wait and retry, not abort (issue #353)."""
+    installing = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=True)
+    done = _info("ccaa-1E1515", "ccaa-1E1515", in_progress=False)
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
+        progresses=[installing, done, installing, done],
+        # step 1 gate eligible; step 2 gate busy once, then eligible.
+        eligibility=[True, False, True],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+
+    assert result.success and result.converged
+    assert result.steps_run == 2
+    assert device.start_calls == 2
+    assert not device._eligibility  # the busy inter-step gate was re-polled
+
+
+@pytest.mark.asyncio
+async def test_first_step_not_eligible_still_fails_fast_without_write() -> None:
+    """Pre-flight (first step) non-eligibility must still fail fast, no write,
+    no waiting out the busy budget."""
+    device = ScriptedDevice(checks=[STEP1_PENDING], eligibility=[False])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+
+    assert not result.success
+    assert device.start_calls == 0
+    assert "not eligible" in result.message
+    assert not device._eligibility
+
+
+@pytest.mark.asyncio
+async def test_busy_error_from_eligibility_is_retried_not_raised() -> None:
+    """A busy LuxpowerAPIError raised by the eligibility probe itself must be
+    tolerated (retried within budget), not escape raw and abort the chain."""
+    installing = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=True)
+    done = _info("ccaa-1E1515", "ccaa-1E1515", in_progress=False)
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, UP_TO_DATE],
+        progresses=[installing, done],
+        eligibility=[LuxpowerAPIError("deviceBusy"), True],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+
+    assert result.success and result.converged
+    assert result.steps_run == 1
+    assert device.start_calls == 1
+    assert not device._eligibility  # the busy eligibility probe was re-polled
+
+
+@pytest.mark.asyncio
+async def test_non_busy_error_from_eligibility_propagates() -> None:
+    """A non-busy API error from the eligibility probe must propagate."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING],
+        eligibility=[LuxpowerAPIError("some other failure")],
+    )
+
+    with pytest.raises(LuxpowerAPIError, match="some other failure"):
+        await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+
+
+@pytest.mark.asyncio
+async def test_non_busy_error_from_start_propagates() -> None:
+    """A non-busy start error (e.g. 'no update available') must NOT be swallowed
+    by the busy-retry — it propagates so a genuine failure surfaces."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING],
+        start_results=[LuxpowerAPIError("no update available")],
+    )
+
+    with pytest.raises(LuxpowerAPIError, match="no update available"):
+        await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+
+
+@pytest.mark.asyncio
+async def test_no_start_write_fires_after_deadline_on_retry() -> None:
+    """If the eligibility probe on a retry straddles the deadline, no start
+    write may fire past it — the budget is a hard bound on retry writes."""
+
+    class SlowRetryEligibilityDevice(ScriptedDevice):
+        elig_calls = 0
+
+        async def check_update_eligibility(self) -> bool:
+            self.elig_calls += 1
+            if self.elig_calls >= 2:
+                # second probe (the retry) runs long, past the tiny budget
+                await asyncio.sleep(0.2)
+            return True
+
+    device = SlowRetryEligibilityDevice(
+        checks=[STEP1_PENDING],
+        start_results=[LuxpowerAPIError("deviceBusy")],  # first start races busy
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0.1)
+
+    assert not result.success
+    # Only the first (in-budget) start fired; the retry bailed before writing.
+    assert device.start_calls == 1
+    assert "busy" in result.message.casefold()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "deviceBusy",
+        "device busy",
+        "DEVICE_BUSY",
+        # A start-call TOCTOU race can report the device/parallel-group as
+        # already updating; these busy-family codes AND their standardUpdate/run
+        # prose variants must also be tolerated, not escape raw (issue #353).
+        "deviceUpdating",
+        "parallelGroupUpdating",
+        "Device is already updating",
+        "Another device in the parallel group is updating",
+    ],
+)
+@pytest.mark.asyncio
+async def test_device_busy_past_start_budget_returns_clean_failure(message: str) -> None:
+    """A persistent busy response exhausts its budget without escaping raw."""
+
+    class PersistentlyBusyDevice(ScriptedDevice):
+        async def start_firmware_update(self, try_fast_mode: bool = False) -> bool:
+            self.start_calls += 1
+            raise LuxpowerAPIError(message)
+
+    device = PersistentlyBusyDevice(checks=[STEP1_PENDING])
+
+    # A budget wide enough for several retries within it, so we verify the loop
+    # retries multiple times AND stops cleanly at the deadline (no write past it).
+    result = await device.run_firmware_update_to_completion(poll_interval=0.02, start_grace=0.2)
+
+    assert not result.success and not result.converged
+    assert result.steps_run == 0
+    assert device.start_calls > 1
+    assert "busy" in result.message.casefold()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.38b4"
+version = "0.9.39b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Fixes the pylxpweb side of eg4_web_monitor#353. On a real **6000XP** multi-component firmware update, the device reports `updateStatus='WAITING'` — a value absent from `UpdateStatus` — which crashed `FirmwareUpdateStatus` validation and (via the integration's swallowed exception) blanked the HA update entity to idle mid-update.

## Changes
- **`UpdateStatus` / `UpdateEligibilityMessage`**: add `WAITING` + a `_missing_` hook that coerces any unrecognized value to a neutral `UNKNOWN` sentinel, so a novel device status / eligibility string never crashes a live update via `ValidationError`.
- **`FirmwareDeviceInfo.is_in_progress`**: treat `WAITING` as active (busy even before the start flag) so the entity/orchestrator keep tracking across components.
- **`run_firmware_update_to_completion`**: tolerate a transient busy race (`deviceBusy` / `BUSY` / `deviceUpdating` / `parallelGroupUpdating` + their `standardUpdate/run` prose variants) on **both** the eligibility probe and the start call, bounded by `min(start_grace, step_timeout)`; never issue a start write past the deadline; fail fast only on a genuine first-step pre-flight rejection; a genuinely non-busy API error still propagates.

## Validation
- Unit tests added/extended (WAITING/unknown via real `model_validate`; eligibility tolerance; transient + persistent busy; inter-step eligibility-busy; deadline-bound; non-busy propagation).
- Multi-model adversarial review (Claude Opus 4.8, Codex GPT-5.6-sol, Gemini 3.1 Pro, Grok 4.5) — **all clean** after 6 rounds.
- Gate: ruff, mypy --strict, full unit suite (**2753 passed**).
- **Hardware convergence pending** on the reporter's retained 6000XP secondary inverter.

Version bumped to **0.9.39b1** (beta, pending hardware validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)