### PR TITLE
feat: inverter-level AC couple start/end SOC params (eg4#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([eg4_web_monitor#352](https://github.com/joyfulhouse/eg4_web_monitor/issues/352)):
   `ControlEndpoints.set_inverter_ac_couple_start_soc` /
   `set_inverter_ac_couple_end_soc` write the inverter's own
-  `_12K_HOLD_AC_COUPLE_{START,END}_SOC` holdParams (0-100 %), and
+  `_12K_HOLD_AC_COUPLE_{START,END}_SOC` holdParams, and
   `get_inverter_ac_couple_soc_limits` reads both back — enabling the reporter's
   grid↔AC-couple transition script on the EG4_OFFGRID family. Distinct from the
-  GridBOSS/MID per-port `set_ac_couple_start_soc`. Cloud-only: the LOCAL Modbus
-  register is not pinned (the SNA12K-US probe cannot separate the SOC params from
-  the `FUNC_LSP_BYPASS` bitfield block; addresses await a live LOCAL probe).
+  GridBOSS/MID per-port `set_ac_couple_start_soc`. START accepts 0-100 %; END
+  accepts 0-100 % **or exactly 255**, the observed disabled / "never stop"
+  sentinel (four factory-state register probes read END=255 paired with
+  START=100). The getter returns `dict[str, int | None]` — `None` for an absent
+  or non-numeric param, since 0 is itself a legal SOC. Cloud-only: the LOCAL
+  Modbus register is not pinned (the SNA12K-US probe cannot separate the SOC
+  params from the `FUNC_LSP_BYPASS` bitfield block; addresses await a live LOCAL
+  probe).
 
 ## [0.9.38] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Inverter AC couple start/stop SOC (cloud)**
+  ([eg4_web_monitor#352](https://github.com/joyfulhouse/eg4_web_monitor/issues/352)):
+  `ControlEndpoints.set_inverter_ac_couple_start_soc` /
+  `set_inverter_ac_couple_end_soc` write the inverter's own
+  `_12K_HOLD_AC_COUPLE_{START,END}_SOC` holdParams (0-100 %), and
+  `get_inverter_ac_couple_soc_limits` reads both back — enabling the reporter's
+  grid↔AC-couple transition script on the EG4_OFFGRID family. Distinct from the
+  GridBOSS/MID per-port `set_ac_couple_start_soc`. Cloud-only: the LOCAL Modbus
+  register is not pinned (the SNA12K-US probe cannot separate the SOC params from
+  the `FUNC_LSP_BYPASS` bitfield block; addresses await a live LOCAL probe).
+
 ## [0.9.38] - 2026-07-13
 
 Stable release consolidating the 0.9.38 beta line (b1–b4) plus a dongle

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -744,6 +744,14 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
     # accident). Canonical row is SCALE_NONE % like reg 160, so the local named
     # read/write pass through raw 1:1 (eg4_web_monitor#331/#332).
     161: ["HOLD_AC_CHARGE_END_BATTERY_SOC"],
+    # Inverter AC-couple START/END SOC (_12K_HOLD_AC_COUPLE_{START,END}_SOC,
+    # eg4_web_monitor#352) are DELIBERATELY not mapped here: they are CLOUD-ONLY
+    # named params (ControlEndpoints.set_inverter_ac_couple_{start,end}_soc). The
+    # SNA12K-US probe co-locates both onto the FUNC_LSP_BYPASS bitfield block
+    # (regs 219-221 = the 48-bit LSP-bypass bitmap), a block-detection artifact
+    # that cannot pin their true register; the clean sibling *_VOLT params sit at
+    # regs 222/223. Add a row here only with a live LOCAL Modbus probe of the
+    # SOC addresses (SCALE_NONE %, raw 1:1) — hardware-evidence follow-up.
     169: ["HOLD_ON_GRID_EOD_VOLTAGE"],  # On-grid EOD voltage (V, ×10; cloud-confirmed name)
     # Peak Shaving time schedule (209-212, packed hour|minute per register;
     # 2 windows). Same canonical packed-time naming as AC First above.

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -2439,23 +2439,33 @@ class ControlEndpoints(BaseEndpoint):
 
         Args:
             inverter_sn: Inverter serial number
-            percent: Battery SOC (%) to stop the AC-coupled source (0-100)
+            percent: Battery SOC (%) to stop the AC-coupled source (0-100), OR
+                exactly 255 — the observed disabled / "never stop" sentinel.
+                Four factory-state register probes (12KPV, FlexBOSS18/21) read
+                END=255 paired with START=100, so 255 must remain writable to
+                restore that state (same spirit as the SOC-101 "never stop"
+                carve-out on ``set_ac_charge_soc_limits``). START has no such
+                sentinel — its disabled pair reads 100, not 255.
             client_type: Client type (WEB/APP)
 
         Returns:
             SuccessResponse: Operation result
 
         Raises:
-            ValueError: If percent is out of range
+            ValueError: If percent is outside 0-100 and not the 255 sentinel
 
         Example:
             >>> # Stop the AC-coupled source when SOC reaches 95%
             >>> await client.control.set_inverter_ac_couple_end_soc(
             ...     "1234567890", 95
             ... )
+            >>> # Disable the stop threshold ("never stop") sentinel
+            >>> await client.control.set_inverter_ac_couple_end_soc(
+            ...     "1234567890", 255
+            ... )
         """
-        if not 0 <= percent <= 100:
-            raise ValueError(f"percent must be 0-100, got {percent}")
+        if not (0 <= percent <= 100 or percent == 255):
+            raise ValueError(f"percent must be 0-100 or 255 (disabled), got {percent}")
 
         return await self.write_parameter(
             inverter_sn,
@@ -2464,24 +2474,41 @@ class ControlEndpoints(BaseEndpoint):
             client_type=client_type,
         )
 
-    async def get_inverter_ac_couple_soc_limits(self, inverter_sn: str) -> dict[str, int]:
+    async def get_inverter_ac_couple_soc_limits(self, inverter_sn: str) -> dict[str, int | None]:
         """Get the inverter AC couple start/stop SOC thresholds via cloud API.
 
         Returns:
-            Dictionary with start_soc and end_soc (whole percent). Missing
-            params default to 0 (the family that lacks these reports neither).
+            Dictionary with ``start_soc`` and ``end_soc``. Each is the whole
+            percent (or the ``end_soc`` 255 "disabled/never-stop" sentinel), or
+            ``None`` when the param is absent (the grid-tied family that lacks
+            these reports neither) or non-numeric. ``None`` is used instead of 0
+            because 0 is itself a legal writable SOC.
 
         Example:
+            >>> # Illustrative only — shape of the return value. The exact
+            >>> # numbers depend on the device; a set→get round-trip through
+            >>> # this cloud getter is unverified pending a live call on
+            >>> # AC-couple-capable hardware.
             >>> limits = await client.control.get_inverter_ac_couple_soc_limits(
             ...     "1234567890"
             ... )
-            >>> limits
-            {'start_soc': 50, 'end_soc': 90}
+            >>> limits  # doctest: +SKIP
+            {'start_soc': 85, 'end_soc': 255}
         """
         params = await self.read_device_parameters_ranges(inverter_sn)
+
+        def _parse(key: str) -> int | None:
+            raw = params.get(key)
+            if raw is None:
+                return None
+            try:
+                return int(raw)
+            except (TypeError, ValueError):
+                return None
+
         return {
-            "start_soc": int(params.get("_12K_HOLD_AC_COUPLE_START_SOC", 0) or 0),
-            "end_soc": int(params.get("_12K_HOLD_AC_COUPLE_END_SOC", 0) or 0),
+            "start_soc": _parse("_12K_HOLD_AC_COUPLE_START_SOC"),
+            "end_soc": _parse("_12K_HOLD_AC_COUPLE_END_SOC"),
         }
 
     # ============================================================================

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -2361,6 +2361,130 @@ class ControlEndpoints(BaseEndpoint):
         }
 
     # ============================================================================
+    # Inverter AC Couple SOC Threshold Controls (Cloud API)
+    # ============================================================================
+    #
+    # INVERTER-LEVEL AC couple start/stop SOC, distinct from the GridBOSS/MID
+    # smart-port methods (``set_ac_couple_start_soc`` / ``set_ac_couple_end_soc``
+    # above), which write per-port ``MIDBOX_HOLD_AC_START_SOC_{port}``. These
+    # write the inverter's own ``_12K_HOLD_AC_COUPLE_{START,END}_SOC`` holdParams
+    # instead — the AC-coupled source (e.g. a grid-tied inverter on the smart
+    # port) is enabled when SOC drops below START and disabled above END.
+    #
+    # WIRE EVIDENCE (eg4_web_monitor#352): the EG4 portal sets these via a
+    # POST of ``_12K_HOLD_AC_COUPLE_START_SOC`` / ``_12K_HOLD_AC_COUPLE_END_SOC``
+    # (reporter mjstrand's 12000XP v2 capture, independently confirmed by
+    # ivanfmartinez and by the SNA12K-US register probe — same EG4_OFFGRID
+    # family — which read back START="50", END="90"). The reporter's "STOP"
+    # wording is the same END param; the wire name is ``_END_SOC``.
+    #
+    # CLOUD-ONLY: the LOCAL Modbus register is NOT pinned. The SNA12K-US probe
+    # co-locates both SOC params onto the ``FUNC_LSP_BYPASS`` bitfield block
+    # (regs 219-221 hold the 48-bit LSP-bypass bitmap in full), a known
+    # block-detection artifact — a 16-bit register cannot hold 16 bit-flags AND
+    # a percent. The clean sibling START/END *VOLT* params land at regs 222/223,
+    # but the SOC register addresses are unverifiable from portal evidence and a
+    # register claim here requires a live LOCAL probe (hardware-evidence
+    # follow-up). Named cloud reads/writes are the proven path — and the path
+    # the reporter actually uses.
+
+    async def set_inverter_ac_couple_start_soc(
+        self,
+        inverter_sn: str,
+        percent: int,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Set the inverter AC couple START SOC threshold via cloud API.
+
+        When battery SOC drops below this threshold, the AC-coupled source on
+        the inverter's smart port is activated.
+
+        Args:
+            inverter_sn: Inverter serial number
+            percent: Battery SOC (%) to start the AC-coupled source (0-100)
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Raises:
+            ValueError: If percent is out of range
+
+        Example:
+            >>> # Start the AC-coupled source when SOC drops below 85%
+            >>> await client.control.set_inverter_ac_couple_start_soc(
+            ...     "1234567890", 85
+            ... )
+        """
+        if not 0 <= percent <= 100:
+            raise ValueError(f"percent must be 0-100, got {percent}")
+
+        return await self.write_parameter(
+            inverter_sn,
+            "_12K_HOLD_AC_COUPLE_START_SOC",
+            str(percent),
+            client_type=client_type,
+        )
+
+    async def set_inverter_ac_couple_end_soc(
+        self,
+        inverter_sn: str,
+        percent: int,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Set the inverter AC couple END SOC threshold via cloud API.
+
+        When battery SOC rises above this threshold, the AC-coupled source on
+        the inverter's smart port is deactivated.
+
+        Args:
+            inverter_sn: Inverter serial number
+            percent: Battery SOC (%) to stop the AC-coupled source (0-100)
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Raises:
+            ValueError: If percent is out of range
+
+        Example:
+            >>> # Stop the AC-coupled source when SOC reaches 95%
+            >>> await client.control.set_inverter_ac_couple_end_soc(
+            ...     "1234567890", 95
+            ... )
+        """
+        if not 0 <= percent <= 100:
+            raise ValueError(f"percent must be 0-100, got {percent}")
+
+        return await self.write_parameter(
+            inverter_sn,
+            "_12K_HOLD_AC_COUPLE_END_SOC",
+            str(percent),
+            client_type=client_type,
+        )
+
+    async def get_inverter_ac_couple_soc_limits(self, inverter_sn: str) -> dict[str, int]:
+        """Get the inverter AC couple start/stop SOC thresholds via cloud API.
+
+        Returns:
+            Dictionary with start_soc and end_soc (whole percent). Missing
+            params default to 0 (the family that lacks these reports neither).
+
+        Example:
+            >>> limits = await client.control.get_inverter_ac_couple_soc_limits(
+            ...     "1234567890"
+            ... )
+            >>> limits
+            {'start_soc': 50, 'end_soc': 90}
+        """
+        params = await self.read_device_parameters_ranges(inverter_sn)
+        return {
+            "start_soc": int(params.get("_12K_HOLD_AC_COUPLE_START_SOC", 0) or 0),
+            "end_soc": int(params.get("_12K_HOLD_AC_COUPLE_END_SOC", 0) or 0),
+        }
+
+    # ============================================================================
     # Sporadic Charge Controls (Cloud API)
     # ============================================================================
 

--- a/tests/unit/endpoints/test_control_helpers.py
+++ b/tests/unit/endpoints/test_control_helpers.py
@@ -758,6 +758,91 @@ class TestACChargeSocLimitsCloud:
         assert limits == {"start_soc": 20, "end_soc": 100}
 
 
+class TestInverterACCoupleSocLimitsCloud:
+    """Inverter-level AC couple SOC cloud API methods (eg4_web_monitor#352).
+
+    Distinct from the GridBOSS/MID per-port ``set_ac_couple_start_soc`` methods:
+    these write the inverter's own ``_12K_HOLD_AC_COUPLE_{START,END}_SOC``
+    holdParams (wire evidence: the reporter's 12000XP v2 portal capture and the
+    SNA12K-US EG4_OFFGRID register probe).
+    """
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_start_soc(self, control: ControlEndpoints) -> None:
+        """Start SOC writes the _12K_HOLD_AC_COUPLE_START_SOC holdParam."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        result = await control.set_inverter_ac_couple_start_soc(SERIAL, 85)
+
+        assert result.success is True
+        control.write_parameter.assert_called_once_with(
+            SERIAL, "_12K_HOLD_AC_COUPLE_START_SOC", "85", client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_end_soc(self, control: ControlEndpoints) -> None:
+        """End SOC writes the _12K_HOLD_AC_COUPLE_END_SOC holdParam (the wire
+        name for the reporter's "STOP" SOC)."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        result = await control.set_inverter_ac_couple_end_soc(SERIAL, 95)
+
+        assert result.success is True
+        control.write_parameter.assert_called_once_with(
+            SERIAL, "_12K_HOLD_AC_COUPLE_END_SOC", "95", client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_start_soc_bounds(self, control: ControlEndpoints) -> None:
+        """0 and 100 are accepted; the reporter's step-wise flow uses 1% too."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        assert (await control.set_inverter_ac_couple_start_soc(SERIAL, 0)).success is True
+        assert (await control.set_inverter_ac_couple_end_soc(SERIAL, 100)).success is True
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_start_soc_invalid(
+        self, control: ControlEndpoints
+    ) -> None:
+        """Out-of-range start SOC raises ValueError before any write."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+        with pytest.raises(ValueError, match="percent must be 0-100"):
+            await control.set_inverter_ac_couple_start_soc(SERIAL, 101)
+        control.write_parameter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_end_soc_invalid(self, control: ControlEndpoints) -> None:
+        """Out-of-range end SOC raises ValueError before any write."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+        with pytest.raises(ValueError, match="percent must be 0-100"):
+            await control.set_inverter_ac_couple_end_soc(SERIAL, -1)
+        control.write_parameter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_ac_couple_soc_limits(self, control: ControlEndpoints) -> None:
+        """Getter surfaces both params from the cloud parameter read (portal
+        returns them as strings, e.g. the SNA12K-US probe's "50"/"90")."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "_12K_HOLD_AC_COUPLE_START_SOC": "50",
+                "_12K_HOLD_AC_COUPLE_END_SOC": "90",
+            }
+        )
+
+        limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
+        assert limits == {"start_soc": 50, "end_soc": 90}
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_ac_couple_soc_limits_absent(
+        self, control: ControlEndpoints
+    ) -> None:
+        """A family without these params (grid-tied) reads back 0/0, not KeyError."""
+        control.read_device_parameters_ranges = AsyncMock(return_value={})
+
+        limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
+        assert limits == {"start_soc": 0, "end_soc": 0}
+
+
 class TestACChargeVoltageLimitsCloud:
     """Test AC charge voltage limit cloud API methods."""
 

--- a/tests/unit/endpoints/test_control_helpers.py
+++ b/tests/unit/endpoints/test_control_helpers.py
@@ -794,10 +794,11 @@ class TestInverterACCoupleSocLimitsCloud:
 
     @pytest.mark.asyncio
     async def test_set_inverter_ac_couple_start_soc_bounds(self, control: ControlEndpoints) -> None:
-        """0 and 100 are accepted; the reporter's step-wise flow uses 1% too."""
+        """0, 1 (the reporter's step-wise low) and 100 are all accepted."""
         control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
 
         assert (await control.set_inverter_ac_couple_start_soc(SERIAL, 0)).success is True
+        assert (await control.set_inverter_ac_couple_start_soc(SERIAL, 1)).success is True
         assert (await control.set_inverter_ac_couple_end_soc(SERIAL, 100)).success is True
 
     @pytest.mark.asyncio
@@ -811,12 +812,60 @@ class TestInverterACCoupleSocLimitsCloud:
         control.write_parameter.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_set_inverter_ac_couple_end_soc_invalid(self, control: ControlEndpoints) -> None:
-        """Out-of-range end SOC raises ValueError before any write."""
+    async def test_set_inverter_ac_couple_start_soc_rejects_255(
+        self, control: ControlEndpoints
+    ) -> None:
+        """The 255 disabled sentinel is END-only; START rejects it with its
+        plain 0-100 message (no probe dump shows start=255 — the observed
+        disabled pair is start=100)."""
         control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
-        with pytest.raises(ValueError, match="percent must be 0-100"):
-            await control.set_inverter_ac_couple_end_soc(SERIAL, -1)
+        with pytest.raises(ValueError, match=r"percent must be 0-100, got 255"):
+            await control.set_inverter_ac_couple_start_soc(SERIAL, 255)
         control.write_parameter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_end_soc_255_accepted(
+        self, control: ControlEndpoints
+    ) -> None:
+        """END accepts the 255 disabled/never-stop sentinel (4 factory-state
+        probe dumps read END=255 paired with START=100)."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        result = await control.set_inverter_ac_couple_end_soc(SERIAL, 255)
+
+        assert result.success is True
+        control.write_parameter.assert_called_once_with(
+            SERIAL, "_12K_HOLD_AC_COUPLE_END_SOC", "255", client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", [-1, 101, 254, 256])
+    async def test_set_inverter_ac_couple_end_soc_invalid(
+        self, control: ControlEndpoints, bad: int
+    ) -> None:
+        """Values outside 0-100 that are not exactly 255 raise before any write
+        (101 and 254 prove 255 is a single sentinel, not an open upper range)."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+        with pytest.raises(ValueError, match="percent must be 0-100 or 255"):
+            await control.set_inverter_ac_couple_end_soc(SERIAL, bad)
+        control.write_parameter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_soc_client_type_propagates(
+        self, control: ControlEndpoints
+    ) -> None:
+        """client_type flows through to write_parameter on both setters."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        await control.set_inverter_ac_couple_start_soc(SERIAL, 85, client_type="APP")
+        await control.set_inverter_ac_couple_end_soc(SERIAL, 95, client_type="APP")
+
+        control.write_parameter.assert_any_call(
+            SERIAL, "_12K_HOLD_AC_COUPLE_START_SOC", "85", client_type="APP"
+        )
+        control.write_parameter.assert_any_call(
+            SERIAL, "_12K_HOLD_AC_COUPLE_END_SOC", "95", client_type="APP"
+        )
 
     @pytest.mark.asyncio
     async def test_get_inverter_ac_couple_soc_limits(self, control: ControlEndpoints) -> None:
@@ -833,14 +882,58 @@ class TestInverterACCoupleSocLimitsCloud:
         assert limits == {"start_soc": 50, "end_soc": 90}
 
     @pytest.mark.asyncio
+    async def test_get_inverter_ac_couple_soc_limits_passes_255_through(
+        self, control: ControlEndpoints
+    ) -> None:
+        """The 255 disabled sentinel is surfaced unmodified (factory state:
+        START=100, END=255)."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "_12K_HOLD_AC_COUPLE_START_SOC": "100",
+                "_12K_HOLD_AC_COUPLE_END_SOC": "255",
+            }
+        )
+
+        limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
+        assert limits == {"start_soc": 100, "end_soc": 255}
+
+    @pytest.mark.asyncio
     async def test_get_inverter_ac_couple_soc_limits_absent(
         self, control: ControlEndpoints
     ) -> None:
-        """A family without these params (grid-tied) reads back 0/0, not KeyError."""
+        """A family without these params (grid-tied) reads back None/None — not
+        0/0, since 0 is a legal writable SOC and would be ambiguous."""
         control.read_device_parameters_ranges = AsyncMock(return_value={})
 
         limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
-        assert limits == {"start_soc": 0, "end_soc": 0}
+        assert limits == {"start_soc": None, "end_soc": None}
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_ac_couple_soc_limits_partial(
+        self, control: ControlEndpoints
+    ) -> None:
+        """A present param is parsed; a missing sibling is None (not 0)."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={"_12K_HOLD_AC_COUPLE_START_SOC": "85"}
+        )
+
+        limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
+        assert limits == {"start_soc": 85, "end_soc": None}
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_ac_couple_soc_limits_non_numeric(
+        self, control: ControlEndpoints
+    ) -> None:
+        """Non-numeric garbage parses to None rather than raising."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "_12K_HOLD_AC_COUPLE_START_SOC": "n/a",
+                "_12K_HOLD_AC_COUPLE_END_SOC": None,
+            }
+        )
+
+        limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
+        assert limits == {"start_soc": None, "end_soc": None}
 
 
 class TestACChargeVoltageLimitsCloud:


### PR DESCRIPTION
## Summary

Adds inverter-level **AC Couple Start/Stop SOC** control to the cloud API, for [eg4_web_monitor#352](https://github.com/joyfulhouse/eg4_web_monitor/issues/352). Reporter mjstrand (12000XP v2, EG4_OFFGRID family) wants to script a safe grid ↔ AC-couple transition for a grid-tied SolarEdge inverter on the EG4 smart port; the EG4 portal drives it by writing the inverter's `_12K_HOLD_AC_COUPLE_{START,END}_SOC` holdParams.

These are **distinct** from the existing GridBOSS/MID per-port methods `set_ac_couple_start_soc` / `set_ac_couple_end_soc` (which write `MIDBOX_HOLD_AC_START_SOC_{port}`) — those are untouched and unshadowed.

## Methods added (`ControlEndpoints`)

- `set_inverter_ac_couple_start_soc(inverter_sn, percent, client_type="WEB")` → writes `_12K_HOLD_AC_COUPLE_START_SOC` (0-100 %)
- `set_inverter_ac_couple_end_soc(inverter_sn, percent, client_type="WEB")` → writes `_12K_HOLD_AC_COUPLE_END_SOC` (0-100 %)
- `get_inverter_ac_couple_soc_limits(inverter_sn)` → `{"start_soc": int, "end_soc": int}`

Design mirrors the reg 160/161 `set_ac_charge_soc_limits` precedent: named cloud writes via `write_parameter` (the only working cloud write path), reads via `read_device_parameters_ranges` (params surface verbatim from range 127-253, same mechanism the eg4 integration already uses for reg 160/161). Setters are **individual** (not paired) so the reporter's step-wise flow — set start=1 %, end=11 %, transfer, then start=85 %, end=95 % — can move each threshold independently without a spurious start<end coupling constraint. This also matches the per-threshold shape of the midbox AC-couple setters.

## Evidence for param names

- **Reporter capture** (issue body): portal POSTs `_12K_HOLD_AC_COUPLE_START_SOC` + `_12K_HOLD_AC_COUPLE_STOP_SOC`.
- **ivanfmartinez** (issue comment): confirms `_12K_HOLD_AC_COUPLE_START_SOC` and `_12K_HOLD_AC_COUPLE_END_SOC` on his inverter.
- **`docs/inverters/SNA12KUS_52XXXXXX68.json`** (SNA12K-US, same EG4_OFFGRID family): register probe reads `_12K_HOLD_AC_COUPLE_START_SOC="50"`, `_12K_HOLD_AC_COUPLE_END_SOC="90"`.

The reporter's "STOP" wording is the same parameter — the actual wire name is `_END_SOC` (confirmed by both the probe and ivanfmartinez). Using `_END_SOC`.

## Registers: cloud-only (NOT pinned) — with evidence

The library rule is a register claim needs live/probe evidence, never inference. **The SOC register addresses could not be pinned**, so this ships cloud-only:

- The SNA12K-US probe co-locates `_12K_HOLD_AC_COUPLE_START_SOC` onto the **register-220 block** and `_END_SOC` onto **register-221**, but those blocks are the `FUNC_LSP_BYPASS` 48-bit bitmap — regs **219/220/221** hold `FUNC_LSP_BYPASS_1-48` (16 bits each) in full. A 16-bit register cannot hold 16 bit-flags **and** a percent, so the co-location is a block-detection artifact (the same pattern mis-attributes `_12K_HOLD_START_PV_POWER` / `_12K_HOLD_SMART_LOAD_END_SOC` onto the `FUNC_LSP_BAT_FIRST` bitmap at regs 216/217).
- Calibration confirms the probe *is* trustworthy for **clean** single-param blocks: it places the known `HOLD_AC_CHARGE_START_BATTERY_SOC`→160 and `HOLD_AC_CHARGE_END_BATTERY_SOC`→161 exactly, and the clean sibling `_12K_HOLD_AC_COUPLE_{START,END}_VOLT` at regs **222/223**. But the SOC params specifically fall in dirty (bitfield-bundled) blocks.

A documented hardware-evidence follow-up comment is left in `constants/registers.py` for anyone who can run a live LOCAL Modbus probe of the SOC addresses. Scaling is raw percent (`SCALE_NONE`), consistent with reg 160/161.

## Test plan

New `TestInverterACCoupleSocLimitsCloud` in `tests/unit/endpoints/test_control_helpers.py` (7 cases): param name on the wire for each setter, 0/100 bounds accepted, out-of-range raises `ValueError` before any write, getter maps both params (string values, as the portal returns), and getter defaults to 0/0 when the family lacks the params.

## Gates

- `ruff check --fix` + `ruff format`: clean
- `mypy --strict src/pylxpweb/`: no issues (94 files)
- `pytest tests/`: 2798 passed, 4 skipped

No version bump; no `uv.lock` change.

Downstream: [joyfulhouse/eg4_web_monitor#352](https://github.com/joyfulhouse/eg4_web_monitor/issues/352)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round (4-reviewer gate) — commit 7c5acd6

Reviewers: Claude code-reviewer (CLEAN), code-simplifier (already minimal), Codex (CLEAN + notes), Gemini (1 P1, confirmed against probe dumps). Fixes applied:

- **255 disabled sentinel (P1, confirmed)**: 4 factory-state probe dumps read `_12K_HOLD_AC_COUPLE_END_SOC="255"` paired with `START_SOC="100"` — the disabled/"never stop" state. `set_inverter_ac_couple_end_soc` now accepts 0-100 **or exactly 255** so that state stays restorable (same spirit as the SOC-101 carve-out on `set_ac_charge_soc_limits`). START stays 0-100.
- **Getter returns `dict[str, int | None]`**: `None` for absent or non-numeric params (0 is a legal SOC, so 0-for-absent was ambiguous for the downstream HA number entity). Parsing is exception-guarded.
- **Docstring softened**: the set→get round-trip through this exact cloud getter is unverified pending AC-couple-capable hardware; the earlier 50/90 readback evidence came from the raw SNA register probe.
- **Tests +9**: 255 accept/reject/passthrough, absent→None, partial params, non-numeric→None, `client_type` propagation.

Correction to this description: the getter reads the **union** of all three parameter ranges (0-126, 127-253, 240-366), so param coverage does not depend on which register the values actually live in.

Downstream note (eg4 #352 entities): family-gate visibility (EG4_OFFGRID), treat `None` as entity-unavailable, and map an `end_soc=255` readback to the disabled state rather than a 0-100 slider value.
