### PR TITLE
docs: stop calling register-110 bit 7 toggle-tested (#476 follow-up)

### DIFF
--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -582,13 +582,17 @@ WEB_PARAM_TO_HOLD_REGISTER = {
 # Register 110 system-function bit layout — SHARED by every inverter family
 # (eg4_web_monitor #476). Both families ever hardware-toggle-tested (18kPV
 # 2026-07-21, 12000XP/SNA PR #220) match the ant0nkr/lxp_modbus
-# H_FUNCTION_ENABLE_3 lineage layout in every *toggle-tested* position
-# (bits 7, 14, 15), while the historic 18kPV-specific upper-bit table
-# matched none of them — so the hybrid and EG4_OFFGRID tables no longer
-# diverge. That agreement does NOT extend to every bit: at bit 5 the EG4
-# cloud decode and lxp_modbus genuinely disagree (see below), and no
-# toggle test has separated them. Displaced/unproven slots
-# are FUNC_110_BITn placeholders (same convention as reg 179/233 unknowns):
+# H_FUNCTION_ENABLE_3 lineage layout in every position this project has
+# hardware evidence for (bits 7, 14, 15), while the historic 18kPV-specific
+# upper-bit table matched none of them — so the hybrid and EG4_OFFGRID
+# tables no longer diverge. Be precise about what that evidence is, since
+# mistaking "the names lined up" for "we toggled it" is what produced #476
+# in the first place: bits 14 and 15 are toggle-proven (18kPV green,
+# 12000XP ECO), while bit 7 rests on the SNA cloud decode plus a constant
+# raw 0x0080 — strong, but not a toggle. That agreement does NOT extend to
+# every bit: at bit 5 the EG4 cloud decode and lxp_modbus genuinely
+# disagree (see below), and no toggle test has separated them.
+# Displaced/unproven slots are FUNC_110_BITn placeholders (same convention as reg 179/233 unknowns):
 # an honest gap beats an unverified decode served as truth — a local write
 # through a wrong slot flips an unrelated config bit while reporting
 # success (#476: every HYBRID/LOCAL "Off-Grid Mode" toggle wrote the


### PR DESCRIPTION
Comment-only. No behaviour change, no API change.

## What

The register-110 summary comment added in #240 claimed the lxp_modbus lineage layout agrees "in every *toggle-tested* position (bits 7, 14, 15)". Bits 14 and 15 are genuinely toggle-proven (18kPV green, 12000XP ECO). **Bit 7 is not** — the per-bit evidence three lines below says so itself: "SNA cloud decode + constant raw `0x0080`". Constant, i.e. observed steady, never toggled.

## Why it is worth a PR

This is the exact conflation that produced #476. The old table's `# verified` annotations meant "the names matched the cloud decode", not "we toggled it and watched the bit move" — and acting on that as if it were proof is why every Local/Hybrid green-mode toggle wrote the wrong bit for as long as it did. Repeating the conflation in the comment that documents the fix is the one place it really must not happen, so the comment now names what kind of evidence each bit has rather than flattening it all to "tested".

Found by an adversarial review pass (Codex GPT-5.6-sol @ ultra) run over the #240 fix round specifically, since those fixes were written in response to review and merged without an independent look of their own.

## Validation

`ruff` clean, `mypy --strict` clean, full suite **2837 passed**.

## Not addressed here

Two other items from the same pass, both deliberately left for a maintainer call rather than folded in:

- **`FUNC_TAKE_LOAD_TOGETHER` is still writable at bit 5** while the comment admits bits 5/10 are unresolved — it keeps a real name, so it bypasses the new placeholder write-guard. Nothing in this library or the EG4 integration writes it, so there is no live bug, but the principle is inconsistent. Demoting it would drop a published canonical name on a bit where EG4's *own* cloud decode says `TAKE_LOAD_TOGETHER`, which is real evidence — so this is a judgement call, tracked on #242.
- **Defensive copying protects only `EG4_OFFGRID`** — the default/hybrid and MIDBOX branches of `get_register_to_param_mapping()` hand back the module-level dict and its inner lists directly. No in-tree caller mutates them (they merge into fresh dicts), so it is latent, but the guarantee is uneven. Blanket deep-copying every branch would add allocation to a path hit on every named read/write, so it wants a deliberate decision rather than a reflex fix. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)