### PR TITLE
docs: correct get_event_list response shape and pin it against drift (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3339 validation rejects the real values), and `eventType` is no longer
   modelled as a closed enum — the row schema documents the observed values
   and passes unknown ones through, matching what the description already
-  promised. Rows are `additionalProperties: true`; the shape is open.
+  promised. `status` (OPEN/CLOSE) loses its enum for the same reason — its
+  unknown values are relayed verbatim too. Rows are
+  `additionalProperties: true`; the shape is open. A unit test pins the
+  docstring's field list to the YAML schema's, so the two hand-maintained
+  copies cannot drift apart again — that drift is what produced this bug.
   Doc-only — the method returns the raw dict, so no behavior change.
+
+  The EG4 integration's `docs/api/openapi.yaml` carried the same contradictory
+  `eventType` enum and is being corrected to match; these two copies of the
+  schema are meant to agree, and the intended direction of convergence is
+  "observed values, not a closed enum".
 - **Green/off-grid mode moved to its real register bit — register 110 bit
   layout unified lineage-wide**
   ([eg4_web_monitor#476](https://github.com/joyfulhouse/eg4_web_monitor/issues/476),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (not `statusText` = `ACTIVE`/`RESOLVED`), `renormalTime` (not `endTime`,
   null while ongoing), plus previously undocumented `datalogSn` and
   `faultDuration`; `eventType` can also be `MIDBOX_WARNING` on
-  GridBOSS/MID serials. Doc-only — the method returns the raw dict, so no
-  behavior change.
+  GridBOSS/MID serials. Rows also carry `plantName`, `eventTypeText`, and
+  the slash-formatted `startSlashTime`/`renormalSlashTime` twins, all now
+  documented. Timestamps are naive portal-local `YYYY-MM-DD HH:MM:SS` with
+  no UTC offset, so the schema deliberately drops `format: date-time` (RFC
+  3339 validation rejects the real values), and `eventType` is no longer
+  modelled as a closed enum — the row schema documents the observed values
+  and passes unknown ones through, matching what the description already
+  promised. Rows are `additionalProperties: true`; the shape is open.
+  Doc-only — the method returns the raw dict, so no behavior change.
 - **Green/off-grid mode moved to its real register bit — register 110 bit
   layout unified lineage-wide**
   ([eg4_web_monitor#476](https://github.com/joyfulhouse/eg4_web_monitor/issues/476),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`get_event_list` docs corrected to the live response shape**
+  ([#236](https://github.com/joyfulhouse/pylxpweb/issues/236)): the
+  docstring (and the matching `EventListResponse` row schema in
+  `docs/luxpower-api.yaml`) described fields the
+  `/WManage/api/analyze/event/list` endpoint never returns. Live validation
+  (2026-07-16, inverter and GridBOSS serials) shows rows carry `recordId`
+  (not `eventId`), `event` (not `eventCode`), `status` = `OPEN`/`CLOSE`
+  (not `statusText` = `ACTIVE`/`RESOLVED`), `renormalTime` (not `endTime`,
+  null while ongoing), plus previously undocumented `datalogSn` and
+  `faultDuration`; `eventType` can also be `MIDBOX_WARNING` on
+  GridBOSS/MID serials. Doc-only — the method returns the raw dict, so no
+  behavior change.
 - **Green/off-grid mode moved to its real register bit — register 110 bit
   layout unified lineage-wide**
   ([eg4_web_monitor#476](https://github.com/joyfulhouse/eg4_web_monitor/issues/476),

--- a/docs/luxpower-api.yaml
+++ b/docs/luxpower-api.yaml
@@ -3459,8 +3459,10 @@ components:
                 example: "1234567890"
               datalogSn:
                 type: string
-                description: Dongle serial number
-                example: "1234567890"
+                description: >-
+                  Dongle serial number. A different serial space from
+                  serialNum — observed values are alphanumeric.
+                example: "BC33600194"
               plantName:
                 type: string
                 description: Station name
@@ -3518,8 +3520,12 @@ components:
                 example: "2025/11/19 10:45:00"
               status:
                 type: string
-                description: Event state (OPEN=active, CLOSE=resolved)
-                enum: [OPEN, CLOSE]
+                description: >-
+                  Event state; observed values OPEN (active) and CLOSE
+                  (resolved). Not modelled as an enum, for the same reason as
+                  eventType: consumers pass unrecognized values through rather
+                  than rejecting them, so a closed enum would contradict the
+                  documented behaviour.
                 example: "CLOSE"
 
     BatteryInfoForSet:

--- a/docs/luxpower-api.yaml
+++ b/docs/luxpower-api.yaml
@@ -3447,39 +3447,54 @@ components:
           type: array
           items:
             type: object
+            description: One event-log record (live-validated 2026-07-16)
             properties:
-              eventId:
+              recordId:
                 type: integer
+                description: Event record identifier
                 example: 12345
               serialNum:
                 type: string
                 example: "1234567890"
-              eventCode:
+              datalogSn:
                 type: string
-                description: Fault/warning code
-                example: "F01"
+                description: Dongle serial number
+                example: "1234567890"
+              event:
+                type: string
+                description: Event code (E###=fault, W###=warning)
+                example: "E019"
               eventType:
                 type: string
-                enum: [FAULT, WARNING, INFO]
+                description: >-
+                  Category. GridBOSS/MID devices also report MIDBOX_WARNING;
+                  treat unknown values as passthrough.
+                enum: [FAULT, WARNING, INFO, MIDBOX_WARNING]
                 example: "FAULT"
               eventText:
                 type: string
                 description: Human-readable event description
                 example: "Grid voltage high"
+              faultDuration:
+                type: string
+                description: Duration in hours (string)
+                example: "0.25"
               startTime:
                 type: string
                 format: date-time
                 description: Event start timestamp
                 example: "2025-11-19 10:30:00"
-              endTime:
+              renormalTime:
                 type: string
                 format: date-time
-                description: Event end timestamp (empty if ongoing)
+                nullable: true
+                description: Return-to-normal timestamp (null while ongoing)
                 example: "2025-11-19 10:45:00"
-              statusText:
+              status:
                 type: string
-                enum: [ACTIVE, RESOLVED]
-                example: "RESOLVED"
+                description: Event state (OPEN=active, CLOSE=resolved)
+                enum: [OPEN, CLOSE]
+                example: "CLOSE"
 
     BatteryInfoForSet:
       type: object

--- a/docs/luxpower-api.yaml
+++ b/docs/luxpower-api.yaml
@@ -3448,6 +3448,7 @@ components:
           items:
             type: object
             description: One event-log record (live-validated 2026-07-16)
+            additionalProperties: true
             properties:
               recordId:
                 type: integer
@@ -3460,6 +3461,10 @@ components:
                 type: string
                 description: Dongle serial number
                 example: "1234567890"
+              plantName:
+                type: string
+                description: Station name
+                example: "Test Plant"
               event:
                 type: string
                 description: Event code (E###=fault, W###=warning)
@@ -3467,10 +3472,15 @@ components:
               eventType:
                 type: string
                 description: >-
-                  Category. GridBOSS/MID devices also report MIDBOX_WARNING;
-                  treat unknown values as passthrough.
-                enum: [FAULT, WARNING, INFO, MIDBOX_WARNING]
+                  Category. Observed values are FAULT, WARNING, INFO and
+                  MIDBOX_WARNING (the last from GridBOSS/MID devices). Not
+                  modelled as an enum: the set is not known to be closed, and
+                  unknown values are passed through rather than rejected.
                 example: "FAULT"
+              eventTypeText:
+                type: string
+                description: Localized category label
+                example: "Fault"
               eventText:
                 type: string
                 description: Human-readable event description
@@ -3481,15 +3491,27 @@ components:
                 example: "0.25"
               startTime:
                 type: string
-                format: date-time
-                description: Event start timestamp
+                description: >-
+                  Event start, portal-local "YYYY-MM-DD HH:MM:SS". Naive — no
+                  timezone or UTC offset, so deliberately not format:date-time
+                  (RFC 3339 validation rejects these values).
                 example: "2025-11-19 10:30:00"
+              startSlashTime:
+                type: string
+                description: Event start in "YYYY/MM/DD HH:MM:SS" form
+                example: "2025/11/19 10:30:00"
               renormalTime:
                 type: string
-                format: date-time
                 nullable: true
-                description: Return-to-normal timestamp (null while ongoing)
+                description: >-
+                  Return-to-normal in the same naive portal-local dash format
+                  (null while ongoing)
                 example: "2025-11-19 10:45:00"
+              renormalSlashTime:
+                type: string
+                nullable: true
+                description: Return-to-normal in slash form (null while ongoing)
+                example: "2025/11/19 10:45:00"
               status:
                 type: string
                 description: Event state (OPEN=active, CLOSE=resolved)

--- a/docs/luxpower-api.yaml
+++ b/docs/luxpower-api.yaml
@@ -3510,7 +3510,11 @@ components:
               renormalSlashTime:
                 type: string
                 nullable: true
-                description: Return-to-normal in slash form (null while ongoing)
+                description: >-
+                  Return-to-normal in slash form. nullable matches the
+                  canonical schema; the observed ongoing-event row omits the
+                  key rather than sending null, so its ongoing value is
+                  unattested.
                 example: "2025/11/19 10:45:00"
               status:
                 type: string

--- a/src/pylxpweb/endpoints/analytics.py
+++ b/src/pylxpweb/endpoints/analytics.py
@@ -408,23 +408,28 @@ class AnalyticsEndpoints(BaseEndpoint):
             event_filter: Event type filter ("_all", or specific fault/warning code)
 
         Returns:
-            Dict containing:
+            Dict containing (live-validated response shape, 2026-07-16):
                 - success: Boolean
                 - total: Total number of events
                 - rows: List of event objects with:
-                    - eventId: Event identifier
-                    - eventCode: Fault/warning code
-                    - eventType: FAULT/WARNING/INFO
+                    - recordId: Event record identifier
+                    - serialNum: Device serial number
+                    - datalogSn: Dongle serial number
+                    - event: Event code (E###=fault, W###=warning)
+                    - eventType: FAULT/WARNING/INFO (GridBOSS/MID devices
+                      also report MIDBOX_WARNING)
                     - eventText: Human-readable description
                     - startTime: Event start timestamp
-                    - endTime: Event end timestamp (empty if ongoing)
-                    - statusText: ACTIVE/RESOLVED
+                    - renormalTime: Return-to-normal timestamp (null while
+                      ongoing)
+                    - faultDuration: Duration in hours (string)
+                    - status: OPEN (active) / CLOSE (resolved)
 
         Example:
             # Get all events
             events = await client.analytics.get_event_list("1234567890")
             for event in events["rows"]:
-                if event["statusText"] == "ACTIVE":
+                if event["status"] == "OPEN":
                     print(f"Active {event['eventType']}: {event['eventText']}")
 
             # Get only faults

--- a/src/pylxpweb/endpoints/analytics.py
+++ b/src/pylxpweb/endpoints/analytics.py
@@ -433,9 +433,9 @@ class AnalyticsEndpoints(BaseEndpoint):
                     - faultDuration: Duration in hours (string)
                     - status: OPEN (active) / CLOSE (resolved)
 
-                Rows carry additional undocumented keys; treat the shape as
-                open.  ``docs/luxpower-api.yaml`` (EventListResponse) is the
-                fuller contract.
+                Rows may carry keys beyond these; treat the shape as open.
+                ``docs/luxpower-api.yaml`` (EventListResponse) is the typed
+                contract for the same fields.
 
         Example:
             # Get all events
@@ -444,10 +444,15 @@ class AnalyticsEndpoints(BaseEndpoint):
                 if event["status"] == "OPEN":
                     print(f"Active {event['eventType']}: {event['eventText']}")
 
-            # Get only faults
-            faults = await client.analytics.get_event_list(
+            # Filter server-side by a specific event code, not by category:
+            # event_filter is sent as the request's eventText field, so it
+            # takes "_all" or a code like "E019" — NOT an eventType value
+            # such as "FAULT".  No caller in this project uses anything but
+            # the "_all" default, so the code form is unverified; filtering
+            # the returned rows on eventType is the attested approach.
+            bus_faults = await client.analytics.get_event_list(
                 "1234567890",
-                event_filter="FAULT"
+                event_filter="E019",
             )
         """
         await self.client._ensure_authenticated()

--- a/src/pylxpweb/endpoints/analytics.py
+++ b/src/pylxpweb/endpoints/analytics.py
@@ -415,15 +415,26 @@ class AnalyticsEndpoints(BaseEndpoint):
                     - recordId: Event record identifier
                     - serialNum: Device serial number
                     - datalogSn: Dongle serial number
+                    - plantName: Station name
                     - event: Event code (E###=fault, W###=warning)
-                    - eventType: FAULT/WARNING/INFO (GridBOSS/MID devices
-                      also report MIDBOX_WARNING)
+                    - eventType: observed values FAULT/WARNING/INFO, plus
+                      MIDBOX_WARNING from GridBOSS/MID devices.  Not a closed
+                      set — treat unrecognized values as passthrough.
+                    - eventTypeText: Localized category ("Fault", "Notice")
                     - eventText: Human-readable description
-                    - startTime: Event start timestamp
-                    - renormalTime: Return-to-normal timestamp (null while
-                      ongoing)
+                    - startTime: Event start, portal-local "YYYY-MM-DD
+                      HH:MM:SS" (naive — no timezone or UTC offset)
+                    - startSlashTime: Same instant, "YYYY/MM/DD HH:MM:SS"
+                    - renormalTime: Return-to-normal in the same dash format
+                      (null while ongoing)
+                    - renormalSlashTime: Same instant in slash format (null
+                      while ongoing)
                     - faultDuration: Duration in hours (string)
                     - status: OPEN (active) / CLOSE (resolved)
+
+                Rows carry additional undocumented keys; treat the shape as
+                open.  ``docs/luxpower-api.yaml`` (EventListResponse) is the
+                fuller contract.
 
         Example:
             # Get all events

--- a/src/pylxpweb/endpoints/analytics.py
+++ b/src/pylxpweb/endpoints/analytics.py
@@ -427,8 +427,9 @@ class AnalyticsEndpoints(BaseEndpoint):
                     - startSlashTime: Same instant, "YYYY/MM/DD HH:MM:SS"
                     - renormalTime: Return-to-normal in the same dash format
                       (null while ongoing)
-                    - renormalSlashTime: Same instant in slash format (null
-                      while ongoing)
+                    - renormalSlashTime: Same instant in slash format.  Its
+                      value on an ongoing event is unattested — observed rows
+                      omit the key entirely rather than sending null.
                     - faultDuration: Duration in hours (string)
                     - status: OPEN (active) / CLOSE (resolved)
 

--- a/tests/unit/endpoints/test_event_list_docs.py
+++ b/tests/unit/endpoints/test_event_list_docs.py
@@ -1,0 +1,103 @@
+"""The event-list row shape is documented twice; keep the two copies honest.
+
+``AnalyticsEndpoints.get_event_list``'s docstring and the
+``EventListResponse`` row schema in ``docs/luxpower-api.yaml`` both enumerate
+the fields of an event row.  Two exhaustive lists of the same open-ended API
+shape drift apart the moment someone discovers another key and updates only
+one of them -- which is how #236 happened in the first place.  This test
+fails when they disagree.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from pylxpweb.endpoints.analytics import AnalyticsEndpoints
+
+_SPEC = Path(__file__).resolve().parents[3] / "docs" / "luxpower-api.yaml"
+
+# Rows are documented as "- fieldName: description", indented under
+# "rows: List of event objects with:", with continuation lines indented
+# further.  Only the "- name:" openers are field declarations.
+_FIELD_LINE = re.compile(r"^\s*- (?P<name>[A-Za-z][A-Za-z0-9]*): ")
+
+
+def _documented_row_fields() -> set[str]:
+    """Field names the get_event_list docstring declares for a row."""
+    docstring = AnalyticsEndpoints.get_event_list.__doc__
+    assert docstring is not None, "get_event_list lost its docstring"
+
+    lines = docstring.splitlines()
+    start = next(i for i, line in enumerate(lines) if "rows: List of event objects with:" in line)
+    row_indent = len(lines[start]) - len(lines[start].lstrip())
+
+    fields: set[str] = set()
+    for line in lines[start + 1 :]:
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        # Dedent back to the "rows:" level ends the row field list.
+        if indent <= row_indent:
+            break
+        match = _FIELD_LINE.match(line)
+        if match:
+            fields.add(match.group("name"))
+    return fields
+
+
+def _spec_row_fields() -> tuple[set[str], dict[str, Any]]:
+    """Field names and the raw row schema from docs/luxpower-api.yaml."""
+    spec = yaml.safe_load(_SPEC.read_text())
+    row = spec["components"]["schemas"]["EventListResponse"]["properties"]["rows"]["items"]
+    return set(row["properties"]), row
+
+
+def test_docstring_and_spec_document_the_same_row_fields() -> None:
+    """The two hand-maintained field lists must not drift apart."""
+    documented = _documented_row_fields()
+    spec_fields, _ = _spec_row_fields()
+
+    assert documented == spec_fields, (
+        "get_event_list's docstring and docs/luxpower-api.yaml disagree on the "
+        f"event row shape. Only in docstring: {sorted(documented - spec_fields)}; "
+        f"only in spec: {sorted(spec_fields - documented)}"
+    )
+
+
+def test_the_field_extractor_actually_finds_fields() -> None:
+    """Guard the guard: an extractor that finds nothing would pass vacuously."""
+    documented = _documented_row_fields()
+    # Anchor on fields whose names were the substance of #236 -- recordId and
+    # status replaced the fictitious eventId and statusText.
+    assert {"recordId", "status", "renormalTime"} <= documented
+    assert len(documented) > 10
+
+
+def test_row_shape_stays_open() -> None:
+    """Rows carry undocumented keys; the spec must not forbid them."""
+    _, row = _spec_row_fields()
+    assert row.get("additionalProperties") is True
+
+
+def test_event_type_is_not_a_closed_enum() -> None:
+    """eventType passes unknown values through, so it cannot be an enum.
+
+    The docstring promises unrecognized values are passed through rather than
+    rejected.  A closed enum would contradict that promise.
+    """
+    _, row = _spec_row_fields()
+    assert "enum" not in row["properties"]["eventType"]
+
+
+def test_timestamps_are_not_declared_rfc3339() -> None:
+    """Portal timestamps are naive local time, which format:date-time rejects."""
+    _, row = _spec_row_fields()
+    for field in ("startTime", "renormalTime", "startSlashTime", "renormalSlashTime"):
+        assert "format" not in row["properties"][field], (
+            f"{field} carries an OpenAPI format; the portal sends naive "
+            "'YYYY-MM-DD HH:MM:SS' with no offset, which fails RFC 3339 validation"
+        )

--- a/tests/unit/endpoints/test_event_list_docs.py
+++ b/tests/unit/endpoints/test_event_list_docs.py
@@ -49,17 +49,19 @@ def _documented_row_fields() -> set[str]:
     return fields
 
 
-def _spec_row_fields() -> tuple[set[str], dict[str, Any]]:
-    """Field names and the raw row schema from docs/luxpower-api.yaml."""
+def _spec_event_row() -> dict[str, Any]:
+    """The event-row schema from docs/luxpower-api.yaml."""
     spec = yaml.safe_load(_SPEC.read_text())
-    row = spec["components"]["schemas"]["EventListResponse"]["properties"]["rows"]["items"]
-    return set(row["properties"]), row
+    row: dict[str, Any] = spec["components"]["schemas"]["EventListResponse"]["properties"]["rows"][
+        "items"
+    ]
+    return row
 
 
 def test_docstring_and_spec_document_the_same_row_fields() -> None:
     """The two hand-maintained field lists must not drift apart."""
     documented = _documented_row_fields()
-    spec_fields, _ = _spec_row_fields()
+    spec_fields = set(_spec_event_row()["properties"])
 
     assert documented == spec_fields, (
         "get_event_list's docstring and docs/luxpower-api.yaml disagree on the "
@@ -79,7 +81,7 @@ def test_the_field_extractor_actually_finds_fields() -> None:
 
 def test_row_shape_stays_open() -> None:
     """Rows carry undocumented keys; the spec must not forbid them."""
-    _, row = _spec_row_fields()
+    row = _spec_event_row()
     assert row.get("additionalProperties") is True
 
 
@@ -90,7 +92,7 @@ def test_passthrough_fields_are_not_closed_enums() -> None:
     rather than rejecting them, so a closed enum would contradict the
     documented behaviour.  Both are documented by observed value instead.
     """
-    _, row = _spec_row_fields()
+    row = _spec_event_row()
     for field in ("eventType", "status"):
         assert "enum" not in row["properties"][field], (
             f"{field} is declared a closed enum, but unknown values are "
@@ -101,7 +103,7 @@ def test_passthrough_fields_are_not_closed_enums() -> None:
 
 def test_timestamps_are_not_declared_rfc3339() -> None:
     """Portal timestamps are naive local time, which format:date-time rejects."""
-    _, row = _spec_row_fields()
+    row = _spec_event_row()
     for field in ("startTime", "renormalTime", "startSlashTime", "renormalSlashTime"):
         assert "format" not in row["properties"][field], (
             f"{field} carries an OpenAPI format; the portal sends naive "

--- a/tests/unit/endpoints/test_event_list_docs.py
+++ b/tests/unit/endpoints/test_event_list_docs.py
@@ -83,14 +83,20 @@ def test_row_shape_stays_open() -> None:
     assert row.get("additionalProperties") is True
 
 
-def test_event_type_is_not_a_closed_enum() -> None:
-    """eventType passes unknown values through, so it cannot be an enum.
+def test_passthrough_fields_are_not_closed_enums() -> None:
+    """Fields whose unknown values pass through cannot be modelled as enums.
 
-    The docstring promises unrecognized values are passed through rather than
-    rejected.  A closed enum would contradict that promise.
+    Consumers relay unrecognized ``eventType`` and ``status`` values verbatim
+    rather than rejecting them, so a closed enum would contradict the
+    documented behaviour.  Both are documented by observed value instead.
     """
     _, row = _spec_row_fields()
-    assert "enum" not in row["properties"]["eventType"]
+    for field in ("eventType", "status"):
+        assert "enum" not in row["properties"][field], (
+            f"{field} is declared a closed enum, but unknown values are "
+            "passed through — the enum would reject what the description "
+            "promises to accept"
+        )
 
 
 def test_timestamps_are_not_declared_rfc3339() -> None:

--- a/tests/unit/endpoints/test_event_list_docs.py
+++ b/tests/unit/endpoints/test_event_list_docs.py
@@ -23,7 +23,15 @@ _SPEC = Path(__file__).resolve().parents[3] / "docs" / "luxpower-api.yaml"
 # Rows are documented as "- fieldName: description", indented under
 # "rows: List of event objects with:", with continuation lines indented
 # further.  Only the "- name:" openers are field declarations.
-_FIELD_LINE = re.compile(r"^\s*- (?P<name>[A-Za-z][A-Za-z0-9]*): ")
+#
+# The name class and the trailing separator are deliberately permissive.  A
+# field this regex fails to recognise is silently dropped from the extracted
+# set, and if that field was added to the docstring ONLY, both the drift test
+# and the guard-the-guard test still pass -- the guard would quietly stop
+# guarding the one thing it exists to catch.  So underscores and digits are
+# accepted anywhere after the first character, and the description may start
+# on the next line (no space required after the colon).
+_FIELD_LINE = re.compile(r"^\s*- (?P<name>[A-Za-z_][A-Za-z0-9_]*):(?: |$)")
 
 
 def _documented_row_fields() -> set[str]:


### PR DESCRIPTION
Fixes #236.

## The bug

`get_event_list`'s docstring documented fields the `/WManage/api/analyze/event/list` endpoint never returns — `eventId`, `eventCode`, `endTime`, and `statusText` with values `ACTIVE`/`RESOLVED` — including a usage example keyed on `event["statusText"] == "ACTIVE"`. The same wrong fields were mirrored in this repo's `docs/luxpower-api.yaml`.

Doc-only: the method returns the raw dict, so no behavior changes.

## The real shape

Established from the canonical `EventRow` schema in the EG4 integration's `docs/api/openapi.yaml`, its live-validated fixtures, and the `normalize_event_row` consumer — all fourteen fields, agreeing three ways:

`recordId`, `serialNum`, `datalogSn`, `plantName`, `event`, `eventType`, `eventTypeText`, `eventText`, `faultDuration`, `startTime`, `startSlashTime`, `renormalTime`, `renormalSlashTime`, `status`.

## What review changed along the way

The first correction was itself incomplete, and each round found something real:

- Four fields were still missing (`plantName`, `eventTypeText`, and the slash-format twins).
- `startTime` / `renormalTime` were declared `format: date-time`, but the portal sends naive local `YYYY-MM-DD HH:MM:SS` with no offset, which RFC 3339 validation rejects. Format dropped, real shape documented.
- `eventType` declared a closed `enum` while its own description promised unknown values pass through — contradictory, since the enum rejects exactly what the description accepts. Now documented by observed value. `status` had the same shape and got the same treatment; consumers relay unknown values for both.
- The docstring asserted rows *carry* undocumented keys; the evidence only supports *may carry*. `additionalProperties: true` says extras are allowed, not present.
- The second usage example passed `event_filter="FAULT"`, but that parameter is wired to the request's `eventText` field and takes `_all` or an event code like `E019` — `"FAULT"` is an `eventType` category, a different axis. No caller passes anything but the default, so the code form is documented as unverified rather than asserted.
- `renormalSlashTime` was claimed null-while-ongoing by symmetry with `renormalTime`; the fixtures omit the key entirely, so that is now marked unattested. (`renormalTime`'s null *is* attested and stays stated as fact.)

## Anti-drift

The row shape is necessarily documented twice — library users read the docstring, spec consumers read the YAML. Rather than delete either, `tests/unit/endpoints/test_event_list_docs.py` parses the field list out of both and fails when they disagree, and pins the three deliberate modeling decisions (open row shape, no closed enums on the passthrough fields, no RFC 3339 format on naive timestamps) so a later tidy-up cannot silently undo them.

Mutation-verified: dropping a field from the spec fails the drift test; re-adding either enum fails the enum test. The field regex was also widened after review found it silently skipped underscore-named fields and fields whose description starts on the next line — a docstring-only addition of either would have passed both tests, i.e. the guard would have stopped guarding without anyone noticing.

## Companion change

The EG4 integration's `docs/api/openapi.yaml` carries the same contradictory `eventType` enum and is corrected on a separate branch, so the two copies of this schema stay in agreement.

## Testing

`ruff check` / `ruff format` clean, `mypy --strict` clean (94 files), `pytest tests/unit/` → 2807 passed.

Reviewed by gpt-5.6-sol (twice), gemini-3.1-pro, and two Claude models; every finding above came from that gate.