### PR TITLE
fix: reject truncated register responses on the battery RS485 transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Battery RS485 transport now rejects truncated register responses**:
+  `BatteryModbusTransport._read_registers` returned however many registers
+  pymodbus decoded from the response's own byte count, with no check against
+  the requested count — the same hole closed on the inverter transports in
+  [#203](https://github.com/joyfulhouse/pylxpweb/pull/203). A short read was
+  decoded as if complete, silently producing wrong battery values (e.g. half
+  a cell-voltage block feeding min/max cell voltage). A short response is now
+  treated like any other failed read for that unit/block: the runtime block
+  fails the unit for that cycle and an extra block is skipped whole, so data
+  is absent rather than wrong, and the next full read recovers normally (no
+  latching — battery block sizes are protocol-fixed, so a short read is
+  truncation, not a firmware-capability signature).
 - **Green mode device helpers work without a cloud client**
   ([#243](https://github.com/joyfulhouse/pylxpweb/issues/243)):
   `BaseInverter.enable_green_mode`, `disable_green_mode` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pymodbus decoded from the response's own byte count, with no check against
   the requested count — the same hole closed on the inverter transports in
   [#203](https://github.com/joyfulhouse/pylxpweb/pull/203). A short read was
+  decoded as if complete, silently producing wrong battery values. A short
+  response is now treated like any other failed read: the runtime block fails
+  the unit for that cycle, and an extra block is dropped whole rather than
+  partially decoded. The next full read recovers normally (no latching —
+  battery block sizes are protocol-fixed, so a short read is truncation, not
+  a firmware-capability signature).
+
+  Dropping a block whole is not the same as reporting no data. `BatteryData`
+  has no nullable cell fields, so a dropped master cell block (regs 113-128)
+  still yields `cell_voltages` of sixteen 0.000 V entries — and, where the
+  dedicated max/min cell registers 37/38 read zero, a 0 V min/max. That is
+  the intended trade: a plausible wrong min/max computed over the surviving
+  fragment is replaced by an implausible 0.0, which is far easier to spot.
+
+  The guard also closes a latent cache-poisoning path. `detect_protocol`
+  classifies a unit as master when at most 2 of registers 0-18 are non-zero,
+  and `_get_protocol` caches that verdict for the life of the transport. A
+  runtime read truncated inside that range made a slave look like a master
+  permanently, so every later read of that unit decoded against the wrong
+  register map. Truncated reads now return before detection is reached.
+
+- **Battery RS485 runtime read no longer discards slaves that clamp the
+  read**: the 42-register initial runtime read is a speculative union of both
+  maps — the master map runs to reg 41, the slave map only to reg 38 — so on
+  every slave 3 registers are requested that are never decoded. A BMS that
+  range-clamps a read past its last implemented register instead of answering
+  ILLEGAL DATA ADDRESS would have had a fully decodable 39-register response
+  rejected wholesale, every cycle, turning a working battery into a
+  permanently missing one. The initial read now requires only what the
+  detected protocol actually decodes (39 for slave, 42 for master, derived
+  from the protocol register maps); extra blocks keep the strict
+  requested-count check, since those sizes are protocol-fixed. The floor
+  stays above the 0-18 detection range, so protocol detection still only ever
+  runs on complete data.
   decoded as if complete, silently producing wrong battery values (e.g. half
   a cell-voltage block feeding min/max cell voltage). A short response is now
   treated like any other failed read for that unit/block: the runtime block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a firmware-capability signature).
 
   Dropping a block whole is not the same as reporting no data. `BatteryData`
-  has no nullable numerics and consumers publish them directly (the Home
+  has no nullable cell fields and consumers publish them directly (the Home
   Assistant integration maps them straight onto sensors), so a dropped master
   cell block (regs 113-128) reaches users as readings, not as unavailable.
   It yields `cell_voltages` of sixteen 0.000 V entries; a 0 V min/max
@@ -45,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `_get_protocol` caches that verdict for the life of the transport. A
   runtime read truncated inside that range made a slave look like a master
   permanently, so every later read of that unit decoded against the wrong
-  register map. Truncated reads now return before detection is reached.
+  register map. A read truncated inside registers 0-18 now returns before
+  detection is reached.
 
 - **Battery RS485 runtime read no longer discards slaves that clamp the
   read**: the 42-register initial runtime read is a speculative union of both
@@ -57,6 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   permanently missing one. The initial read now requires only what the
   detected protocol actually decodes (39 for slave, 42 for master, derived
   from the protocol register maps); extra blocks keep the strict
+  requested-count check, since those sizes are protocol-fixed. The floor is
+  itself clamped to at least the 0-18 detection range, so protocol detection
+  only ever runs on data complete through register 18 — a master clamped to
+  39-41 registers is still detected, then rejected against its own
+  requirement.
   requested-count check, since those sizes are protocol-fixed. The floor
   stays above the 0-18 detection range, so protocol detection still only ever
   runs on complete data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a firmware-capability signature).
 
   Dropping a block whole is not the same as reporting no data. `BatteryData`
-  has no nullable cell fields, so a dropped master cell block (regs 113-128)
-  still yields `cell_voltages` of sixteen 0.000 V entries — and, where the
-  dedicated max/min cell registers 37/38 read zero, a 0 V min/max. That is
-  the intended trade: a plausible wrong min/max computed over the surviving
-  fragment is replaced by an implausible 0.0, which is far easier to spot.
+  has no nullable numerics and consumers publish them directly (the Home
+  Assistant integration maps them straight onto sensors), so a dropped master
+  cell block (regs 113-128) reaches users as readings, not as unavailable.
+  It yields `cell_voltages` of sixteen 0.000 V entries; a 0 V min/max
+  wherever the dedicated max/min cell registers 37/38 also read zero; and,
+  through `decode_with_slaves`, a master voltage that reverts to register 22
+  — the bank MINIMUM, not the master's own sum-of-cells.
+
+  The first two are implausible enough to notice, which is the intended
+  trade: a plausible wrong min/max computed over the surviving fragment is
+  replaced by an obvious 0.0. The voltage fallback goes the other way — it
+  swaps an obviously wrong fragment sum for a plausible number that is
+  silently the wrong quantity. Dropping the block is still the right call,
+  but it buys detectability, not correctness. Beyond a DEBUG log line the
+  library gives callers no signal that a block was dropped; bounded per-unit
+  health reporting is tracked in
+  [#248](https://github.com/joyfulhouse/pylxpweb/issues/248).
 
   The guard also closes a latent cache-poisoning path. `detect_protocol`
   classifies a unit as master when at most 2 of registers 0-18 are non-zero,

--- a/src/pylxpweb/transports/battery_modbus.py
+++ b/src/pylxpweb/transports/battery_modbus.py
@@ -206,7 +206,7 @@ class BatteryModbusTransport:
             # holding-register paths on the inverter transports, #203).
             #
             # Rejecting a block does not make its fields absent: BatteryData
-            # has no nullable numerics, so a dropped block reads out as
+            # has no nullable cell fields, so a dropped block reads out as
             # zeroes or as whatever fallback the protocol has. See the note
             # on _read_unit_raw. Callers get no signal beyond this DEBUG
             # line; per-unit health reporting is pylxpweb#248.
@@ -377,7 +377,7 @@ class BatteryModbusTransport:
         Note:
             An extra block that fails is dropped whole rather than partially
             decoded, but "dropped" is not "absent" — ``BatteryData`` has no
-            nullable numerics, and consumers publish these fields directly.
+            nullable cell fields, and consumers publish these fields directly.
             For the master cell block (113-128) that means sixteen 0.000 V
             cells, a 0 V min/max wherever regs 37/38 also read zero, and --
             via ``decode_with_slaves`` -- a master voltage that quietly

--- a/src/pylxpweb/transports/battery_modbus.py
+++ b/src/pylxpweb/transports/battery_modbus.py
@@ -147,7 +147,23 @@ class BatteryModbusTransport:
             )
             if result.isError():
                 return None
-            return list(result.registers)
+            registers = list(result.registers)
+            # pymodbus decodes registers from the response's own byte_count
+            # and never checks it against the requested count, so a truncated
+            # response returns a short list without error and would be
+            # decoded as if complete, producing wrong battery values.
+            # Reject it like any other failed read (same guard as the
+            # holding-register paths on the inverter transports, #203).
+            if len(registers) < count:
+                _LOGGER.debug(
+                    "Short read: unit=%d start=%d expected %d registers, got %d",
+                    unit_id,
+                    start,
+                    count,
+                    len(registers),
+                )
+                return None
+            return registers
         except Exception:
             _LOGGER.debug("Read failed: unit=%d start=%d count=%d", unit_id, start, count)
             return None

--- a/src/pylxpweb/transports/battery_modbus.py
+++ b/src/pylxpweb/transports/battery_modbus.py
@@ -204,6 +204,12 @@ class BatteryModbusTransport:
             # decoded as if complete, producing wrong battery values.
             # Reject it like any other failed read (same guard as the
             # holding-register paths on the inverter transports, #203).
+            #
+            # Rejecting a block does not make its fields absent: BatteryData
+            # has no nullable numerics, so a dropped block reads out as
+            # zeroes or as whatever fallback the protocol has. See the note
+            # on _read_unit_raw. Callers get no signal beyond this DEBUG
+            # line; per-unit health reporting is pylxpweb#248.
             if len(registers) < required:
                 _LOGGER.debug(
                     "Short read: unit=%d start=%d expected %d registers, got %d",
@@ -367,6 +373,19 @@ class BatteryModbusTransport:
         Returns:
             Tuple of (raw_registers, decoded_data). Raw registers are always
             returned (may be empty). Decoded data is None on read failure.
+
+        Note:
+            An extra block that fails is dropped whole rather than partially
+            decoded, but "dropped" is not "absent" — ``BatteryData`` has no
+            nullable numerics, and consumers publish these fields directly.
+            For the master cell block (113-128) that means sixteen 0.000 V
+            cells, a 0 V min/max wherever regs 37/38 also read zero, and --
+            via ``decode_with_slaves`` -- a master voltage that quietly
+            reverts to reg 22, the bank MINIMUM rather than the master's own
+            sum-of-cells. The first two are implausible enough to notice; the
+            last is not. Dropping the block is still right (a min/max computed
+            over half a cell block is plausible AND wrong), but it buys
+            detectability, not correctness.
         """
         runtime_regs = await self._read_registers(
             0, _INITIAL_BLOCK_COUNT, unit_id, minimum=_MIN_INITIAL_REGISTERS

--- a/src/pylxpweb/transports/battery_modbus.py
+++ b/src/pylxpweb/transports/battery_modbus.py
@@ -30,8 +30,18 @@ from pylxpweb.transports.data import BatteryData, InverterRuntimeData
 
 _LOGGER = logging.getLogger(__name__)
 
-# Number of registers to read for initial runtime block (covers both protocols)
+# Number of registers to read for initial runtime block (covers both protocols).
+# This is a speculative union read issued before the protocol is known: the
+# master map runs to reg 41, the slave map only to reg 38, so on every slave
+# 3 of these registers are requested but never decoded.
 _INITIAL_BLOCK_COUNT = 42
+
+# Registers 0-18 decide master vs slave in ``detect_protocol``. A runtime read
+# shorter than this must never reach detection: a truncated slave looks like a
+# master (all-zero early registers) and the result is cached for the life of
+# the transport. Both protocols need well past this, so it is a floor, not the
+# acceptance threshold.
+_DETECTION_REGISTER_COUNT = 19
 
 # Small delay between sequential register reads to avoid bus congestion (seconds)
 _INTER_READ_DELAY = 0.1
@@ -44,6 +54,36 @@ _PROTOCOL_MAP: dict[str, type[BatteryProtocol]] = {
     "eg4_master": EG4MasterProtocol,
     "eg4_slave": EG4SlaveProtocol,
 }
+
+
+def _initial_block_requirement(protocol: BatteryProtocol) -> int:
+    """Registers a protocol actually decodes out of the initial runtime read.
+
+    Derived from the protocol's own blocks so it tracks map changes: the
+    master runtime block ends at reg 41 (42 registers), the slave's at reg 38
+    (39). Blocks that start past the initial read (master cells 113-128,
+    slave info 105-127) are fetched separately and excluded here.
+
+    Args:
+        protocol: Protocol whose register map defines the requirement.
+
+    Returns:
+        Minimum number of registers the initial read must return for this
+        protocol to decode without holes.
+    """
+    return max(
+        (b.start + b.count for b in protocol.register_blocks if b.start < _INITIAL_BLOCK_COUNT),
+        default=_DETECTION_REGISTER_COUNT,
+    )
+
+
+# Least any candidate protocol needs from the initial read. Accepting down to
+# this instead of the full union avoids discarding a decodable slave, and the
+# detected protocol's own requirement is re-checked afterwards.
+_MIN_INITIAL_REGISTERS = max(
+    _DETECTION_REGISTER_COUNT,
+    min(_initial_block_requirement(cls()) for cls in _PROTOCOL_MAP.values()),
+)
 
 
 class BatteryModbusTransport:
@@ -128,19 +168,29 @@ class BatteryModbusTransport:
             self._client.close()
         self._connected = False
 
-    async def _read_registers(self, start: int, count: int, unit_id: int) -> list[int] | None:
+    async def _read_registers(
+        self,
+        start: int,
+        count: int,
+        unit_id: int,
+        minimum: int | None = None,
+    ) -> list[int] | None:
         """Read holding registers from a battery unit.
 
         Args:
             start: First register address to read.
             count: Number of contiguous registers to read.
             unit_id: Modbus unit/slave ID.
+            minimum: Registers that must come back for the response to be
+                usable. Defaults to ``count``; pass a lower value only when
+                the request deliberately over-reads what will be decoded.
 
         Returns:
-            List of register values, or None on error/timeout.
+            List of register values, or None on error/timeout/short read.
         """
         if not self._client:
             return None
+        required = count if minimum is None else minimum
         try:
             result = await self._client.read_holding_registers(
                 start, count=count, device_id=unit_id
@@ -154,12 +204,12 @@ class BatteryModbusTransport:
             # decoded as if complete, producing wrong battery values.
             # Reject it like any other failed read (same guard as the
             # holding-register paths on the inverter transports, #203).
-            if len(registers) < count:
+            if len(registers) < required:
                 _LOGGER.debug(
                     "Short read: unit=%d start=%d expected %d registers, got %d",
                     unit_id,
                     start,
-                    count,
+                    required,
                     len(registers),
                 )
                 return None
@@ -318,12 +368,32 @@ class BatteryModbusTransport:
             Tuple of (raw_registers, decoded_data). Raw registers are always
             returned (may be empty). Decoded data is None on read failure.
         """
-        runtime_regs = await self._read_registers(0, _INITIAL_BLOCK_COUNT, unit_id)
+        runtime_regs = await self._read_registers(
+            0, _INITIAL_BLOCK_COUNT, unit_id, minimum=_MIN_INITIAL_REGISTERS
+        )
         if runtime_regs is None:
             return {}, None
 
         raw: dict[int, int] = dict(enumerate(runtime_regs))
+        # Safe to detect: the guard above guarantees registers 0-18 are all
+        # present, so a truncated response can no longer be cached as the
+        # wrong protocol for the life of the transport.
         protocol = self._get_protocol(unit_id, raw)
+
+        # A BMS that range-clamps a read past its last implemented register
+        # (rather than answering ILLEGAL DATA ADDRESS) returns a slave's full
+        # 39 registers for the 42 requested. That is complete data, so it is
+        # only rejected when the detected protocol needs the missing tail.
+        required = _initial_block_requirement(protocol)
+        if len(runtime_regs) < required:
+            _LOGGER.debug(
+                "Short runtime read: unit=%d protocol=%s needs %d registers, got %d",
+                unit_id,
+                protocol.name,
+                required,
+                len(runtime_regs),
+            )
+            return {}, None
 
         for block in protocol.register_blocks:
             if block.start >= _INITIAL_BLOCK_COUNT:

--- a/tests/unit/transports/test_battery_modbus.py
+++ b/tests/unit/transports/test_battery_modbus.py
@@ -598,6 +598,10 @@ class TestBatteryModbusTransportShortRead:
         min/max fallback.  That is the point of the guard — it trades a
         plausible wrong min/max computed over the surviving fragment for
         an implausible 0.0, and implausible-wrong is far easier to spot.
+
+        That trade does not hold for every field:
+        ``test_dropped_cell_block_falls_back_to_bank_minimum_voltage``
+        pins one that moves the other way.
         """
         master_regs = _make_master_regs()
         short_cell_regs = [3310] * 8  # 8 of 16 requested
@@ -724,6 +728,46 @@ class TestBatteryModbusTransportShortRead:
 
         assert await connected_transport.read_unit(1) is None
         assert connected_transport._detected_protocols[1].name == "eg4_master"
+
+    @pytest.mark.asyncio
+    async def test_dropped_cell_block_falls_back_to_bank_minimum_voltage(self) -> None:
+        """A dropped cell block silently reverts master voltage to reg 22.
+
+        ``decode_with_slaves`` normally overrides reg 22 (the MINIMUM
+        across all batteries) with the sum of the master's own cells,
+        because reg 22 is not the master's individual voltage.  A
+        dropped cell block leaves ``cell_voltages`` as sixteen zeros —
+        which is a *truthy* list, so the override branch is entered and
+        then abandoned on ``cell_sum > 0``.  Voltage falls back to the
+        bank minimum.
+
+        Unlike the zeroed cells, this one is a plausible-looking number:
+        the guard makes this field *less* detectable, not more, and it
+        is pinned here so that trade is visible rather than assumed.
+        """
+
+        async def read(cell_regs: list[int]) -> BatteryData:
+            transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1, 2])
+            transport._client = AsyncMock()
+            transport._client.close = MagicMock()
+            transport._connected = True
+            transport._client.read_holding_registers = AsyncMock(
+                side_effect=[
+                    _mock_result(_make_master_regs()),  # unit 1 runtime
+                    _mock_result(cell_regs),  # unit 1 cells (113-128)
+                    _mock_result(_make_slave_regs()),  # unit 2 runtime
+                    _mock_result([0] * 23),  # unit 2 info block
+                ],
+            )
+            return (await transport.read_all())[0]
+
+        # Full block: master voltage is the sum of its own 16 cells.
+        assert (await read([3310] * 16)).voltage == pytest.approx(52.96)
+
+        # Short block: falls back to reg 22 = 5294, the bank minimum.
+        # Without the guard this would be the 8-cell fragment sum, 26.48 —
+        # wrong, but obviously so.
+        assert (await read([3310] * 8)).voltage == pytest.approx(52.94)
 
 
 class TestInitialBlockRequirement:

--- a/tests/unit/transports/test_battery_modbus.py
+++ b/tests/unit/transports/test_battery_modbus.py
@@ -524,6 +524,105 @@ class TestBatteryModbusTransportReadRegisters:
         result = await connected_transport._read_registers(0, 3, 1)
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_read_registers_short_read_returns_none(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """A response with fewer registers than requested is rejected (#203).
+
+        pymodbus decodes from the response's own byte_count without
+        checking it against the requested count, so a truncated frame
+        returns a short list without error.  The transport must treat
+        that as a failed read, never as data.
+        """
+        mock_result = MagicMock()
+        mock_result.isError.return_value = False
+        mock_result.registers = [100] * 20  # 20 of 42 requested
+
+        connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
+            return_value=mock_result,
+        )
+
+        result = await connected_transport._read_registers(0, 42, 2)
+        assert result is None
+
+
+class TestBatteryModbusTransportShortRead:
+    """End-to-end tests for short-read rejection on unit reads."""
+
+    @pytest.mark.asyncio
+    async def test_read_unit_short_runtime_block_returns_none(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """A truncated runtime block fails the whole unit read.
+
+        Without the short-read guard the 20-register fragment would be
+        decoded as a complete 42-register block, producing a BatteryData
+        with silently wrong values.
+        """
+        short_regs = _make_slave_regs()[:20]  # truncated mid-block
+        mock_result = MagicMock()
+        mock_result.isError.return_value = False
+        mock_result.registers = short_regs
+
+        connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
+            return_value=mock_result,
+        )
+
+        data = await connected_transport.read_unit(2)
+        assert data is None
+
+    @pytest.mark.asyncio
+    async def test_read_unit_short_extra_block_skips_block(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """A truncated extra block is skipped, never partially decoded.
+
+        Without the guard, a short master cell-voltage read (8 of 16
+        registers) would populate half the cells with real-looking
+        values and leave the rest at zero — min/max cell voltage would
+        then be computed over the fragment.  With the guard the block
+        is dropped entirely: absent data, not wrong data.
+        """
+        master_regs = _make_master_regs()
+        short_cell_regs = [3310] * 8  # 8 of 16 requested
+
+        connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
+            side_effect=[
+                _mock_result(master_regs),  # runtime block, full
+                _mock_result(short_cell_regs),  # cell block 113-128, short
+            ],
+        )
+
+        data = await connected_transport.read_unit(1)
+        assert data is not None
+        # Cell block dropped: no partial cell voltages leak into min/max
+        assert data.max_cell_voltage == 0.0
+        assert data.min_cell_voltage == 0.0
+
+    @pytest.mark.asyncio
+    async def test_read_unit_recovers_after_short_read(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """A short read is transient: the next full read succeeds normally."""
+        full_regs = _make_slave_regs()
+        short_result = MagicMock()
+        short_result.isError.return_value = False
+        short_result.registers = full_regs[:20]
+
+        connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
+            side_effect=[
+                short_result,  # first runtime read: truncated
+                _mock_result(full_regs),  # second runtime read: full
+                _mock_result([0] * 23),  # slave info block 105-127
+            ],
+        )
+
+        assert await connected_transport.read_unit(2) is None
+        data = await connected_transport.read_unit(2)
+        assert data is not None
+        assert data.voltage == pytest.approx(52.94)
+
 
 def _make_slave_regs(soc: int = 80, remaining: int = 224) -> list[int]:
     """Build a minimal slave register set (42 regs).

--- a/tests/unit/transports/test_battery_modbus.py
+++ b/tests/unit/transports/test_battery_modbus.py
@@ -6,7 +6,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from pylxpweb.transports.battery_modbus import BatteryModbusTransport
+from pylxpweb.battery_protocols.eg4_master import EG4MasterProtocol
+from pylxpweb.battery_protocols.eg4_slave import EG4SlaveProtocol
+from pylxpweb.transports.battery_modbus import (
+    _INITIAL_BLOCK_COUNT,
+    _MIN_INITIAL_REGISTERS,
+    _PROTOCOL_MAP,
+    BatteryModbusTransport,
+    _initial_block_requirement,
+)
 from pylxpweb.transports.data import BatteryData, InverterRuntimeData
 
 
@@ -576,13 +584,20 @@ class TestBatteryModbusTransportShortRead:
     async def test_read_unit_short_extra_block_skips_block(
         self, connected_transport: BatteryModbusTransport
     ) -> None:
-        """A truncated extra block is skipped, never partially decoded.
+        """A truncated extra block is dropped whole, never partially decoded.
 
         Without the guard, a short master cell-voltage read (8 of 16
         registers) would populate half the cells with real-looking
         values and leave the rest at zero — min/max cell voltage would
-        then be computed over the fragment.  With the guard the block
-        is dropped entirely: absent data, not wrong data.
+        then be computed over the fragment.
+
+        The block being dropped does not make the cells absent:
+        ``BatteryData`` has no nullable cell fields, so cell_count (reg
+        41, from the runtime block) still yields sixteen 0.000 V cells
+        and, with the dedicated max/min registers 37/38 unset, a 0 V
+        min/max fallback.  That is the point of the guard — it trades a
+        plausible wrong min/max computed over the surviving fragment for
+        an implausible 0.0, and implausible-wrong is far easier to spot.
         """
         master_regs = _make_master_regs()
         short_cell_regs = [3310] * 8  # 8 of 16 requested
@@ -599,6 +614,8 @@ class TestBatteryModbusTransportShortRead:
         # Cell block dropped: no partial cell voltages leak into min/max
         assert data.max_cell_voltage == 0.0
         assert data.min_cell_voltage == 0.0
+        # ...and the dropped block reads out as zeroed cells, not as absence.
+        assert data.cell_voltages == [0.0] * 16
 
     @pytest.mark.asyncio
     async def test_read_unit_recovers_after_short_read(
@@ -622,6 +639,108 @@ class TestBatteryModbusTransportShortRead:
         data = await connected_transport.read_unit(2)
         assert data is not None
         assert data.voltage == pytest.approx(52.94)
+
+    @pytest.mark.asyncio
+    async def test_short_read_does_not_poison_protocol_cache(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """A truncated read never reaches protocol detection.
+
+        ``detect_protocol`` calls a unit a master when at most 2 of
+        registers 0-18 are non-zero, and ``_get_protocol`` caches the
+        verdict permanently.  A slave truncated to its first 2 registers
+        therefore looks exactly like a master, and every later read of
+        that unit would decode against the wrong register map for the
+        life of the transport.  The guard returns before detection runs.
+        """
+        full_regs = _make_slave_regs()
+        truncated = MagicMock()
+        truncated.isError.return_value = False
+        truncated.registers = full_regs[:2]  # 2 of 42 -> would detect as master
+
+        connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
+            side_effect=[
+                truncated,
+                _mock_result(full_regs),
+                _mock_result([0] * 23),  # slave info block 105-127
+            ],
+        )
+
+        assert await connected_transport.read_unit(2) is None
+        assert connected_transport._detected_protocols == {}
+
+        # The next clean read detects the unit correctly.
+        data = await connected_transport.read_unit(2)
+        assert data is not None
+        assert connected_transport._detected_protocols[2].name == "eg4_slave"
+
+    @pytest.mark.asyncio
+    async def test_slave_accepts_clamped_runtime_read(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """A BMS that clamps the read to its own map still decodes.
+
+        The 42-register runtime read is sized for the master map; the
+        slave map ends at reg 38.  A BMS that range-clamps a read past
+        its last implemented register instead of raising ILLEGAL DATA
+        ADDRESS returns 39 registers — everything the slave decodes.
+        Rejecting that would delete a working battery every cycle.
+        """
+        clamped = MagicMock()
+        clamped.isError.return_value = False
+        clamped.registers = _make_slave_regs()[:39]  # 39 of 42, slave map complete
+
+        connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
+            side_effect=[
+                clamped,
+                _mock_result([0] * 23),  # slave info block 105-127
+            ],
+        )
+
+        data = await connected_transport.read_unit(2)
+        assert data is not None
+        assert data.voltage == pytest.approx(52.94)
+        assert data.soc == 80
+        assert data.cell_count == 16
+
+    @pytest.mark.asyncio
+    async def test_master_rejects_runtime_read_short_of_its_map(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """The relaxed floor does not let a truncated master through.
+
+        39 registers satisfy the slave map but cut the master's map off
+        at reg 38, dropping num_cells (41) and the min/max cell indices
+        (39/40).  Detection still runs on complete data, so the unit is
+        correctly identified and then rejected for the cycle.
+        """
+        truncated = MagicMock()
+        truncated.isError.return_value = False
+        truncated.registers = _make_master_regs()[:39]  # master needs all 42
+
+        connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
+            return_value=truncated,
+        )
+
+        assert await connected_transport.read_unit(1) is None
+        assert connected_transport._detected_protocols[1].name == "eg4_master"
+
+
+class TestInitialBlockRequirement:
+    """The initial runtime read must cover every protocol's runtime block."""
+
+    def test_requirement_matches_each_protocol_map(self) -> None:
+        """Requirements are derived from the maps, not hardcoded guesses."""
+        assert _initial_block_requirement(EG4SlaveProtocol()) == 39  # regs 0-38
+        assert _initial_block_requirement(EG4MasterProtocol()) == 42  # regs 0-41
+
+    def test_union_read_covers_all_protocols(self) -> None:
+        """_INITIAL_BLOCK_COUNT is the union; the floor is the smallest map."""
+        requirements = [_initial_block_requirement(cls()) for cls in _PROTOCOL_MAP.values()]
+        assert max(requirements) == _INITIAL_BLOCK_COUNT
+        assert min(requirements) == _MIN_INITIAL_REGISTERS
+        # Detection reads registers 0-18; the floor must never dip below it.
+        assert _MIN_INITIAL_REGISTERS >= 19
 
 
 def _make_slave_regs(soc: int = 80, remaining: int = 224) -> list[int]:

--- a/tests/unit/transports/test_battery_modbus.py
+++ b/tests/unit/transports/test_battery_modbus.py
@@ -6,9 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from pylxpweb.battery_protocols.detection import _DETECTION_RANGE_END
 from pylxpweb.battery_protocols.eg4_master import EG4MasterProtocol
 from pylxpweb.battery_protocols.eg4_slave import EG4SlaveProtocol
 from pylxpweb.transports.battery_modbus import (
+    _DETECTION_REGISTER_COUNT,
     _INITIAL_BLOCK_COUNT,
     _MIN_INITIAL_REGISTERS,
     _PROTOCOL_MAP,
@@ -708,6 +710,33 @@ class TestBatteryModbusTransportShortRead:
         assert data.cell_count == 16
 
     @pytest.mark.asyncio
+    async def test_slave_rejects_read_one_short_of_its_map(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """38 registers is one short of the slave map and must be rejected.
+
+        39 is accepted as a legitimately clamped read; 38 has genuinely lost
+        data (balance_bitmap, reg 38).  Only the accept side of that boundary
+        was covered.
+
+        This pins the end-to-end outcome, not the mechanism: rejection is
+        defence in depth.  Lowering _MIN_INITIAL_REGISTERS to 38 does NOT
+        make this test pass -- the per-protocol recheck against the slave's
+        own requirement of 39 still rejects it (only the drift test in
+        TestInitialBlockRequirement catches the lowered floor itself).  That
+        redundancy is the point: neither guard alone is load-bearing here.
+        """
+        truncated = MagicMock()
+        truncated.isError.return_value = False
+        truncated.registers = _make_slave_regs()[:38]  # slave map needs 39
+
+        connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
+            return_value=truncated,
+        )
+
+        assert await connected_transport.read_unit(2) is None
+
+    @pytest.mark.asyncio
     async def test_master_rejects_runtime_read_short_of_its_map(
         self, connected_transport: BatteryModbusTransport
     ) -> None:
@@ -784,7 +813,22 @@ class TestInitialBlockRequirement:
         assert max(requirements) == _INITIAL_BLOCK_COUNT
         assert min(requirements) == _MIN_INITIAL_REGISTERS
         # Detection reads registers 0-18; the floor must never dip below it.
-        assert _MIN_INITIAL_REGISTERS >= 19
+        # This is the load-bearing guarantee: it is the outer max() in
+        # _MIN_INITIAL_REGISTERS that enforces it, not the happenstance that
+        # today's smallest map (39) already exceeds 19.  A protocol with a
+        # short map added later would drag min() down, and detection would
+        # still be safe.
+        assert _MIN_INITIAL_REGISTERS >= _DETECTION_REGISTER_COUNT
+
+    def test_detection_floor_tracks_the_detection_range(self) -> None:
+        """The transport's copy of the detection range must not drift.
+
+        battery_modbus mirrors detection's range as its own constant.  If
+        detection widens its range and this copy is not updated, the floor
+        silently stops guaranteeing detection sees complete data -- the exact
+        safety property the relaxed floor rests on.
+        """
+        assert _DETECTION_REGISTER_COUNT == _DETECTION_RANGE_END
 
 
 def _make_slave_regs(soc: int = 80, remaining: int = 224) -> list[int]:


### PR DESCRIPTION
`BatteryModbusTransport._read_registers` returned `list(result.registers)` without checking the count against the request. pymodbus decodes from the response's own `byte_count` and never compares it to what was asked for, so a truncated response came back as a short list with no error and was decoded as if complete — producing **wrong battery values**, not an error.

Every other transport in this library got this guard in PR #203; this one was written later and missed it.

## What a truncated read actually did

Concretely, an 8-of-16 truncated master cell block yielded a `max_cell_voltage` of 3.31 V computed over the surviving fragment. If cell 12 were the low cell at 3.05 V, the reported minimum would have been 3.31 V and the imbalance would have been masked entirely.

It also poisoned protocol detection **permanently**: `detect_protocol` classifies a unit as master when at most 2 of registers 0-18 are non-zero, and `_get_protocol` caches that verdict for the life of the transport with no eviction path. A read truncated inside that range made a slave look like a master forever, so every later read of that unit decoded against the wrong register map. Verified by execution: after reverting the guard, the next *clean* read of the real slave still decoded as master, reporting `voltage 0.0 / soc 0`.

## The guard

Rejected like any other failed read — DEBUG line, return `None`. Deliberately not a raise: this function has no retry loop (unlike `_ModbusBase._read_registers`, which raises only after exhausting one), and `read_unit()` / `read_all()` both document non-raising behaviour, so a raise would escape on the first transient blip and abort discovery of every later unit. There is direct precedent for the idiom in `_register_data.py`, which rejects a short `bms_data` read the same way (#261).

No latching. Battery block sizes are protocol-fixed and never coalesced, so a short read here is truncation, not the firmware-capability signature that justifies latching elsewhere.

## Not rejecting reads that are legitimately clamped

The 42-register initial read is a speculative union of both maps — master runs to reg 41, slave only to reg 38. A BMS that range-clamps past its last implemented register instead of answering ILLEGAL DATA ADDRESS returns 39 registers: complete slave data. A strict check would have deleted a working battery every cycle.

So the initial read accepts down to `_MIN_INITIAL_REGISTERS`, **derived** from the protocol register maps rather than hardcoded, and the detected protocol's own requirement is re-checked afterwards. Two stages: the floor gates detection, the recheck gates completeness. Extra blocks keep the strict requested-count check, since those sizes are genuinely protocol-fixed.

The floor is clamped to at least the detection range, so a short-mapped protocol added later cannot drag it below what detection inspects — and a test now ties that constant to detection's own, which it had been mirroring by hand.

## Honest scope

Dropping a block whole is **not** the same as reporting no data. `BatteryData` has no nullable cell fields, so a dropped master cell block surfaces as sixteen 0.000 V entries and — through `decode_with_slaves`, where `if data.cell_voltages:` is truthy for a list of zeros — a master voltage that reverts to register 22, the **bank minimum** (52.94 V measured, against the master's real 52.96 V).

For that one field the guard trades obvious garbage for a plausible wrong quantity. It is still the right trade — a min/max over half a cell block is plausible *and* wrong — but it buys detectability, not correctness, and not uniformly. Filed as #249.

Min/max cell voltages do **not** degrade on real hardware: registers 37/38 are the master's dedicated max/min and sit inside the runtime block, not the dropped one. The zeros an early review saw were a test-fixture artifact.

## Testing

`ruff` clean, `mypy --strict` clean (94 files), `pytest tests/unit/` → 2819 passed. 48 tests in the transport file.

Callers get no signal beyond the DEBUG line — a systematically truncating unit is currently indistinguishable from an absent one. Filed as #248 with the missing consecutive-error tracking and reconnect.

Reviewed by gpt-5.6-sol, gemini-3.1-pro and Claude Opus across three rounds; the clamped-slave regression, the cache-poisoning path and two wording over-claims all came from that gate.