### PR TITLE
fix: green mode helpers work on transport-created LOCAL instances (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Green mode device helpers work without a cloud client**
+  ([#243](https://github.com/joyfulhouse/pylxpweb/issues/243)):
+  `BaseInverter.enable_green_mode`, `disable_green_mode` and
+  `get_green_mode_status` dereferenced `self._client.api` unconditionally,
+  so transport-created LOCAL instances (`client=None`) crashed with
+  `AttributeError` even after #476 pinned `FUNC_GREEN_EN` to register 110
+  bit 14 and made local reads/writes of that bit work. The three helpers
+  now route through the shared register-bit dual path (the
+  `set_standby_mode` model): transport mode performs an atomic
+  read-modify-write of register 110 bit 14, cloud mode drives the named
+  `FUNC_GREEN_EN` bit server-side via `control_function` (the same request
+  the old cloud-only helpers issued), and a successful write invalidates
+  the cached parameters. With neither a transport nor a client attached the
+  helpers raise a clear `LuxpowerDeviceError` instead of `AttributeError`.
+  New constant `FUNC_SYS_BIT_GREEN_EN = 14` alongside the existing
+  `FUNC_SYS_REGISTER`. The related transport-level gap —
+  `HTTPTransport.write_named_parameters` turning a named bitfield update
+  into a raw register-110 write that `ControlEndpoints` rejects — is noted
+  on #243 and not changed here.
+
 - **`get_event_list` docs corrected to the live response shape**
   ([#236](https://github.com/joyfulhouse/pylxpweb/issues/236)): the
   docstring (and the matching `EventListResponse` row schema in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `get_green_mode_status` dereferenced `self._client.api` unconditionally,
   so transport-created LOCAL instances (`client=None`) crashed with
   `AttributeError` even after #476 pinned `FUNC_GREEN_EN` to register 110
-  bit 14 and made local reads/writes of that bit work. The three helpers
-  now route through the shared register-bit dual path (the
-  `set_standby_mode` model): transport mode performs an atomic
-  read-modify-write of register 110 bit 14, cloud mode drives the named
-  `FUNC_GREEN_EN` bit server-side via `control_function` (the same request
-  the old cloud-only helpers issued), and a successful write invalidates
-  the cached parameters. With neither a transport nor a client attached the
-  helpers raise a clear `LuxpowerDeviceError` instead of `AttributeError`.
-  New constant `FUNC_SYS_BIT_GREEN_EN = 14` alongside the existing
-  `FUNC_SYS_REGISTER`. The related transport-level gap —
+  bit 14 and made local reads/writes of that bit work. The helpers now
+  preserve their historical, client-first route contract: a bare call on a
+  cloud-created or HYBRID inverter uses the dedicated cloud endpoint even
+  when a local transport is attached, while a clientless LOCAL inverter
+  reads register 110 bit 14 and writes `FUNC_GREEN_EN` through the
+  transport's named-parameter API. That named write holds the transport
+  operation lock across the complete read-modify-write, preserving
+  concurrent changes to other register-110 bits. The public method
+  signatures are unchanged, so the Home Assistant HYBRID cloud fallback
+  needs no integration change. A caller that must force LOCAL can use
+  `inverter.transport.write_named_parameters`; a caller that must force
+  cloud can use the `LuxpowerClient.api.control` green-mode endpoints.
+  Successful writes invalidate the cached parameters, and with neither a
+  transport nor a client attached the helpers raise a clear
+  `LuxpowerDeviceError` instead of `AttributeError`. New constant
+  `FUNC_SYS_BIT_GREEN_EN = 14` alongside the existing `FUNC_SYS_REGISTER`.
+  The related transport-level gap —
   `HTTPTransport.write_named_parameters` turning a named bitfield update
   into a raw register-110 write that `ControlEndpoints` rejects — is noted
   on #243 and not changed here.

--- a/src/pylxpweb/constants/__init__.py
+++ b/src/pylxpweb/constants/__init__.py
@@ -126,6 +126,7 @@ from .registers import (
     FUNC_EXT_REGISTER,
     # System function register (110)
     FUNC_SYS_BIT_CHARGE_LAST,
+    FUNC_SYS_BIT_GREEN_EN,
     FUNC_SYS_REGISTER,
     # GridBOSS parameters
     GRIDBOSS_PARAMETERS,
@@ -421,6 +422,7 @@ __all__ = [
     "FUNC_EXT_BIT_PV_SELL_TO_GRID",
     "FUNC_SYS_REGISTER",
     "FUNC_SYS_BIT_CHARGE_LAST",
+    "FUNC_SYS_BIT_GREEN_EN",
     "HOLD_AC_CHARGE_POWER_CMD",
     "HOLD_AC_CHARGE_SOC_LIMIT",
     "HOLD_AC_CHARGE_TIME_0_START",

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -151,6 +151,7 @@ FUNC_EN_BIT_FORCED_CHG_EN = 11  # Force charge enable
 # System Function Register (Address 110) - Bit Field
 FUNC_SYS_REGISTER = 110
 FUNC_SYS_BIT_CHARGE_LAST = 4  # Charge last: charge battery after loads satisfied
+FUNC_SYS_BIT_GREEN_EN = 14  # Green/off-grid mode (hardware toggle-verified 2026-07-21, #476)
 
 # Extended Function Enable Register (Address 179) - Bit Field
 FUNC_EXT_REGISTER = 179

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -2492,26 +2492,48 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
     # ============================================================================
 
     async def _set_green_mode(self, enabled: bool) -> bool:
-        """Set the green mode bit via transport or cloud (shared tail).
+        """Set green mode through cloud, or LOCAL when no client exists.
 
         Register 110 bit 14 (FUNC_GREEN_EN, hardware toggle-verified
-        2026-07-21, eg4_web_monitor #476). Transport mode performs an atomic
-        read-modify-write; cloud mode sets the named FUNC_GREEN_EN bit
-        server-side via control_function — the same request the old
-        cloud-only helpers issued, so transport-created LOCAL instances
-        (``client=None``) no longer crash with AttributeError (#243).
+        2026-07-21, eg4_web_monitor #476). A client-bearing inverter keeps
+        the historical cloud route, even when a HYBRID local transport is
+        attached. A clientless LOCAL inverter uses the transport's named
+        parameter API, whose operation lock spans the full read-modify-write.
         """
         from pylxpweb.constants import FUNC_SYS_BIT_GREEN_EN, FUNC_SYS_REGISTER
+        from pylxpweb.transports.exceptions import TransportError
 
-        result = await self._set_modbus_register_bit(
-            FUNC_SYS_REGISTER, FUNC_SYS_BIT_GREEN_EN, enabled=enabled
-        )
+        client = self._client
+        if client is not None:
+            if enabled:
+                response = await client.api.control.enable_green_mode(self.serial_number)
+            else:
+                response = await client.api.control.disable_green_mode(self.serial_number)
+            success = bool(response.success)
+        else:
+            transport = self._transport
+            if transport is None:
+                raise LuxpowerDeviceError(
+                    f"Register {FUNC_SYS_REGISTER} write requires a transport or a cloud client"
+                )
+
+            param_key = self._cloud_param_key(FUNC_SYS_REGISTER, FUNC_SYS_BIT_GREEN_EN)
+            try:
+                success = await transport.write_named_parameters({param_key: enabled})
+            except TransportError as err:
+                raise LuxpowerDeviceError(
+                    f"Register {FUNC_SYS_REGISTER} write requires a successful Modbus write"
+                ) from err
+            if not success:
+                raise LuxpowerDeviceError(
+                    f"Register {FUNC_SYS_REGISTER} write requires a successful Modbus write"
+                )
 
         # Invalidate parameter cache on successful write
-        if result:
+        if success:
             self._parameters_cache_time = None
 
-        return result
+        return success
 
     async def enable_green_mode(self) -> bool:
         """Enable green mode (off-grid mode in the web monitoring display).
@@ -2522,6 +2544,11 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
 
         Note: This is FUNC_GREEN_EN in register 110 (bit 14), distinct from
         FUNC_EPS_EN (battery backup/EPS mode) in register 21.
+
+        Route selection is client-first for compatibility: cloud-created and
+        HYBRID instances use the cloud function-control endpoint. A
+        transport-created LOCAL instance with no cloud client uses the
+        lock-held named-parameter RMW on its transport.
 
         Universal control: All inverters support green mode.
 
@@ -2549,6 +2576,11 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         Note: This is FUNC_GREEN_EN in register 110 (bit 14), distinct from
         FUNC_EPS_EN (battery backup/EPS mode) in register 21.
 
+        Route selection is client-first for compatibility: cloud-created and
+        HYBRID instances use the cloud function-control endpoint. A
+        transport-created LOCAL instance with no cloud client uses the
+        lock-held named-parameter RMW on its transport.
+
         Universal control: All inverters support green mode.
 
         Returns:
@@ -2569,8 +2601,9 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         """Get current green mode (off-grid mode) status.
 
         Green Mode controls the off-grid operating mode toggle visible in the
-        EG4 web monitoring interface. Transport mode reads register 110 bit 14
-        directly; cloud mode reads the named FUNC_GREEN_EN parameter.
+        EG4 web monitoring interface. Cloud-created and HYBRID instances keep
+        the historical cloud status endpoint. A clientless LOCAL instance
+        reads register 110 bit 14 directly.
 
         Universal control: All inverters support green mode.
 
@@ -2588,6 +2621,8 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         """
         from pylxpweb.constants import FUNC_SYS_BIT_GREEN_EN, FUNC_SYS_REGISTER
 
+        if self._client is not None:
+            return await self._client.api.control.get_green_mode_status(self.serial_number)
         return await self._get_register_bit(FUNC_SYS_REGISTER, FUNC_SYS_BIT_GREEN_EN)
 
     @property

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -2491,6 +2491,28 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
     # Green Mode Control (Off-Grid Mode in Web Monitor)
     # ============================================================================
 
+    async def _set_green_mode(self, enabled: bool) -> bool:
+        """Set the green mode bit via transport or cloud (shared tail).
+
+        Register 110 bit 14 (FUNC_GREEN_EN, hardware toggle-verified
+        2026-07-21, eg4_web_monitor #476). Transport mode performs an atomic
+        read-modify-write; cloud mode sets the named FUNC_GREEN_EN bit
+        server-side via control_function — the same request the old
+        cloud-only helpers issued, so transport-created LOCAL instances
+        (``client=None``) no longer crash with AttributeError (#243).
+        """
+        from pylxpweb.constants import FUNC_SYS_BIT_GREEN_EN, FUNC_SYS_REGISTER
+
+        result = await self._set_modbus_register_bit(
+            FUNC_SYS_REGISTER, FUNC_SYS_BIT_GREEN_EN, enabled=enabled
+        )
+
+        # Invalidate parameter cache on successful write
+        if result:
+            self._parameters_cache_time = None
+
+        return result
+
     async def enable_green_mode(self) -> bool:
         """Enable green mode (off-grid mode in the web monitoring display).
 
@@ -2498,20 +2520,24 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         EG4 web monitoring interface. When enabled, the inverter operates in
         an off-grid optimized configuration.
 
-        Note: This is FUNC_GREEN_EN in register 110, distinct from FUNC_EPS_EN
-        (battery backup/EPS mode) in register 21.
+        Note: This is FUNC_GREEN_EN in register 110 (bit 14), distinct from
+        FUNC_EPS_EN (battery backup/EPS mode) in register 21.
 
         Universal control: All inverters support green mode.
 
         Returns:
-            True if successful
+            True if successful; in cloud mode, False if the API rejected the
+            write
+
+        Raises:
+            LuxpowerDeviceError: In transport mode, if the Modbus write fails;
+                in cloud mode, if neither a transport nor a client is attached.
 
         Example:
             >>> await inverter.enable_green_mode()
             True
         """
-        result = await self._client.api.control.enable_green_mode(self.serial_number)
-        return result.success
+        return await self._set_green_mode(enabled=True)
 
     async def disable_green_mode(self) -> bool:
         """Disable green mode (off-grid mode in the web monitoring display).
@@ -2520,38 +2546,49 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         EG4 web monitoring interface. When disabled, the inverter operates in
         standard grid-tied configuration.
 
-        Note: This is FUNC_GREEN_EN in register 110, distinct from FUNC_EPS_EN
-        (battery backup/EPS mode) in register 21.
+        Note: This is FUNC_GREEN_EN in register 110 (bit 14), distinct from
+        FUNC_EPS_EN (battery backup/EPS mode) in register 21.
 
         Universal control: All inverters support green mode.
 
         Returns:
-            True if successful
+            True if successful; in cloud mode, False if the API rejected the
+            write
+
+        Raises:
+            LuxpowerDeviceError: In transport mode, if the Modbus write fails;
+                in cloud mode, if neither a transport nor a client is attached.
 
         Example:
             >>> await inverter.disable_green_mode()
             True
         """
-        result = await self._client.api.control.disable_green_mode(self.serial_number)
-        return result.success
+        return await self._set_green_mode(enabled=False)
 
     async def get_green_mode_status(self) -> bool:
         """Get current green mode (off-grid mode) status.
 
         Green Mode controls the off-grid operating mode toggle visible in the
-        EG4 web monitoring interface.
+        EG4 web monitoring interface. Transport mode reads register 110 bit 14
+        directly; cloud mode reads the named FUNC_GREEN_EN parameter.
 
         Universal control: All inverters support green mode.
 
         Returns:
             True if green mode is enabled, False otherwise
 
+        Raises:
+            LuxpowerDeviceError: In transport mode, if the Modbus read fails;
+                in cloud mode, if neither a transport nor a client is attached.
+
         Example:
             >>> is_enabled = await inverter.get_green_mode_status()
             >>> is_enabled
             True
         """
-        return await self._client.api.control.get_green_mode_status(self.serial_number)
+        from pylxpweb.constants import FUNC_SYS_BIT_GREEN_EN, FUNC_SYS_REGISTER
+
+        return await self._get_register_bit(FUNC_SYS_REGISTER, FUNC_SYS_BIT_GREEN_EN)
 
     @property
     def green_mode_enabled(self) -> bool | None:

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -2557,8 +2557,9 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             write
 
         Raises:
-            LuxpowerDeviceError: In transport mode, if the Modbus write fails;
-                in cloud mode, if neither a transport nor a client is attached.
+            LuxpowerDeviceError: On the transport route, if the Modbus write
+                fails; or, on any route, if the instance has neither a
+                transport nor a cloud client attached.
 
         Example:
             >>> await inverter.enable_green_mode()
@@ -2588,8 +2589,9 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             write
 
         Raises:
-            LuxpowerDeviceError: In transport mode, if the Modbus write fails;
-                in cloud mode, if neither a transport nor a client is attached.
+            LuxpowerDeviceError: On the transport route, if the Modbus write
+                fails; or, on any route, if the instance has neither a
+                transport nor a cloud client attached.
 
         Example:
             >>> await inverter.disable_green_mode()
@@ -2611,8 +2613,9 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             True if green mode is enabled, False otherwise
 
         Raises:
-            LuxpowerDeviceError: In transport mode, if the Modbus read fails;
-                in cloud mode, if neither a transport nor a client is attached.
+            LuxpowerDeviceError: On the transport route, if the Modbus read
+                fails; or, on any route, if the instance has neither a
+                transport nor a cloud client attached.
 
         Example:
             >>> is_enabled = await inverter.get_green_mode_status()

--- a/tests/unit/devices/inverters/test_base.py
+++ b/tests/unit/devices/inverters/test_base.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -12,6 +13,7 @@ from pylxpweb.devices.inverters.base import BaseInverter
 from pylxpweb.devices.models import DeviceInfo, Entity
 from pylxpweb.exceptions import LuxpowerDeviceError
 from pylxpweb.models import EnergyInfo, InverterRuntime, SuccessResponse
+from pylxpweb.transports.modbus import ModbusTransport
 
 
 class ConcreteInverter(BaseInverter):
@@ -1271,7 +1273,7 @@ class TestGreenModeEnabledProperty:
 
 
 class TestGreenModeControls:
-    """Green mode helpers are dual-path: transport RMW or cloud named bit.
+    """Green mode helpers preserve cloud routing and support clientless LOCAL.
 
     Regression tests for #243: the helpers used to dereference
     ``self._client.api`` unconditionally, so transport-created LOCAL
@@ -1279,70 +1281,79 @@ class TestGreenModeControls:
     register 110 bit 14 (FUNC_GREEN_EN) reads/writes work locally
     (hardware-verified 2026-07-21, eg4_web_monitor #476).
 
-    Raw values mirror the #476 hardware capture: 1056 (0x0420) with green
-    off, 17440 (0x4420) with only bit 14 added.
+    The fixture extends the #476 hardware capture with the hardware-backed
+    buzzer and battery-ECO bits so a green write must preserve bits 7 and 15
+    as well as the capture's pre-existing bits 5 and 10.
     """
 
-    GREEN_OFF_RAW = 1056  # 0x0420 — bits 5+10 set, bit 14 clear
-    GREEN_ON_RAW = 17440  # 0x4420 — same plus bit 14
+    GREEN_OFF_RAW = 0x84A0  # Bits 5, 7, 10, and 15 set; bit 14 clear
+    GREEN_ON_RAW = 0xC4A0  # Same bits plus green mode at bit 14
 
-    def _local_inverter(self) -> ConcreteInverter:
-        """Transport-created instance: no cloud client at all (#243)."""
-        return ConcreteInverter(
+    def _local_inverter(
+        self, raw_value: int, *, write_success: bool = True
+    ) -> tuple[ConcreteInverter, ModbusTransport]:
+        """Create a transport-only inverter backed by the real named RMW."""
+        transport = ModbusTransport(host="192.0.2.1", serial="1234567890")
+        transport._connected = True
+        transport.read_parameters = AsyncMock(return_value={110: raw_value})
+        transport.write_parameters = AsyncMock(return_value=write_success)
+        inverter = ConcreteInverter(
             client=None,
             serial_number="1234567890",
             model="TestModel",
-            transport=Mock(),
+            transport=transport,
         )
+        return inverter, transport
 
     @pytest.mark.asyncio
     async def test_enable_green_mode_transport_without_client(self) -> None:
-        """LOCAL enable sets bit 14 of register 110 via read-modify-write."""
-        inverter = self._local_inverter()
-        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_OFF_RAW)
-        inverter.write_transport_register = AsyncMock(return_value=True)
+        """LOCAL enable sets bit 14 and preserves bits 7 and 15."""
+        inverter, transport = self._local_inverter(self.GREEN_OFF_RAW)
         inverter._parameters_cache_time = datetime.now()
 
         result = await inverter.enable_green_mode()
 
         assert result is True
-        inverter.read_transport_register.assert_awaited_once_with(110)
-        inverter.write_transport_register.assert_awaited_once_with(110, self.GREEN_ON_RAW)
+        transport.read_parameters.assert_awaited_once_with(110, 1)
+        transport.write_parameters.assert_awaited_once_with({110: self.GREEN_ON_RAW})
+        written = transport.write_parameters.await_args.args[0][110]
+        assert written & (1 << 7)
+        assert written & (1 << 15)
+        assert written & (1 << 8) == 0
         # Successful write invalidates the parameter cache
         assert inverter._parameters_cache_time is None
 
     @pytest.mark.asyncio
     async def test_disable_green_mode_transport_without_client(self) -> None:
-        """LOCAL disable clears bit 14 while preserving the other bits."""
-        inverter = self._local_inverter()
-        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_ON_RAW)
-        inverter.write_transport_register = AsyncMock(return_value=True)
+        """LOCAL disable clears bit 14 and preserves bits 7 and 15."""
+        inverter, transport = self._local_inverter(self.GREEN_ON_RAW)
         inverter._parameters_cache_time = datetime.now()
 
         result = await inverter.disable_green_mode()
 
         assert result is True
-        inverter.write_transport_register.assert_awaited_once_with(110, self.GREEN_OFF_RAW)
+        transport.write_parameters.assert_awaited_once_with({110: self.GREEN_OFF_RAW})
+        written = transport.write_parameters.await_args.args[0][110]
+        assert written & (1 << 7)
+        assert written & (1 << 15)
+        assert written & (1 << 14) == 0
         assert inverter._parameters_cache_time is None
 
     @pytest.mark.asyncio
     async def test_get_green_mode_status_transport_without_client(self) -> None:
         """LOCAL status reads register 110 and extracts bit 14."""
-        inverter = self._local_inverter()
-        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_ON_RAW)
+        inverter, transport = self._local_inverter(self.GREEN_ON_RAW)
 
         assert await inverter.get_green_mode_status() is True
 
-        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_OFF_RAW)
+        transport.read_parameters = AsyncMock(return_value={110: self.GREEN_OFF_RAW})
 
         assert await inverter.get_green_mode_status() is False
 
     @pytest.mark.asyncio
     async def test_transport_write_failure_leaves_cache_intact(self) -> None:
         """A failed Modbus write raises and must NOT invalidate the cache."""
-        inverter = self._local_inverter()
-        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_OFF_RAW)
-        inverter.write_transport_register = AsyncMock(return_value=False)
+        inverter, _ = self._local_inverter(self.GREEN_OFF_RAW, write_success=False)
         cache_time = datetime.now()
         inverter._parameters_cache_time = cache_time
 
@@ -1352,42 +1363,96 @@ class TestGreenModeControls:
         assert inverter._parameters_cache_time is cache_time
 
     @pytest.mark.asyncio
+    async def test_local_green_write_is_atomic_with_concurrent_eco_update(self) -> None:
+        """The transport lock spans green mode's complete register-110 RMW."""
+        register_110 = 0x0080  # Pre-existing buzzer bit 7
+        transport = ModbusTransport(host="192.0.2.1", serial="1234567890")
+        transport._connected = True
+        inverter = ConcreteInverter(
+            client=None,
+            serial_number="1234567890",
+            model="TestModel",
+            transport=transport,
+        )
+        first_read_started = asyncio.Event()
+        release_first_read = asyncio.Event()
+        other_write_started = asyncio.Event()
+        first_read = True
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            nonlocal first_read
+            assert (address, count) == (110, 1)
+            snapshot = register_110
+            if first_read:
+                first_read = False
+                first_read_started.set()
+                await release_first_read.wait()
+            return [snapshot]
+
+        async def write_holding(address: int, values: list[int]) -> bool:
+            nonlocal register_110
+            assert address == 110
+            register_110 = values[0]
+            return True
+
+        async def enable_eco_mode() -> bool:
+            other_write_started.set()
+            return await transport.write_named_parameters({"FUNC_BATTERY_ECO_EN": True})
+
+        with (
+            patch.object(transport, "_read_holding_registers", side_effect=read_holding),
+            patch.object(transport, "_write_holding_registers", side_effect=write_holding),
+        ):
+            green_task = asyncio.create_task(inverter.enable_green_mode())
+            await asyncio.wait_for(first_read_started.wait(), timeout=1)
+            eco_task = asyncio.create_task(enable_eco_mode())
+            await asyncio.wait_for(other_write_started.wait(), timeout=1)
+            release_first_read.set()
+            results = await asyncio.wait_for(
+                asyncio.gather(green_task, eco_task),
+                timeout=1,
+            )
+
+        assert results == [True, True]
+        assert register_110 == 0xC080
+        assert register_110 & (1 << 7)
+        assert register_110 & (1 << 14)
+        assert register_110 & (1 << 15)
+        assert register_110 & (1 << 8) == 0
+
+    @pytest.mark.asyncio
     async def test_enable_green_mode_cloud(self, mock_client: LuxpowerClient) -> None:
-        """Cloud enable drives the named FUNC_GREEN_EN function-control bit."""
+        """Cloud enable preserves the historical dedicated endpoint."""
         inverter = ConcreteInverter(
             client=mock_client, serial_number="1234567890", model="TestModel"
         )
         mock_client.api.control = Mock()
-        mock_response = Mock()
-        mock_response.success = True
-        mock_client.api.control.control_function = AsyncMock(return_value=mock_response)
+        mock_client.api.control.enable_green_mode = AsyncMock(
+            return_value=SuccessResponse(success=True)
+        )
         inverter._parameters_cache_time = datetime.now()
 
         result = await inverter.enable_green_mode()
 
         assert result is True
-        mock_client.api.control.control_function.assert_called_once_with(
-            "1234567890", "FUNC_GREEN_EN", True
-        )
+        mock_client.api.control.enable_green_mode.assert_awaited_once_with("1234567890")
         assert inverter._parameters_cache_time is None
 
     @pytest.mark.asyncio
     async def test_disable_green_mode_cloud(self, mock_client: LuxpowerClient) -> None:
-        """Cloud disable drives the named FUNC_GREEN_EN function-control bit."""
+        """Cloud disable preserves the historical dedicated endpoint."""
         inverter = ConcreteInverter(
             client=mock_client, serial_number="1234567890", model="TestModel"
         )
         mock_client.api.control = Mock()
-        mock_response = Mock()
-        mock_response.success = True
-        mock_client.api.control.control_function = AsyncMock(return_value=mock_response)
+        mock_client.api.control.disable_green_mode = AsyncMock(
+            return_value=SuccessResponse(success=True)
+        )
 
         result = await inverter.disable_green_mode()
 
         assert result is True
-        mock_client.api.control.control_function.assert_called_once_with(
-            "1234567890", "FUNC_GREEN_EN", False
-        )
+        mock_client.api.control.disable_green_mode.assert_awaited_once_with("1234567890")
 
     @pytest.mark.asyncio
     async def test_enable_green_mode_cloud_rejection_keeps_cache(
@@ -1398,9 +1463,9 @@ class TestGreenModeControls:
             client=mock_client, serial_number="1234567890", model="TestModel"
         )
         mock_client.api.control = Mock()
-        mock_response = Mock()
-        mock_response.success = False
-        mock_client.api.control.control_function = AsyncMock(return_value=mock_response)
+        mock_client.api.control.enable_green_mode = AsyncMock(
+            return_value=SuccessResponse(success=False)
+        )
         cache_time = datetime.now()
         inverter._parameters_cache_time = cache_time
 
@@ -1411,17 +1476,72 @@ class TestGreenModeControls:
 
     @pytest.mark.asyncio
     async def test_get_green_mode_status_cloud(self, mock_client: LuxpowerClient) -> None:
-        """Cloud status reads register 110 and extracts the named parameter."""
+        """Cloud status preserves the historical dedicated endpoint."""
         inverter = ConcreteInverter(
             client=mock_client, serial_number="1234567890", model="TestModel"
         )
         mock_client.api.control = Mock()
-        mock_response = Mock()
-        mock_response.parameters = {"FUNC_GREEN_EN": True}
-        mock_client.api.control.read_parameters = AsyncMock(return_value=mock_response)
+        mock_client.api.control.get_green_mode_status = AsyncMock(return_value=True)
 
         assert await inverter.get_green_mode_status() is True
-        mock_client.api.control.read_parameters.assert_called_once_with("1234567890", 110, 1)
+        mock_client.api.control.get_green_mode_status.assert_awaited_once_with("1234567890")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "endpoint_name"),
+        [
+            pytest.param("enable_green_mode", "enable_green_mode", id="enable"),
+            pytest.param("disable_green_mode", "disable_green_mode", id="disable"),
+        ],
+    )
+    async def test_green_mode_write_with_client_and_transport_uses_cloud(
+        self,
+        mock_client: LuxpowerClient,
+        method_name: str,
+        endpoint_name: str,
+    ) -> None:
+        """A HYBRID bare call remains the cloud route used by HA fallback."""
+        transport = Mock()
+        transport.read_parameters = AsyncMock(return_value={110: self.GREEN_OFF_RAW})
+        transport.write_parameters = AsyncMock(return_value=True)
+        transport.write_named_parameters = AsyncMock(return_value=True)
+        inverter = ConcreteInverter(
+            client=mock_client,
+            serial_number="1234567890",
+            model="TestModel",
+            transport=transport,
+        )
+        mock_client.api.control = Mock()
+        endpoint = AsyncMock(return_value=SuccessResponse(success=True))
+        setattr(mock_client.api.control, endpoint_name, endpoint)
+
+        assert await getattr(inverter, method_name)() is True
+
+        endpoint.assert_awaited_once_with("1234567890")
+        transport.read_parameters.assert_not_awaited()
+        transport.write_parameters.assert_not_awaited()
+        transport.write_named_parameters.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_green_mode_status_with_client_and_transport_uses_cloud(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A HYBRID status call ignores the attached local transport."""
+        transport = Mock()
+        transport.read_parameters = AsyncMock(return_value={110: self.GREEN_OFF_RAW})
+        inverter = ConcreteInverter(
+            client=mock_client,
+            serial_number="1234567890",
+            model="TestModel",
+            transport=transport,
+        )
+        mock_client.api.control = Mock()
+        mock_client.api.control.get_green_mode_status = AsyncMock(return_value=True)
+
+        assert await inverter.get_green_mode_status() is True
+
+        mock_client.api.control.get_green_mode_status.assert_awaited_once_with("1234567890")
+        transport.read_parameters.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_green_mode_no_transport_no_client_raises_device_error(self) -> None:

--- a/tests/unit/devices/inverters/test_base.py
+++ b/tests/unit/devices/inverters/test_base.py
@@ -1555,4 +1555,6 @@ class TestGreenModeControls:
         with pytest.raises(LuxpowerDeviceError, match="transport or a cloud client"):
             await inverter.enable_green_mode()
         with pytest.raises(LuxpowerDeviceError, match="transport or a cloud client"):
+            await inverter.disable_green_mode()
+        with pytest.raises(LuxpowerDeviceError, match="transport or a cloud client"):
             await inverter.get_green_mode_status()

--- a/tests/unit/devices/inverters/test_base.py
+++ b/tests/unit/devices/inverters/test_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -1267,3 +1268,171 @@ class TestGreenModeEnabledProperty:
         assert inverter.green_mode_enabled is False
         inverter.parameters = {"FUNC_GREEN_EN": 0}
         assert inverter.green_mode_enabled is False
+
+
+class TestGreenModeControls:
+    """Green mode helpers are dual-path: transport RMW or cloud named bit.
+
+    Regression tests for #243: the helpers used to dereference
+    ``self._client.api`` unconditionally, so transport-created LOCAL
+    instances (``client=None``) crashed with AttributeError even though
+    register 110 bit 14 (FUNC_GREEN_EN) reads/writes work locally
+    (hardware-verified 2026-07-21, eg4_web_monitor #476).
+
+    Raw values mirror the #476 hardware capture: 1056 (0x0420) with green
+    off, 17440 (0x4420) with only bit 14 added.
+    """
+
+    GREEN_OFF_RAW = 1056  # 0x0420 — bits 5+10 set, bit 14 clear
+    GREEN_ON_RAW = 17440  # 0x4420 — same plus bit 14
+
+    def _local_inverter(self) -> ConcreteInverter:
+        """Transport-created instance: no cloud client at all (#243)."""
+        return ConcreteInverter(
+            client=None,
+            serial_number="1234567890",
+            model="TestModel",
+            transport=Mock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_enable_green_mode_transport_without_client(self) -> None:
+        """LOCAL enable sets bit 14 of register 110 via read-modify-write."""
+        inverter = self._local_inverter()
+        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_OFF_RAW)
+        inverter.write_transport_register = AsyncMock(return_value=True)
+        inverter._parameters_cache_time = datetime.now()
+
+        result = await inverter.enable_green_mode()
+
+        assert result is True
+        inverter.read_transport_register.assert_awaited_once_with(110)
+        inverter.write_transport_register.assert_awaited_once_with(110, self.GREEN_ON_RAW)
+        # Successful write invalidates the parameter cache
+        assert inverter._parameters_cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_disable_green_mode_transport_without_client(self) -> None:
+        """LOCAL disable clears bit 14 while preserving the other bits."""
+        inverter = self._local_inverter()
+        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_ON_RAW)
+        inverter.write_transport_register = AsyncMock(return_value=True)
+        inverter._parameters_cache_time = datetime.now()
+
+        result = await inverter.disable_green_mode()
+
+        assert result is True
+        inverter.write_transport_register.assert_awaited_once_with(110, self.GREEN_OFF_RAW)
+        assert inverter._parameters_cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_get_green_mode_status_transport_without_client(self) -> None:
+        """LOCAL status reads register 110 and extracts bit 14."""
+        inverter = self._local_inverter()
+        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_ON_RAW)
+
+        assert await inverter.get_green_mode_status() is True
+
+        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_OFF_RAW)
+
+        assert await inverter.get_green_mode_status() is False
+
+    @pytest.mark.asyncio
+    async def test_transport_write_failure_leaves_cache_intact(self) -> None:
+        """A failed Modbus write raises and must NOT invalidate the cache."""
+        inverter = self._local_inverter()
+        inverter.read_transport_register = AsyncMock(return_value=self.GREEN_OFF_RAW)
+        inverter.write_transport_register = AsyncMock(return_value=False)
+        cache_time = datetime.now()
+        inverter._parameters_cache_time = cache_time
+
+        with pytest.raises(LuxpowerDeviceError, match="requires a successful Modbus write"):
+            await inverter.enable_green_mode()
+
+        assert inverter._parameters_cache_time is cache_time
+
+    @pytest.mark.asyncio
+    async def test_enable_green_mode_cloud(self, mock_client: LuxpowerClient) -> None:
+        """Cloud enable drives the named FUNC_GREEN_EN function-control bit."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_client.api.control = Mock()
+        mock_response = Mock()
+        mock_response.success = True
+        mock_client.api.control.control_function = AsyncMock(return_value=mock_response)
+        inverter._parameters_cache_time = datetime.now()
+
+        result = await inverter.enable_green_mode()
+
+        assert result is True
+        mock_client.api.control.control_function.assert_called_once_with(
+            "1234567890", "FUNC_GREEN_EN", True
+        )
+        assert inverter._parameters_cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_disable_green_mode_cloud(self, mock_client: LuxpowerClient) -> None:
+        """Cloud disable drives the named FUNC_GREEN_EN function-control bit."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_client.api.control = Mock()
+        mock_response = Mock()
+        mock_response.success = True
+        mock_client.api.control.control_function = AsyncMock(return_value=mock_response)
+
+        result = await inverter.disable_green_mode()
+
+        assert result is True
+        mock_client.api.control.control_function.assert_called_once_with(
+            "1234567890", "FUNC_GREEN_EN", False
+        )
+
+    @pytest.mark.asyncio
+    async def test_enable_green_mode_cloud_rejection_keeps_cache(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A cloud-rejected write returns False and keeps the cache."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_client.api.control = Mock()
+        mock_response = Mock()
+        mock_response.success = False
+        mock_client.api.control.control_function = AsyncMock(return_value=mock_response)
+        cache_time = datetime.now()
+        inverter._parameters_cache_time = cache_time
+
+        result = await inverter.enable_green_mode()
+
+        assert result is False
+        assert inverter._parameters_cache_time is cache_time
+
+    @pytest.mark.asyncio
+    async def test_get_green_mode_status_cloud(self, mock_client: LuxpowerClient) -> None:
+        """Cloud status reads register 110 and extracts the named parameter."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_client.api.control = Mock()
+        mock_response = Mock()
+        mock_response.parameters = {"FUNC_GREEN_EN": True}
+        mock_client.api.control.read_parameters = AsyncMock(return_value=mock_response)
+
+        assert await inverter.get_green_mode_status() is True
+        mock_client.api.control.read_parameters.assert_called_once_with("1234567890", 110, 1)
+
+    @pytest.mark.asyncio
+    async def test_green_mode_no_transport_no_client_raises_device_error(self) -> None:
+        """Neither transport nor client -> clear LuxpowerDeviceError, not AttributeError."""
+        inverter = ConcreteInverter(
+            client=None,
+            serial_number="1234567890",
+            model="TestModel",
+        )
+
+        with pytest.raises(LuxpowerDeviceError, match="transport or a cloud client"):
+            await inverter.enable_green_mode()
+        with pytest.raises(LuxpowerDeviceError, match="transport or a cloud client"):
+            await inverter.get_green_mode_status()


### PR DESCRIPTION
Fixes #243.

## The bug

`BaseInverter.enable_green_mode`, `disable_green_mode` and `get_green_mode_status` dereferenced `self._client.api` unconditionally. Transport-created LOCAL instances are built with `client=None` (`from_modbus_transport` / `from_dongle_transport` pass a placeholder), so all three raised `AttributeError: 'NoneType' object has no attribute 'api'` — even though #476 pinned `FUNC_GREEN_EN` to register 110 bit 14 and local reads and writes work fine.

## The fix

All three helpers now take the library's established dual path. **Register 110 bit 14** throughout — bit 8 was the historical wrong mapping and appears nowhere.

**Route contract:** an instance that HAS a cloud client uses the cloud route even when a transport is attached; a clientless instance with a transport uses the local route. Public signatures are unchanged.

That direction matters and is the second thing this PR fixes. The first attempt routed transport-first, which silently broke the Home Assistant integration's HYBRID cloud fallback: the integration passes these very methods as its *cloud* retry after a local failure, and in HYBRID the local transport is attached to the same cloud-created inverter object — so the "cloud" retry would have re-issued the local write that had just failed. Reproduced with zero `control_function` calls before the correction.

Instance shapes, before and after:

| shape | before | after |
|---|---|---|
| client, no transport (CLOUD) | cloud | cloud — unchanged |
| transport, no client (LOCAL) | **AttributeError** | local, lock-held RMW |
| client + transport (HYBRID) | cloud | cloud — preserved |
| neither | AttributeError | `LuxpowerDeviceError` |

There is no pure-LOCAL-with-client shape to regress: every transport-created inverter is clientless, and HYBRID inverters are HTTP-discovered client-bearing objects with a transport attached afterwards. The two are disjoint.

## Atomicity

The local write goes through `transport.write_named_parameters`, whose operation lock spans the complete read-modify-write on every transport a clientless inverter can be built from. The first attempt used a helper that awaited the read and the write separately, releasing the lock between them — demonstrated losing battery-ECO bit 15 under a concurrent update (`0x8080` then a stale `0x4080`).

Worth recording for future maintainers: the atomicity guarantee is a property of the transport *subclasses*, not of `write_named_parameters` itself, and the strengthened bit-preservation fixtures do **not** catch a non-atomic regression — the non-atomic path emits an identical single-register call. `test_local_green_write_is_atomic_with_concurrent_eco_update` is the sole guard on it.

## Testing

`ruff` clean, `mypy --strict` clean (94 files), `pytest tests/unit/` → 2820 passed.

Bit-preservation fixtures now carry bits 5, 7, 10 and 15 so selective clobbering fails; review confirmed a bit-8 substitution is caught four ways and could not construct a passing mutation.

## Scope

This closes green mode only. Seven sibling bit controls (`enable_battery_backup`, `enable_feed_in_grid`, `enable_ac_charge_mode`, and others) still dereference the cloud client unconditionally and crash the same way on clientless instances — filed as #247. The integration is unaffected by those, since its switches read from the coordinator cache and write via `_execute_named_parameter_action`.

Reviewed by gpt-5.6-sol, gemini-3.1-pro and Claude Opus; the route-contract regression and the non-atomic RMW were both found by that gate, not by CI.