### PR TITLE
feat: inverter AC couple enable/disable (FUNC_AC_COUPLING_FUNCTION) (eg4_web_monitor#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Modbus register is not pinned (the SNA12K-US probe cannot separate the SOC
   params from the `FUNC_LSP_BYPASS` bitfield block; addresses await a live LOCAL
   probe).
+- **Inverter AC couple enable/disable (cloud)**
+  ([eg4_web_monitor#471](https://github.com/joyfulhouse/eg4_web_monitor/issues/471)):
+  `ControlEndpoints.set_inverter_ac_couple_enabled` toggles the inverter's own
+  `FUNC_AC_COUPLING_FUNCTION` via the functionControl endpoint — de-energizing
+  the AC-coupled smart-port source at any battery level, independent of the
+  start/stop SOC window above. Distinct from the GridBOSS/MID per-port
+  `FUNC_AC_COUPLE_EN_{n}` (`enable_ac_couple` / `disable_ac_couple`).
+  `get_inverter_ac_couple_soc_limits` now also returns `"enabled": bool | None`
+  (widening its return type to `dict[str, int | bool | None]`) — `None` for an
+  absent or unparseable param, never a fabricated `False`. Cloud-routed: the
+  Luxpower doc places the param at holding register 179 bit 11 (candidate, not
+  yet pinned by the raw↔named lockstep standard — a LOCAL path is a follow-up).
 
 ## [0.9.38] - 2026-07-13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.39b2"
+version = "0.9.39b3"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -783,6 +783,16 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
     # Bits 9,10 (FUNC_BAT_CHARGE/DISCHARGE_CONTROL) confirmed 2026-02-18 (SOC↔Voltage).
     # Other known params: FUNC_ACTIVE_POWER_LIMIT_MODE, FUNC_AC_COUPLING_FUNCTION,
     # FUNC_CT_DIRECTION_REVERSED,
+    #
+    # FUNC_AC_COUPLING_FUNCTION: BIT 11 CANDIDATE (eg4_web_monitor#471,
+    # ivanfmartinez 2026-07-17): the Luxpower Modbus doc places it at reg 179
+    # bit 11, another integration uses that mapping, and the reporter has
+    # driven the control through it before on his LXP (his LXPUS810K dump —
+    # AC couple enabled — reads the named param True; the SNA12K-US probe —
+    # disabled — reads False). NOT yet pinned by this project's raw↔named
+    # lockstep standard (the bit-3 procedure below); until a live toggle
+    # verifies the bit, reads/writes stay on the named cloud path
+    # (set_inverter_ac_couple_enabled / get_inverter_ac_couple_soc_limits).
     # FUNC_GEN_PEAK_SHAVING, FUNC_ON_GRID_ALWAYS_ON, FUNC_PV_ARC, FUNC_PV_ARC_FAULT_CLEAR,
     # FUNC_PV_SELL_TO_GRID_EN, FUNC_RSD_DISABLE, FUNC_SMART_LOAD_ENABLE,
     # FUNC_TOTAL_LOAD_COMPENSATION_EN, FUNC_TRIP_TIME_UNIT, FUNC_WATT_VOLT_EN

--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -2474,15 +2474,65 @@ class ControlEndpoints(BaseEndpoint):
             client_type=client_type,
         )
 
-    async def get_inverter_ac_couple_soc_limits(self, inverter_sn: str) -> dict[str, int | None]:
-        """Get the inverter AC couple start/stop SOC thresholds via cloud API.
+    async def set_inverter_ac_couple_enabled(
+        self,
+        inverter_sn: str,
+        enabled: bool,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Enable or disable the inverter's AC couple function via cloud API.
+
+        Toggles ``FUNC_AC_COUPLING_FUNCTION`` — the inverter-level smart-port
+        AC couple function, distinct from the GridBOSS/MID per-port
+        ``FUNC_AC_COUPLE_EN_{n}`` functions (``enable_ac_couple`` /
+        ``disable_ac_couple``). Disabling de-energizes the AC-coupled source
+        regardless of the START/END SOC window (eg4_web_monitor#471; portal
+        wire name confirmed by two independent reporters in
+        eg4_web_monitor#352).
+
+        Cloud-routed: the Luxpower doc places the param at holding register
+        179 bit 11 (candidate, see the reg-179 note in
+        ``constants/registers.py``), but the bit is not yet pinned by this
+        project's raw↔named lockstep standard — a local register path is a
+        follow-up once a live toggle verifies it.
+
+        Args:
+            inverter_sn: Inverter serial number
+            enabled: Enable or disable the AC couple function
+            client_type: Client type (WEB/APP)
 
         Returns:
-            Dictionary with ``start_soc`` and ``end_soc``. Each is the whole
-            percent (or the ``end_soc`` 255 "disabled/never-stop" sentinel), or
-            ``None`` when the param is absent (the grid-tied family that lacks
-            these reports neither) or non-numeric. ``None`` is used instead of 0
-            because 0 is itself a legal writable SOC.
+            SuccessResponse: Operation result
+
+        Example:
+            >>> # De-energize the smart port before a transfer-switch flip
+            >>> await client.control.set_inverter_ac_couple_enabled(
+            ...     "1234567890", False
+            ... )
+        """
+        return await self.control_function(
+            inverter_sn,
+            "FUNC_AC_COUPLING_FUNCTION",
+            enabled,
+            client_type=client_type,
+        )
+
+    async def get_inverter_ac_couple_soc_limits(
+        self, inverter_sn: str
+    ) -> dict[str, int | bool | None]:
+        """Get the inverter AC couple SOC thresholds and enable state via cloud API.
+
+        Returns:
+            Dictionary with ``start_soc``, ``end_soc`` and ``enabled``.
+            ``start_soc``/``end_soc`` are the whole percent (or the ``end_soc``
+            255 "disabled/never-stop" sentinel), or ``None`` when the param is
+            absent (the grid-tied family that lacks these reports neither) or
+            non-numeric. ``None`` is used instead of 0 because 0 is itself a
+            legal writable SOC. ``enabled`` is the
+            ``FUNC_AC_COUPLING_FUNCTION`` state — the cloud returns function
+            params as JSON booleans (string ``"true"``/``"false"`` also
+            accepted defensively); absent or unparseable reads ``None``, never
+            a fake ``False``.
 
         Example:
             >>> # Illustrative only — shape of the return value. The exact
@@ -2493,7 +2543,7 @@ class ControlEndpoints(BaseEndpoint):
             ...     "1234567890"
             ... )
             >>> limits  # doctest: +SKIP
-            {'start_soc': 85, 'end_soc': 255}
+            {'start_soc': 85, 'end_soc': 255, 'enabled': True}
         """
         params = await self.read_device_parameters_ranges(inverter_sn)
 
@@ -2506,9 +2556,21 @@ class ControlEndpoints(BaseEndpoint):
             except (TypeError, ValueError):
                 return None
 
+        def _parse_enabled(raw: object) -> bool | None:
+            if isinstance(raw, bool):
+                return raw
+            if isinstance(raw, str):
+                lowered = raw.strip().lower()
+                if lowered == "true":
+                    return True
+                if lowered == "false":
+                    return False
+            return None
+
         return {
             "start_soc": _parse("_12K_HOLD_AC_COUPLE_START_SOC"),
             "end_soc": _parse("_12K_HOLD_AC_COUPLE_END_SOC"),
+            "enabled": _parse_enabled(params.get("FUNC_AC_COUPLING_FUNCTION")),
         }
 
     # ============================================================================

--- a/tests/unit/endpoints/test_control_helpers.py
+++ b/tests/unit/endpoints/test_control_helpers.py
@@ -868,18 +868,48 @@ class TestInverterACCoupleSocLimitsCloud:
         )
 
     @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_enabled(self, control: ControlEndpoints) -> None:
+        """Enable/disable routes through the functionControl endpoint with the
+        inverter-level FUNC_AC_COUPLING_FUNCTION param (eg4_web_monitor#471)."""
+        control.control_function = AsyncMock(return_value=SuccessResponse(success=True))
+
+        assert (await control.set_inverter_ac_couple_enabled(SERIAL, True)).success is True
+        control.control_function.assert_called_with(
+            SERIAL, "FUNC_AC_COUPLING_FUNCTION", True, client_type="WEB"
+        )
+
+        assert (await control.set_inverter_ac_couple_enabled(SERIAL, False)).success is True
+        control.control_function.assert_called_with(
+            SERIAL, "FUNC_AC_COUPLING_FUNCTION", False, client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_ac_couple_enabled_client_type_propagates(
+        self, control: ControlEndpoints
+    ) -> None:
+        """client_type is forwarded to control_function."""
+        control.control_function = AsyncMock(return_value=SuccessResponse(success=True))
+
+        await control.set_inverter_ac_couple_enabled(SERIAL, True, client_type="APP")
+        control.control_function.assert_called_once_with(
+            SERIAL, "FUNC_AC_COUPLING_FUNCTION", True, client_type="APP"
+        )
+
+    @pytest.mark.asyncio
     async def test_get_inverter_ac_couple_soc_limits(self, control: ControlEndpoints) -> None:
-        """Getter surfaces both params from the cloud parameter read (portal
-        returns them as strings, e.g. the SNA12K-US probe's "50"/"90")."""
+        """Getter surfaces all three params from the cloud parameter read (the
+        portal returns HOLD params as strings, e.g. the SNA12K-US probe's
+        "50"/"90", and FUNC params as JSON booleans)."""
         control.read_device_parameters_ranges = AsyncMock(
             return_value={
                 "_12K_HOLD_AC_COUPLE_START_SOC": "50",
                 "_12K_HOLD_AC_COUPLE_END_SOC": "90",
+                "FUNC_AC_COUPLING_FUNCTION": True,
             }
         )
 
         limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
-        assert limits == {"start_soc": 50, "end_soc": 90}
+        assert limits == {"start_soc": 50, "end_soc": 90, "enabled": True}
 
     @pytest.mark.asyncio
     async def test_get_inverter_ac_couple_soc_limits_passes_255_through(
@@ -895,18 +925,19 @@ class TestInverterACCoupleSocLimitsCloud:
         )
 
         limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
-        assert limits == {"start_soc": 100, "end_soc": 255}
+        assert limits == {"start_soc": 100, "end_soc": 255, "enabled": None}
 
     @pytest.mark.asyncio
     async def test_get_inverter_ac_couple_soc_limits_absent(
         self, control: ControlEndpoints
     ) -> None:
-        """A family without these params (grid-tied) reads back None/None — not
-        0/0, since 0 is a legal writable SOC and would be ambiguous."""
+        """A family without these params (grid-tied) reads back all-None — not
+        0/0/False, since 0 is a legal writable SOC and a fake False would
+        misreport the function as disabled."""
         control.read_device_parameters_ranges = AsyncMock(return_value={})
 
         limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
-        assert limits == {"start_soc": None, "end_soc": None}
+        assert limits == {"start_soc": None, "end_soc": None, "enabled": None}
 
     @pytest.mark.asyncio
     async def test_get_inverter_ac_couple_soc_limits_partial(
@@ -918,22 +949,52 @@ class TestInverterACCoupleSocLimitsCloud:
         )
 
         limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
-        assert limits == {"start_soc": 85, "end_soc": None}
+        assert limits == {"start_soc": 85, "end_soc": None, "enabled": None}
 
     @pytest.mark.asyncio
     async def test_get_inverter_ac_couple_soc_limits_non_numeric(
         self, control: ControlEndpoints
     ) -> None:
-        """Non-numeric garbage parses to None rather than raising."""
+        """Non-numeric/unparseable garbage parses to None rather than raising."""
         control.read_device_parameters_ranges = AsyncMock(
             return_value={
                 "_12K_HOLD_AC_COUPLE_START_SOC": "n/a",
                 "_12K_HOLD_AC_COUPLE_END_SOC": None,
+                "FUNC_AC_COUPLING_FUNCTION": "garbage",
             }
         )
 
         limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
-        assert limits == {"start_soc": None, "end_soc": None}
+        assert limits == {"start_soc": None, "end_soc": None, "enabled": None}
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_ac_couple_soc_limits_enabled_false(
+        self, control: ControlEndpoints
+    ) -> None:
+        """A real False passes through — distinct from the absent-param None."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={"FUNC_AC_COUPLING_FUNCTION": False}
+        )
+
+        limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
+        assert limits == {"start_soc": None, "end_soc": None, "enabled": False}
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_ac_couple_soc_limits_enabled_string(
+        self, control: ControlEndpoints
+    ) -> None:
+        """Defensive parse: "true"/"false" strings (any case) are accepted."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={"FUNC_AC_COUPLING_FUNCTION": "TRUE"}
+        )
+        limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
+        assert limits["enabled"] is True
+
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={"FUNC_AC_COUPLING_FUNCTION": "false"}
+        )
+        limits = await control.get_inverter_ac_couple_soc_limits(SERIAL)
+        assert limits["enabled"] is False
 
 
 class TestACChargeVoltageLimitsCloud:

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.39b2"
+version = "0.9.39b3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
Cloud control for the inverter's own AC couple function — the pylxpweb half of [eg4_web_monitor#471](https://github.com/joyfulhouse/eg4_web_monitor/issues/471), follow-up to the #352 AC couple start/stop SOC window.

- **`set_inverter_ac_couple_enabled(sn, enabled)`** toggles `FUNC_AC_COUPLING_FUNCTION` via the functionControl endpoint — de-energizing the AC-coupled smart-port source at any battery level, independent of the SOC window. Distinct from the GridBOSS/MID per-port `FUNC_AC_COUPLE_EN_{n}` (`enable_ac_couple`/`disable_ac_couple`).
- **`get_inverter_ac_couple_soc_limits`** now also returns `"enabled": bool | None` — return type widened `dict[str, int | None]` → `dict[str, int | bool | None]`. `None` for an absent or unparseable param (defensively also parses `"true"`/`"false"` strings), never a fabricated `False`. The only caller (the eg4 coordinator mixin) already consumes the dict field-wise.
- **reg 179 bit 11** recorded as the LOCAL candidate (Luxpower doc + cross-integration use + @ivanfmartinez's LXP dump reads the named param `True` while the disabled SNA probe reads `False`) but **not pinned** — a local register path awaits a live raw↔named lockstep toggle (the bit-3 procedure), tracked in eg4_web_monitor#472.

## Root cause / design
No inverter-level AC couple enable existed; only the per-port GridBOSS functions and the #352 SOC window. The portal drives this with a single `FUNC_AC_COUPLING_FUNCTION` toggle, wrapped here through the existing `control_function` path so the integration can feature-detect by method presence.

## Test plan
- New: setter routes through `control_function` with the right param + `client_type`; getter surfaces `enabled` as bool, parses `"true"/"false"`, returns `None` for absent/garbage, and passes the SOC 255 sentinel through unchanged; all-absent → all-None.
- Full suite: **2816 tests pass**; `ruff` + `mypy --strict` clean.

## Review
Tri-vendor adversarial review (Claude + Codex GPT-5.6-sol xhigh + Gemini 3.1 Pro), 2 rounds. Round-2 Codex: clean. No blocking findings against this repo's diff.

## Release note
Version bumped to **0.9.39b3**. eg4_web_monitor#471 pins `pylxpweb >= 0.9.39b3`, so **this must be published to PyPI before that PR's CI can pass** (see the merge-ordering note there).

Refs eg4_web_monitor#471, eg4_web_monitor#472, eg4_web_monitor#352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)