### PR TITLE
fix: isolate every register-mapping branch; block writes to disputed bits (#245, #242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cloud-only" restriction is lifted: with the bit pinned, local reads and
   writes work on every family. `OFFGRID_REGISTER_110_PARAM_KEYS` remains as
   a back-compat alias of the unified list.
+- **Every register-mapping branch now returns an isolated copy**
+  ([#245](https://github.com/joyfulhouse/pylxpweb/issues/245)):
+  `get_register_to_param_mapping()` handed back the live module-level dict
+  *and its per-register lists* on every branch except `EG4_OFFGRID`
+  (default, and `device_type="MIDBOX"`). Bit positions are list indices, so
+  a caller mutating a returned list reordered bits process-wide for every
+  subsequent named read and write. Measured at ~4.5 us per copy over 86
+  registers — noise beside the Modbus round-trip it precedes — so the
+  published `dict[int, list[str]]` return type is unchanged.
+- **Writes to disputed bit positions are refused**
+  ([#242](https://github.com/joyfulhouse/pylxpweb/issues/242)):
+  `write_named_parameters` raises `ValueError` for
+  `FUNC_TAKE_LOAD_TOGETHER`, whose register-110 bit is claimed at 5 by
+  EG4's own decode and at 10 by ant0nkr/lxp_modbus, with the one live read
+  that could separate them showing both bits set. Reads are unaffected and
+  keep EG4's name. **This is local-transport only** — the cloud
+  functionControl endpoint writes by name and EG4 resolves the bit itself,
+  so that path is unaffected and still works. Nothing in this library or
+  the EG4 integration writes the key, so no caller changes behaviour.
 - **`FUNC_<register>_BIT<n>` placeholders are now decode-only**:
   `write_named_parameters` raises `ValueError` for them instead of
   read-modify-writing the bit. The placeholders exist so reads decode a

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -976,9 +976,16 @@ OFFGRID_REGISTER_110_PARAM_KEYS: list[str] = REGISTER_110_PARAM_KEYS
 # credible sources, as opposed to simply unknown. Unknown bits are
 # FUNC_<reg>_BIT<n> placeholders and are refused by name pattern; these keep
 # a real name because a first-party source does identify them, so they decode
-# normally — but they must not be WRITTEN, for exactly the reason the
-# placeholders must not be: if the position is wrong the firmware still ACKs
-# and some other setting silently moves (eg4_web_monitor #476).
+# normally — but they must not be WRITTEN over a LOCAL transport, for exactly
+# the reason the placeholders must not be: if the position is wrong the
+# firmware still ACKs and some other setting silently moves (#476).
+#
+# Deliberately LOCAL-ONLY. The cloud functionControl endpoint writes by NAME
+# and EG4's own server resolves it to whichever bit EG4 uses, so the cloud
+# path carries none of this risk — it is the local path, where WE compute the
+# bit position, that can land on the wrong one. Do not "fix" the asymmetry by
+# extending this to ControlEndpoints.control_function(): that would remove a
+# working capability to guard against a hazard the cloud path does not have.
 #
 #   FUNC_TAKE_LOAD_TOGETHER — EG4's own cloud decode puts it at register 110
 #   bit 5; ant0nkr/lxp_modbus puts a CT-sample-ratio field at bits 5-6 and

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -972,6 +972,34 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
 OFFGRID_REGISTER_110_PARAM_KEYS: list[str] = REGISTER_110_PARAM_KEYS
 
 
+# Named parameters whose bit position is genuinely DISPUTED between two
+# credible sources, as opposed to simply unknown. Unknown bits are
+# FUNC_<reg>_BIT<n> placeholders and are refused by name pattern; these keep
+# a real name because a first-party source does identify them, so they decode
+# normally — but they must not be WRITTEN, for exactly the reason the
+# placeholders must not be: if the position is wrong the firmware still ACKs
+# and some other setting silently moves (eg4_web_monitor #476).
+#
+#   FUNC_TAKE_LOAD_TOGETHER — EG4's own cloud decode puts it at register 110
+#   bit 5; ant0nkr/lxp_modbus puts a CT-sample-ratio field at bits 5-6 and
+#   TakeLoadTogether at bit 10. The live 18kPV read that would settle it had
+#   bits 5 AND 10 both set (raw 0x0420), so it separates nothing. Reads keep
+#   EG4's name because EG4's decode is first-party evidence; writes wait for
+#   a toggle capture. See pylxpweb #242.
+DISPUTED_WRITE_BLOCKED_PARAMS: frozenset[str] = frozenset({"FUNC_TAKE_LOAD_TOGETHER"})
+
+
+def _copy_register_mapping(mapping: dict[int, list[str]]) -> dict[int, list[str]]:
+    """Copy a register→param-key mapping, including its per-register lists.
+
+    A plain ``dict()`` copy shares the inner lists, which is worse than no
+    copy at all: it looks defensive while leaving the part that actually
+    matters — bit ordering, since a bit position IS a list index — open to
+    mutation by any caller.
+    """
+    return {register: list(keys) for register, keys in mapping.items()}
+
+
 def _offgrid_register_to_param_keys() -> dict[int, list[str]]:
     """Return the EG4_OFFGRID register→param mapping.
 
@@ -981,7 +1009,7 @@ def _offgrid_register_to_param_keys() -> dict[int, list[str]]:
     like the pre-unification override did, so callers cannot mutate the
     shared module-level table — including its per-register key lists.
     """
-    return {register: list(keys) for register, keys in REGISTER_TO_PARAM_KEYS.items()}
+    return _copy_register_mapping(REGISTER_TO_PARAM_KEYS)
 
 
 # ============================================================================
@@ -1856,13 +1884,20 @@ def get_register_to_param_mapping(
     """
     # The HTTP transport handles family-specific differences on the server
     # side; this mapping only drives LOCAL (Modbus/dongle) named access.
+    #
+    # Every branch returns a copy, including the per-register key lists.
+    # Bit positions are list indices, so a caller that mutates a returned
+    # list would silently reorder bits for every subsequent read and write
+    # in the process — the #476 failure mode reached through a different
+    # door. Measured at ~4.5 us per call against a table of 86 registers,
+    # which is noise beside the Modbus round-trip it precedes.
     if device_type == "MIDBOX":
-        return MIDBOX_REGISTER_TO_PARAM_KEYS
+        return _copy_register_mapping(MIDBOX_REGISTER_TO_PARAM_KEYS)
 
     if family == "EG4_OFFGRID":
         return _offgrid_register_to_param_keys()
 
-    return REGISTER_TO_PARAM_KEYS
+    return _copy_register_mapping(REGISTER_TO_PARAM_KEYS)
 
 
 def get_param_to_register_mapping(

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -968,7 +968,15 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         address=110,
         bit_position=5,
         canonical_name="take_load_together",
-        api_param_key="FUNC_TAKE_LOAD_TOGETHER",  # verified
+        # DISPUTED POSITION, not verified: EG4's cloud decode puts this at
+        # bit 5, ant0nkr/lxp_modbus puts a CT-ratio field at 5-6 and
+        # TakeLoadTogether at bit 10, and the one live read that could
+        # separate them had both bits set (raw 0x0420). The name is EG4's,
+        # so reads keep it; LOCAL writes are refused via
+        # DISPUTED_WRITE_BLOCKED_PARAMS until a toggle capture settles it.
+        # The old "# verified" here meant the NAME matched the cloud, never
+        # that the bit was toggle-tested — the exact conflation behind #476.
+        api_param_key="FUNC_TAKE_LOAD_TOGETHER",
         category=HoldingCategory.FUNCTION,
         description="Take load together mode (parallel load sharing).",
     ),

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -539,7 +539,11 @@ class BaseTransport:
                 "BIT_MIDBOX_SP_MODE_1": 2,  # AC Couple
             })
         """
-        from pylxpweb.constants.registers import LOCAL_PARAM_SCALE_DIV10, MULTI_BIT_FIELDS
+        from pylxpweb.constants.registers import (
+            DISPUTED_WRITE_BLOCKED_PARAMS,
+            LOCAL_PARAM_SCALE_DIV10,
+            MULTI_BIT_FIELDS,
+        )
 
         register_to_params, param_to_register = self._resolve_register_mappings(
             param_names=list(parameters.keys()),
@@ -557,6 +561,14 @@ class BaseTransport:
                     f"Refusing to write placeholder parameter '{param_name}': this bit's "
                     "function is not hardware-verified, and writing it would alter an "
                     "unknown device setting. Placeholders are decode-only."
+                )
+
+            if param_name in DISPUTED_WRITE_BLOCKED_PARAMS:
+                raise ValueError(
+                    f"Refusing to write '{param_name}': two credible sources disagree "
+                    "about which bit it occupies, and no toggle test has separated "
+                    "them. A write to the wrong bit is ACKed by the firmware and "
+                    "silently changes a different setting. Reads are unaffected."
                 )
 
             register_addr = param_to_register[param_name]

--- a/tests/unit/transports/test_named_parameters.py
+++ b/tests/unit/transports/test_named_parameters.py
@@ -875,6 +875,51 @@ class TestRegister110UnifiedLayout:
         offgrid[110][0] = "CLOBBERED"
         assert REGISTER_TO_PARAM_KEYS[110] == original
 
+    @pytest.mark.parametrize(
+        ("family", "device_type"),
+        [
+            ("EG4_OFFGRID", None),
+            ("EG4_HYBRID", None),
+            ("LXP", None),
+            ("UNKNOWN", None),
+            (None, None),
+            (None, "MIDBOX"),
+        ],
+        ids=["offgrid", "hybrid", "lxp", "unknown", "no-family", "midbox"],
+    )
+    def test_every_mapping_branch_returns_an_isolated_copy(
+        self, family: str | None, device_type: str | None
+    ) -> None:
+        """No branch hands back the live module table (pylxpweb #245).
+
+        Only EG4_OFFGRID used to copy; every other branch returned the
+        shared dict AND its inner lists. Bit positions are list indices, so
+        one caller mutating a returned list reorders bits process-wide for
+        every subsequent read and write — #476's failure mode via another
+        door.
+        """
+        from pylxpweb.constants.registers import (
+            MIDBOX_REGISTER_TO_PARAM_KEYS,
+            REGISTER_TO_PARAM_KEYS,
+            get_register_to_param_mapping,
+        )
+
+        source = (
+            MIDBOX_REGISTER_TO_PARAM_KEYS if device_type == "MIDBOX" else REGISTER_TO_PARAM_KEYS
+        )
+        before = {register: list(keys) for register, keys in source.items()}
+
+        mapping = get_register_to_param_mapping(family, device_type=device_type)
+        assert mapping is not source, "returned the live module dict"
+
+        a_register = next(iter(mapping))
+        mapping[a_register].append("FAKE_BIT")
+        mapping[a_register].insert(0, "CLOBBERED")
+        mapping[123456] = ["FAKE_REGISTER"]
+
+        assert source == before, "caller mutation reached the module table"
+        assert 123456 not in source
+
     def test_param_to_register_resolves_green_eco_buzzer(self) -> None:
         """Reverse mapping resolves the pinned bits to register 110."""
         from pylxpweb.constants.registers import get_param_to_register_mapping
@@ -986,6 +1031,28 @@ class TestRegister110UnifiedLayout:
         offgrid_transport.write_parameters.assert_called_once_with({110: 0x4080})
         written = offgrid_transport.write_parameters.call_args[0][0][110]
         assert not written & (1 << 8), "bit 8 (old green slot) must stay untouched"
+
+    @pytest.mark.asyncio
+    async def test_disputed_bit_decodes_but_is_not_writable(
+        self, offgrid_transport: ModbusTransport
+    ) -> None:
+        """A disputed bit still reads, but refuses to be written (#242).
+
+        FUNC_TAKE_LOAD_TOGETHER keeps EG4's own name because EG4's cloud
+        decode is first-party evidence for bit 5. lxp_modbus puts it at
+        bit 10 instead, and the one live read that could separate them had
+        both bits set. Writing the wrong one is ACKed and moves some other
+        setting, so writes wait for a toggle capture while reads carry on.
+        """
+        offgrid_transport.read_parameters = AsyncMock(return_value={110: 0x0020})
+
+        decoded = await offgrid_transport.read_named_parameters(110, 1)
+        assert decoded["FUNC_TAKE_LOAD_TOGETHER"] is True
+
+        with pytest.raises(ValueError, match="disagree"):
+            await offgrid_transport.write_named_parameters({"FUNC_TAKE_LOAD_TOGETHER": False})
+
+        offgrid_transport.write_parameters.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_placeholder_bits_are_not_writable(

--- a/tests/unit/transports/test_named_parameters.py
+++ b/tests/unit/transports/test_named_parameters.py
@@ -897,6 +897,13 @@ class TestRegister110UnifiedLayout:
         one caller mutating a returned list reorders bits process-wide for
         every subsequent read and write — #476's failure mode via another
         door.
+
+        There are only three real branches (MIDBOX, EG4_OFFGRID, default),
+        so the four default-family cases are deliberately redundant: they
+        pin that no family string quietly acquires an override that skips
+        the copy. Against the pre-fix code all six fail, but not all six
+        for their own sake — the leaked table lets one case's mutation
+        corrupt the next, which is the process-wide damage this guards.
         """
         from pylxpweb.constants.registers import (
             MIDBOX_REGISTER_TO_PARAM_KEYS,


### PR DESCRIPTION
Closes #245. Addresses #242 (the writability half; the bit-5 position question stays open pending a toggle capture).

## #245 — every mapping branch now returns an isolated copy

`get_register_to_param_mapping()` returned the live module-level dict **and its inner lists** on every branch except `EG4_OFFGRID`. Bit positions are list indices, so a caller mutating a returned list reorders bits process-wide for every subsequent named read and write — #476's failure mode reached through a different door.

**The perf objection that deferred this turned out to be unfounded.** I measured it rather than guessing: a full copy of the 86-register table is **~4.5 µs**, against a Modbus round-trip measured in milliseconds. So every branch now copies, which keeps the published `dict[int, list[str]]` return type intact — no immutable-view API change, nothing for downstream consumers to adapt to.

The new test parametrises all six branch/family combinations and **fails on all six against the old code**. Worth noting *why* all six fail rather than just the two buggy branches: with the bug present, the first case's mutation corrupts the shared table for every later case. That cross-test contamination is precisely the process-wide damage the issue describes, reproduced in miniature.

## #242 — disputed bits decode but refuse writes

`FUNC_TAKE_LOAD_TOGETHER` kept a real parameter name, so it sailed straight past the placeholder write-guard while being documented as disputed:

- EG4's own cloud decode puts it at register 110 **bit 5**
- ant0nkr/lxp_modbus puts a CT-sample-ratio field at bits 5-6 and TakeLoadTogether at **bit 10**
- The one live 18kPV read that could separate them had **bits 5 and 10 both set** (raw `0x0420`), so it settles nothing

Writing the wrong bit is ACKed by the firmware and silently moves a different setting — the exact failure this project spent #476 eliminating.

This implements **option 3** from the issue discussion: reads keep EG4's name, because EG4's decode is first-party evidence and demoting it would arguably be *less* accurate than lxp_modbus's third-party claim; writes raise until a toggle capture settles the position. Neither discards EG4's decode nor leaves a disputed bit writable.

No caller in this library or the EG4 integration writes that key, so nothing breaks today — this closes the hole before something does.

## Validation

`ruff` clean, `mypy --strict` clean, full suite **2844 passed**. Both new tests verified by mutation: reverting each fix turns the corresponding test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)