### PR TITLE
fix: widen lifetime energy spike cap for outage catch-up deltas (eg4_web_monitor#479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Post-outage lifetime-energy catch-up deltas no longer rejected as spikes**
+  ([eg4_web_monitor#479](https://github.com/joyfulhouse/eg4_web_monitor/issues/479)):
+  while a device is offline the portal serves its lifetime counters frozen, so
+  on reconnect the true value arrives as one large but legitimate catch-up
+  delta — previously rejected by the monotonicity cap (`rated_kw * 1.5` per
+  cycle) five times before the upward self-heal accepted it. The cap now widens
+  with the time since a counter last increased on a committed read, but only
+  when outage evidence is armed: a cloud runtime payload flagged `lost`
+  (inverters, and GridBOSS via the newly modeled `MidboxRuntime.lost` field —
+  previously dropped by pydantic) or a transport link-down transition. Idle
+  devices keep the tight always-on corruption canary, and 0xFFFF-scale jumps
+  exceed even the widened cap.
+
 ### Added
 
 - **Inverter AC couple start/stop SOC (cloud)**

--- a/src/pylxpweb/devices/base.py
+++ b/src/pylxpweb/devices/base.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, TypeVar
 
 from pylxpweb.validation import (
+    MAX_ELAPSED_HOURS,
     MAX_ENERGY_DELTA,
     validate_daily_energy_bounds,
     validate_energy_monotonicity,
@@ -150,6 +151,21 @@ class BaseDevice(ABC):
         # Monotonic clock — wall-clock (DST/NTP) steps must not move the window.
         self._daily_energy_change_monotonic: float | None = None
 
+        # Tracks when a lifetime energy counter last *increased* on a
+        # COMMITTED read (_note_energy_accepted).  Used by _is_energy_valid
+        # to widen the per-cycle monotonicity spike cap after an outage:
+        # while a device is offline the cloud serves its counters frozen,
+        # so on reconnect the true value arrives as one large — but
+        # legitimate — catch-up delta (eg4_web_monitor#479).  Monotonic
+        # clock; None until the first validated read seeds it.
+        self._lifetime_energy_change_monotonic: float | None = None
+        # Outage evidence gate for that widening: armed by a cloud payload
+        # flagged lost or a transport link-down transition, disarmed when a
+        # committed read shows a counter increase.  Without this gate a
+        # merely-idle device (every counter flat overnight) would widen its
+        # own spike cap and weaken the always-on corruption canary.
+        self._energy_source_stale: bool = False
+
         # ===== Transport link health (eg4-57g / integration #226) =====
         # Consecutive transport-read failures and last-success timestamp.
         # When the counter crosses TRANSPORT_LINK_DOWN_THRESHOLD, the link
@@ -285,6 +301,9 @@ class BaseDevice(ABC):
                 self.serial_number,
                 self._transport_consecutive_failures,
             )
+            # Sustained outage evidence: the recovery read may carry a large
+            # legitimate catch-up energy delta (eg4_web_monitor#479).
+            self._note_energy_source_stale()
             self._on_transport_link_down()
 
     def _on_transport_link_down(self) -> None:
@@ -335,6 +354,19 @@ class BaseDevice(ABC):
         (the warm-up counter consumed by ``_is_daily_energy_valid``) as
         side-effects.
 
+        When outage evidence is armed (``_energy_source_stale``), the spike
+        cap is widened by the time since a lifetime counter last increased
+        on a committed read (``_lifetime_energy_change_monotonic``, capped
+        at ``MAX_ELAPSED_HOURS``).  ``_max_energy_delta`` is
+        ``rated_power_kw * 1.5`` — an hour of full rated output with the
+        50% safety margin — so ``max_delta * elapsed_hours`` preserves that
+        margin across the whole catch-up window, and the legitimate
+        reconnect delta is accepted on the first read instead of stalling
+        on the 5-strike self-heal (eg4_web_monitor#479).  Without armed
+        evidence the cap never widens: a merely-idle device keeps the tight
+        per-cycle canary, and gross corruption (0xFFFF-scale jumps) exceeds
+        even the widened cap.
+
         Args:
             prev_values: Previous cycle's lifetime energy dict.
             curr_values: Current cycle's lifetime energy dict.
@@ -343,14 +375,77 @@ class BaseDevice(ABC):
             True if the data should be accepted, False if it should be rejected.
         """
         self._energy_validation_calls += 1
+
+        max_delta = self._max_energy_delta
+        if self._lifetime_energy_change_monotonic is None:
+            # Seed on the first validated read so restarts never grant a
+            # spuriously wide window (first reads pass trivially anyway —
+            # there is no previous value to compare against).
+            self._lifetime_energy_change_monotonic = time.monotonic()
+        elif self._energy_source_stale:
+            elapsed_hours = min(
+                (time.monotonic() - self._lifetime_energy_change_monotonic) / 3600.0,
+                MAX_ELAPSED_HOURS,
+            )
+            max_delta = max(max_delta, self._max_energy_delta * elapsed_hours)
+
         result, self._energy_reject_count = validate_energy_monotonicity(
             prev_values,
             curr_values,
             self._energy_reject_count,
             self.serial_number,
-            max_delta=self._max_energy_delta,
+            max_delta=max_delta,
         )
         return result != "reject"
+
+    def _note_energy_source_stale(self) -> None:
+        """Arm the catch-up widening: served energy data is known stale.
+
+        Called on outage evidence only — a cloud runtime payload flagged
+        ``lost`` or a transport link-down transition.  A plain failed fetch
+        deliberately does NOT arm it: transient blips fall back to the
+        pre-existing 5-strike self-heal, keeping the always-on corruption
+        canary tight (an armed gate plus an idle window would let moderate
+        corruption through immediately).
+
+        Disarmed only by ``_note_energy_accepted`` observing a committed
+        counter increase — a recovery cannot disarm it earlier, because the
+        catch-up delta arrives before any increase can commit.
+        """
+        self._energy_source_stale = True
+
+    def _note_energy_accepted(
+        self,
+        prev_values: dict[str, float | None] | None,
+        curr_values: dict[str, float | None],
+    ) -> None:
+        """Re-arm the widening window after a snapshot is COMMITTED.
+
+        Called by the fetch paths after BOTH lifetime and daily validation
+        pass and the new snapshot replaces the cache — never from
+        ``_is_energy_valid`` itself, so a snapshot that later fails daily
+        bounds does not consume the widening window (the identical catch-up
+        delta must still be accepted on the next read).  Frozen outage
+        reads (``curr == prev``) never re-arm, so the window keeps growing
+        until real accumulation lands.
+
+        Also seeds the window on the very first committed snapshot: the
+        production fetch paths skip lifetime validation entirely when no
+        previous snapshot exists, so without this seed a restart during an
+        outage would leave the clock None until the second read.
+        """
+        if self._lifetime_energy_change_monotonic is None:
+            self._lifetime_energy_change_monotonic = time.monotonic()
+        if prev_values is None:
+            return
+        for key, curr in curr_values.items():
+            if curr is None:
+                continue
+            prev = prev_values.get(key)
+            if prev is not None and curr > prev:
+                self._lifetime_energy_change_monotonic = time.monotonic()
+                self._energy_source_stale = False
+                return
 
     def _is_daily_energy_valid(
         self,

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -901,6 +901,11 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                 )
                 self._runtime = runtime_data
                 self._runtime_cache_time = datetime.now()
+                if runtime_data.lost:
+                    # The portal says the dongle is offline and is serving a
+                    # frozen register mirror — arm the energy catch-up
+                    # widening for the eventual reconnect delta (#479).
+                    self._note_energy_source_stale()
             except Exception as err:
                 # Keep existing cached data on API/connection errors
                 _LOGGER.debug("Failed to fetch runtime data for %s: %s", self.serial_number, err)
@@ -924,8 +929,13 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                         self.serial_number,
                     )
                     return
-                if self._transport_energy is not None and not self._is_energy_valid(
-                    self._transport_energy.lifetime_energy_values(),
+                prev_lifetime = (
+                    self._transport_energy.lifetime_energy_values()
+                    if self._transport_energy is not None
+                    else None
+                )
+                if prev_lifetime is not None and not self._is_energy_valid(
+                    prev_lifetime,
                     transport_data.lifetime_energy_values(),
                 ):
                     return  # keep cached energy data
@@ -941,6 +951,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                     return  # keep cached energy data
                 self._transport_energy = transport_data
                 self._energy_cache_time = datetime.now()
+                self._note_energy_accepted(prev_lifetime, transport_data.lifetime_energy_values())
             except Exception as err:
                 # Keep existing cached data on transport errors
                 _LOGGER.debug("Failed to fetch energy data for %s: %s", self.serial_number, err)
@@ -969,6 +980,10 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                     return  # keep cached energy data
                 self._energy = energy_data
                 self._energy_cache_time = datetime.now()
+                self._note_energy_accepted(
+                    prev.lifetime_energy_values() if prev is not None else None,
+                    curr.lifetime_energy_values(),
+                )
             except Exception as err:
                 # Keep existing cached data on API/connection errors
                 _LOGGER.debug("Failed to fetch energy data for %s: %s", self.serial_number, err)
@@ -1092,11 +1107,16 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             # (e.g. a manual refresh button overlapping a poll), so the
             # prev-baseline comparison and reject counters cannot interleave.
             async with self._energy_cache_lock:
-                if self._transport_energy is None:
+                prev_lifetime = (
+                    self._transport_energy.lifetime_energy_values()
+                    if self._transport_energy is not None
+                    else None
+                )
+                if prev_lifetime is None:
                     energy_valid = True
                 else:
                     energy_valid = self._is_energy_valid(
-                        self._transport_energy.lifetime_energy_values(),
+                        prev_lifetime,
                         energy.lifetime_energy_values(),
                     )
                 if energy_valid:
@@ -1112,6 +1132,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                 if energy_valid:
                     self._transport_energy = energy
                     self._energy_cache_time = datetime.now()
+                    self._note_energy_accepted(prev_lifetime, energy.lifetime_energy_values())
             if battery is not None:
                 # Accept battery data only if it passes canary checks.
                 # Corrupt battery data is silently skipped, preserving the

--- a/src/pylxpweb/devices/mid_device.py
+++ b/src/pylxpweb/devices/mid_device.py
@@ -258,12 +258,18 @@ class MIDDevice(FirmwareUpdateMixin, MIDRuntimePropertiesMixin, BaseDevice):
                         self.serial_number,
                     )
                     return
+                prev_lifetime = (
+                    self._transport_runtime.lifetime_energy_values()
+                    if self._transport_runtime is not None
+                    else None
+                )
                 if not self._validate_runtime_energy(runtime_data):
                     return  # keep cached runtime
                 now = datetime.now()
                 self._transport_runtime = runtime_data
                 self._runtime_cache_time = now
                 self._last_refresh = now
+                self._note_energy_accepted(prev_lifetime, runtime_data.lifetime_energy_values())
                 _LOGGER.debug(
                     "Refreshed MID device %s via transport",
                     self.serial_number,
@@ -301,16 +307,28 @@ class MIDDevice(FirmwareUpdateMixin, MIDRuntimePropertiesMixin, BaseDevice):
             from pylxpweb.transports.data import MidboxRuntimeData
 
             self._runtime = await self._client.api.devices.get_midbox_runtime(self.serial_number)
+            if self._runtime.lost:
+                # The portal says the dongle is offline and is serving a
+                # frozen register mirror — arm the energy catch-up widening
+                # for the eventual reconnect delta (#479), mirroring the
+                # inverter _fetch_runtime_http path.
+                self._note_energy_source_stale()
             new_runtime = MidboxRuntimeData.from_http_response(self._runtime.midboxData)
             # Extract isOffGrid from deviceData (primary inverter's data)
             if self._runtime.deviceData is not None:
                 new_runtime.off_grid = self._runtime.deviceData.isOffGrid
+            prev_lifetime = (
+                self._transport_runtime.lifetime_energy_values()
+                if self._transport_runtime is not None
+                else None
+            )
             if not self._validate_runtime_energy(new_runtime):
                 return  # keep cached runtime
             now = datetime.now()
             self._transport_runtime = new_runtime
             self._runtime_cache_time = now
             self._last_refresh = now
+            self._note_energy_accepted(prev_lifetime, new_runtime.lifetime_energy_values())
         except Exception as err:
             _LOGGER.warning(
                 "Failed to fetch MID device runtime for %s: %s",

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -1026,6 +1026,11 @@ class MidboxRuntime(BaseModel):
     success: bool
     serialNum: str
     fwCode: str
+    # True when the dongle is offline from the portal and the cloud is
+    # serving its last register mirror frozen — same semantics as
+    # InverterRuntime.lost (present in live captures; previously dropped by
+    # pydantic, which hid the outage signal from consumers — #479).
+    lost: bool | None = None
     midboxData: MidboxData
     deviceData: MidboxDeviceData | None = None
 

--- a/tests/unit/devices/test_issue_479_wiring.py
+++ b/tests/unit/devices/test_issue_479_wiring.py
@@ -1,0 +1,165 @@
+"""Wiring tests for the #479 outage catch-up widening (eg4_web_monitor#479).
+
+TestLifetimeCatchupWidening (test_validation.py) covers the isolated
+BaseDevice logic; these tests pin the integration points — the arming
+triggers and a commit site — so a refactor cannot silently detach them.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from pylxpweb import LuxpowerClient
+from pylxpweb.devices.base import TRANSPORT_LINK_DOWN_THRESHOLD
+from pylxpweb.devices.inverters.base import BaseInverter
+from pylxpweb.devices.mid_device import MIDDevice
+from pylxpweb.devices.models import Entity
+from pylxpweb.models import EnergyInfo, InverterRuntime, MidboxRuntime
+
+
+class ConcreteInverter(BaseInverter):
+    """Concrete implementation for testing."""
+
+    def to_entities(self) -> list[Entity]:
+        return []
+
+
+@pytest.fixture
+def mock_client() -> LuxpowerClient:
+    client = Mock(spec=LuxpowerClient)
+    client.api = Mock()
+    client.api.devices = Mock()
+    client.api.control = Mock()
+    return client
+
+
+def _runtime(*, lost: bool) -> InverterRuntime:
+    return InverterRuntime.model_construct(
+        success=True,
+        serialNum="1234567890",
+        statusText="offline" if lost else "normal",
+        lost=lost,
+        fwCode="TEST-1.0",
+    )
+
+
+def _energy(total_yielding_raw: int) -> EnergyInfo:
+    """EnergyInfo with a controllable pv lifetime counter (raw 0.1 kWh)."""
+    return EnergyInfo(
+        success=True,
+        serialNum="1234567890",
+        soc=75,
+        todayYielding=100,
+        todayCharging=50,
+        todayDischarging=40,
+        todayImport=20,
+        todayExport=10,
+        todayUsage=80,
+        totalYielding=total_yielding_raw,
+        totalCharging=500000,
+        totalDischarging=400000,
+        totalImport=200000,
+        totalExport=100000,
+        totalUsage=800000,
+    )
+
+
+class TestArmingTriggers:
+    """The two outage-evidence triggers must arm _energy_source_stale."""
+
+    @pytest.mark.asyncio
+    async def test_lost_cloud_runtime_arms_stale(self, mock_client) -> None:
+        inverter = ConcreteInverter(mock_client, "1234567890", "TestModel")
+        mock_client.api.devices.get_inverter_runtime = AsyncMock(return_value=_runtime(lost=True))
+        assert inverter._energy_source_stale is False
+        await inverter._fetch_runtime_http()
+        assert inverter._energy_source_stale is True
+
+    @pytest.mark.asyncio
+    async def test_online_cloud_runtime_does_not_arm(self, mock_client) -> None:
+        inverter = ConcreteInverter(mock_client, "1234567890", "TestModel")
+        mock_client.api.devices.get_inverter_runtime = AsyncMock(return_value=_runtime(lost=False))
+        await inverter._fetch_runtime_http()
+        assert inverter._energy_source_stale is False
+
+    def test_link_down_transition_arms_stale(self, mock_client) -> None:
+        inverter = ConcreteInverter(mock_client, "1234567890", "TestModel")
+        for _ in range(TRANSPORT_LINK_DOWN_THRESHOLD):
+            inverter._record_transport_read_failure()
+        assert inverter.transport_link_down is True
+        assert inverter._energy_source_stale is True
+
+    def test_single_transport_failure_does_not_arm(self, mock_client) -> None:
+        """Transient blips deliberately fall back to the 5-strike self-heal."""
+        inverter = ConcreteInverter(mock_client, "1234567890", "TestModel")
+        inverter._record_transport_read_failure()
+        assert inverter._energy_source_stale is False
+
+    @pytest.mark.asyncio
+    async def test_lost_midbox_runtime_arms_stale(self, mock_client) -> None:
+        mid = MIDDevice(mock_client, "0987654321", "GridBOSS")
+        runtime = MidboxRuntime.model_construct(
+            success=True,
+            serialNum="0987654321",
+            fwCode="TEST-1.0",
+            lost=True,
+            midboxData=Mock(),
+        )
+        mock_client.api.devices.get_midbox_runtime = AsyncMock(return_value=runtime)
+        assert mid._energy_source_stale is False
+        # from_http_response on the Mock midboxData raises inside the guarded
+        # try — the arming must already have happened before conversion.
+        await mid._refresh_via_http()
+        assert mid._energy_source_stale is True
+
+
+class TestCommitSiteEndToEnd:
+    """Outage → reconnect through the real _fetch_energy_http path."""
+
+    @pytest.mark.asyncio
+    async def test_catchup_delta_accepted_on_reconnect(self, mock_client) -> None:
+        """The #479 log line, end to end: 4188.0 -> 4215.7 with 15 kWh cap."""
+        inverter = ConcreteInverter(mock_client, "1234567890", "TestModel")
+        inverter._max_energy_delta = 15.0
+
+        baseline = _energy(41880)  # 4188.0 kWh
+        mock_client.api.devices.get_inverter_energy = AsyncMock(return_value=baseline)
+        await inverter._fetch_energy_http()
+        assert inverter._energy is baseline
+
+        # 5h cloud outage: lost runtime arms the evidence; the counters sat
+        # frozen so the change window is 5h old.
+        mock_client.api.devices.get_inverter_runtime = AsyncMock(return_value=_runtime(lost=True))
+        await inverter._fetch_runtime_http()
+        inverter._lifetime_energy_change_monotonic = time.monotonic() - 5 * 3600
+
+        # Reconnect: +27.7 kWh catch-up accepted on the FIRST read.
+        recovery = _energy(42157)  # 4215.7 kWh
+        inverter._energy_cache_time = None  # bypass fetch throttle
+        mock_client.api.devices.get_inverter_energy = AsyncMock(return_value=recovery)
+        await inverter._fetch_energy_http()
+        assert inverter._energy is recovery
+        assert inverter._energy_reject_count == 0
+        # The commit disarmed the evidence and re-armed the window.
+        assert inverter._energy_source_stale is False
+
+    @pytest.mark.asyncio
+    async def test_same_delta_without_evidence_rejected(self, mock_client) -> None:
+        """Control: no outage evidence → the tight cap still rejects 27.7."""
+        inverter = ConcreteInverter(mock_client, "1234567890", "TestModel")
+        inverter._max_energy_delta = 15.0
+
+        baseline = _energy(41880)
+        mock_client.api.devices.get_inverter_energy = AsyncMock(return_value=baseline)
+        await inverter._fetch_energy_http()
+
+        inverter._lifetime_energy_change_monotonic = time.monotonic() - 5 * 3600
+        spike = _energy(42157)
+        inverter._energy_cache_time = None
+        mock_client.api.devices.get_inverter_energy = AsyncMock(return_value=spike)
+        await inverter._fetch_energy_http()
+        assert inverter._energy is baseline  # cached data kept
+        assert inverter._energy_reject_count == 1

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -706,3 +706,134 @@ class TestUpwardSelfHealCeiling:
             results.append(result)
         assert results[:4] == ["reject"] * 4
         assert results[4] == "self_healed"
+
+
+class TestLifetimeCatchupWidening:
+    """Elapsed-time widening of the lifetime spike cap (eg4_web_monitor#479).
+
+    While a device is offline the cloud keeps serving its lifetime counters
+    frozen at the pre-outage value; on reconnect the true value arrives as a
+    single large catch-up delta.  When outage evidence is armed
+    (``_note_energy_source_stale``), the cap widens with the time since a
+    counter last increased on a COMMITTED read so legitimate catch-up is
+    accepted on the first read.  Without armed evidence — a merely-idle
+    device — the tight per-cycle canary is unchanged.
+    """
+
+    def _make(self, *, stale: bool = True, window_hours: float = 5.0) -> _StubDevice:
+        dev = _make_device()
+        # 10 kW inverter → per-cycle cap 15 kWh (rated_kw * 1.5), matching
+        # the exact #479 report ("delta 27.7 > 15 max").
+        dev._max_energy_delta = 15.0
+        dev._lifetime_energy_change_monotonic = time.monotonic() - window_hours * 3600
+        dev._energy_source_stale = stale
+        return dev
+
+    def test_first_call_seeds_change_clock(self) -> None:
+        """The first validated read seeds the window at 'now'."""
+        dev = _make_device()
+        assert dev._lifetime_energy_change_monotonic is None
+        assert dev._is_energy_valid({}, {"pv_energy_total": 4188.0})
+        assert dev._lifetime_energy_change_monotonic is not None
+
+    def test_normal_cadence_keeps_tight_cap(self) -> None:
+        """With a fresh change clock the per-cycle cap still rejects 27.7."""
+        dev = self._make(stale=True, window_hours=0.0)
+        prev = {"pv_energy_total": 4188.0}
+        curr = {"pv_energy_total": 4215.7}  # +27.7 > 15
+        assert not dev._is_energy_valid(prev, curr)
+        assert dev._energy_reject_count == 1
+
+    def test_catchup_delta_accepted_after_outage_gap(self) -> None:
+        """The #479 scenario: 5h lost-flagged outage, +27.7 kWh accepted.
+
+        Widened cap = 15 * 5h = 75 kWh > 27.7 — accepted on the first read
+        instead of stalling on the 5-strike self-heal.
+        """
+        dev = self._make(stale=True, window_hours=5.0)
+        prev = {"pv_energy_total": 4188.0}
+        curr = {"pv_energy_total": 4215.7}
+        assert dev._is_energy_valid(prev, curr)
+        assert dev._energy_reject_count == 0
+
+    def test_idle_window_without_outage_evidence_keeps_tight_cap(self) -> None:
+        """No armed evidence → no widening, even after a 12h idle window.
+
+        A merely-idle device (every counter flat overnight) must keep the
+        always-on corruption canary tight: a moderate corrupt jump
+        (+102.4 kWh, a low-word bit flip) stays rejected.
+        """
+        dev = self._make(stale=False, window_hours=12.0)
+        prev = {"pv_energy_total": 4188.0}
+        curr = {"pv_energy_total": 4188.0 + 102.4}
+        assert not dev._is_energy_valid(prev, curr)
+        assert dev._energy_reject_count == 1
+
+    def test_widened_cap_still_rejects_gross_corruption(self) -> None:
+        """A 0xFFFF-scale jump exceeds even the widened cap."""
+        dev = self._make(stale=True, window_hours=5.0)
+        prev = {"pv_energy_total": 4188.0}
+        curr = {"pv_energy_total": 4188.0 + 6553.5}  # 0xFFFF / 10
+        assert not dev._is_energy_valid(prev, curr)
+
+    def test_widening_bounded_by_max_elapsed_hours(self) -> None:
+        """A week-long gap caps at MAX_ELAPSED_HOURS (24h → 360 kWh)."""
+        dev = self._make(stale=True, window_hours=7 * 24)
+        prev = {"pv_energy_total": 4188.0}
+        bound = 15.0 * MAX_ELAPSED_HOURS
+        assert not dev._is_energy_valid(prev, {"pv_energy_total": 4188.0 + bound + 1.0})
+        assert dev._is_energy_valid(prev, {"pv_energy_total": 4188.0 + bound - 1.0})
+
+    def test_sub_hour_window_keeps_base_cap_floor(self) -> None:
+        """elapsed < 1h never narrows the cap below the per-cycle base."""
+        dev = self._make(stale=True, window_hours=0.25)
+        prev = {"pv_energy_total": 4188.0}
+        curr = {"pv_energy_total": 4188.0 + 14.0}  # under the 15 base cap
+        assert dev._is_energy_valid(prev, curr)
+
+    def test_validation_alone_never_rearms_the_window(self) -> None:
+        """_is_energy_valid must not consume the window on acceptance.
+
+        Re-arming happens only when the snapshot is COMMITTED
+        (_note_energy_accepted) — an accepted lifetime check whose snapshot
+        is later rejected by daily bounds must leave the widening window
+        (and the armed evidence) intact for the next read.
+        """
+        dev = self._make(stale=True, window_hours=5.0)
+        seeded = dev._lifetime_energy_change_monotonic
+        prev = {"pv_energy_total": 4188.0}
+        curr = {"pv_energy_total": 4215.7}
+        assert dev._is_energy_valid(prev, curr)
+        assert dev._lifetime_energy_change_monotonic == seeded
+        assert dev._energy_source_stale is True
+
+    def test_note_energy_accepted_rearms_and_disarms(self) -> None:
+        """A committed increase re-arms the window and clears the evidence."""
+        dev = self._make(stale=True, window_hours=5.0)
+        seeded = dev._lifetime_energy_change_monotonic
+        dev._note_energy_accepted({"pv_energy_total": 4188.0}, {"pv_energy_total": 4215.7})
+        assert dev._lifetime_energy_change_monotonic > seeded
+        assert dev._energy_source_stale is False
+
+    def test_frozen_commit_keeps_window_and_evidence(self) -> None:
+        """curr == prev (outage freeze) must NOT re-arm or disarm."""
+        dev = self._make(stale=True, window_hours=1.0)
+        seeded = dev._lifetime_energy_change_monotonic
+        frozen = {"pv_energy_total": 4188.0}
+        dev._note_energy_accepted(dict(frozen), dict(frozen))
+        assert dev._lifetime_energy_change_monotonic == seeded
+        assert dev._energy_source_stale is True
+
+    def test_first_commit_with_no_prev_is_a_noop(self) -> None:
+        """prev None (first read) cannot re-arm — nothing to compare."""
+        dev = self._make(stale=True, window_hours=1.0)
+        seeded = dev._lifetime_energy_change_monotonic
+        dev._note_energy_accepted(None, {"pv_energy_total": 4188.0})
+        assert dev._lifetime_energy_change_monotonic == seeded
+        assert dev._energy_source_stale is True
+
+    def test_note_energy_source_stale_arms(self) -> None:
+        dev = _make_device()
+        assert dev._energy_source_stale is False
+        dev._note_energy_source_stale()
+        assert dev._energy_source_stale is True


### PR DESCRIPTION
Companion to joyfulhouse/eg4_web_monitor#481 (issue eg4_web_monitor#479, reported by @ivanfmartinez).

## Bug and root cause

While a device is offline the portal serves its lifetime energy counters frozen at the pre-outage value; on reconnect the true value arrives as one large but legitimate catch-up delta. In the #479 report: `pv_energy_total jumped 4188.0 -> 4215.7 (delta 27.7 > 15 max)` — over the `rated_kw * 1.5` per-cycle cap — rejected 5 consecutive times before the upward self-heal accepted it (~10 min of stale energy data after every outage). `validate_energy_monotonicity` had no time-awareness and no outage-awareness (unlike the daily-bounds check, which is elapsed-time-scaled).

## What the fix does

- `_lifetime_energy_change_monotonic` tracks when a lifetime counter last **increased on a committed read** (mirrors the existing `_daily_energy_change_monotonic` pattern; None-sentinel monotonic seeding per the fresh-boot throttle convention).
- When **outage evidence is armed**, `_is_energy_valid` widens the cap to `max(base, base * elapsed_hours)` — per-hour allowance = `rated_kw * 1.5`, preserving the documented 50% margin — bounded by `MAX_ELAPSED_HOURS` (24 h). The #479 delta is accepted on the first reconnect read.
- **Evidence gate** `_energy_source_stale`: armed by a cloud runtime payload flagged `lost` (inverter `getInverterRuntime` AND GridBOSS `getMidboxRuntime` — the top-level `lost` field is now modeled on `MidboxRuntime` instead of being silently dropped by pydantic) or a transport link-down transition. Deliberately NOT armed by transient fetch exceptions. Without armed evidence the cap never widens — a merely-idle device keeps the tight always-on corruption canary, and 0xFFFF-scale jumps exceed even the widened cap.
- The window **re-arms only at snapshot commit** (`_note_energy_accepted`, wired at all 5 commit sites: inverter `_fetch_energy`, `_fetch_energy_http`, the combined-read block, MID transport refresh, MID `_refresh_via_http`) — so a snapshot later rejected by daily bounds cannot consume it, and the first committed snapshot seeds the clock (restart-mid-outage starts its window immediately). Frozen reads (`curr == prev`) never re-arm; rejected reads never re-arm; the gate disarms only when a committed increase lands.

## Test plan

- `TestLifetimeCatchupWidening` (12 tests): #479 scenario accepted, unarmed idle window keeps the tight cap (moderate +102.4 kWh corruption still rejected), gross-corruption rejection, 24 h bound, commit-order semantics, seed/re-arm/disarm invariants.
- `tests/unit/devices/test_issue_479_wiring.py` (7 tests): both arming triggers (inverter lost payload, MID lost payload, link-down transition; single transient failure does NOT arm) and the reconnect path end-to-end through the real `_fetch_energy_http` (the exact #479 log line, plus the no-evidence control).
- Full suite: **2834 passed**; ruff + mypy strict clean.

## Review

Tri-vendor adversarial gate, 3 rounds (Claude + Codex gpt-5.6-sol xhigh + Gemini 3.1 Pro). Round 1 (Codex) reshaped the design: evidence gating (idle windows must not widen), commit-time re-arm, margin-preserving math. Round 2 (Claude/Codex) added the MID `lost` modeling and first-commit seeding. Round 3: Codex + Gemini both **NO BLOCKING ISSUES**.

Risk-accepted (documented):
- State is in-memory: a restart landing shortly before reconnect falls back to the pre-existing 5-strike self-heal (persistence would need wall-clock plumbing through the consumer).
- Link-down cache clearing (#226 design) means recovery's first commit has `prev=None` and cannot disarm the gate until the next committed increase — transient over-widening only, and the monotonicity bypass on a cleared cache is pre-existing.
- MID validate+commit has no dedicated energy lock — but runs with no intervening await (event-loop atomic); whole-request reordering under concurrent `refresh()` calls is pre-existing behavior.
- A 3-strike downward self-heal does not re-arm the window — intentional: the subsequent recovery jump back to the true baseline needs the widened cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)