### PR TITLE
fix(battery): derive master voltage from cells; escalate RS485 read failures

### DIFF
--- a/scripts/decode_master_battery.py
+++ b/scripts/decode_master_battery.py
@@ -26,6 +26,8 @@ import sys
 
 from pymodbus.client import AsyncModbusTcpClient
 
+from pylxpweb.battery_protocols.eg4_master import _derive_master_voltage
+
 
 def make_signed16(value: int) -> int:
     """Reinterpret unsigned 16-bit as signed."""
@@ -135,11 +137,10 @@ def decode_master_battery(regs: dict[int, int]) -> dict[str, object]:
     raw_21 = regs.get(21, 0)
     data["error_raw"] = raw_21
 
-    # Reg 22 (offset 0x2c): Pack voltage (÷100 for V)
-    # Firmware: minimum of all slaves' voltage + local BMS voltage
+    # Reg 22 (offset 0x2c): minimum pack voltage across the bank (÷100 for V)
     raw_22 = regs.get(22, 0)
-    data["voltage_raw"] = raw_22
-    data["voltage"] = raw_22 / 100.0
+    data["bank_min_voltage_raw"] = raw_22
+    data["bank_min_voltage"] = raw_22 / 100.0
 
     # Reg 23 (offset 0x2e): Current
     # Firmware: FUN_0001933c() × 10, capped at ±30000
@@ -242,12 +243,21 @@ def decode_master_battery(regs: dict[int, int]) -> dict[str, object]:
 
     # --- Cell voltages at register 113+ (offset 0xe2) ---
     num_cells = data["num_cells"]
+    cells: list[float] = []
     if isinstance(num_cells, int) and num_cells > 0:
-        cells = []
         for i in range(num_cells):
             cell_mv = regs.get(113 + i, 0)
             cells.append(cell_mv / 1000.0)
-        data["cell_voltages"] = cells
+    data["cell_voltages"] = cells
+    following_cell_voltage = 0.0
+    if isinstance(num_cells, int) and 0 <= num_cells < 16:
+        following_cell_voltage = regs.get(113 + num_cells, 0) / 1000.0
+    data["voltage"] = _derive_master_voltage(
+        cells,
+        num_cells if isinstance(num_cells, int) else 0,
+        bank_min_voltage=raw_22 / 100.0,
+        following_cell_voltage=following_cell_voltage,
+    )
 
     return data
 
@@ -292,7 +302,11 @@ def print_master_battery(data: dict[str, object]) -> None:
     print(f"{'=' * 72}")
 
     print("\n  --- Core Data ---")
-    print(f"  Pack Voltage:     {data['voltage']:.2f} V  (reg 22 = {data['voltage_raw']})")
+    print(f"  Pack Voltage:     {data['voltage']:.2f} V  (derived from cells)")
+    print(
+        f"  Bank Min Voltage: {data['bank_min_voltage']:.2f} V  "
+        f"(reg 22 = {data['bank_min_voltage_raw']})"
+    )
     print(f"  Current:          {data['current_cA']:.2f} A  (reg 23 = {data['current_raw']}, ÷100)")
     print(f"  Temperature:      {data['temperature']}°C  (reg 24 = {data['temperature_raw']})")
 
@@ -449,6 +463,7 @@ async def main() -> None:
             f"  T={master_data['temperature']}°C  Cycles={master_data['cycle_count']}"
             f"  Cells={master_data['num_cells']}"
         )
+        print(f"                  BankMin={master_data['bank_min_voltage']:.2f}V (reg 22)")
         print(
             f"                  MaxCell={master_data['max_cell_voltage']:.3f}V"
             f"  MinCell={master_data['min_cell_voltage']:.3f}V"

--- a/src/pylxpweb/battery_protocols/eg4_master.py
+++ b/src/pylxpweb/battery_protocols/eg4_master.py
@@ -23,6 +23,11 @@ Temperature limitations (master RS485):
   - No min temperature register exists. Probed regs 0-255; confirmed no hidden data.
   - Per-cell NTC readings are only available via CAN bus (cloud API).
   - min_cell_temperature and max_cell_temperature are both set to reg 24 value.
+
+Master pack voltage is derived only from a complete, usable cell-voltage set.
+Register 22 is a bank minimum, so it is never exposed as the master's own
+voltage; when the cells are unavailable, voltage is the explicit 0.0 absent
+sentinel instead.
 """
 
 from __future__ import annotations
@@ -42,7 +47,12 @@ _RUNTIME_REGISTERS = (
     BatteryRegister(19, "status", ScaleFactor.SCALE_NONE),
     BatteryRegister(20, "protection", ScaleFactor.SCALE_NONE),
     BatteryRegister(21, "soc", ScaleFactor.SCALE_NONE, unit="%"),
-    BatteryRegister(22, "voltage", ScaleFactor.SCALE_100, unit="V"),
+    # Named for what it is, not for the field it used to populate. Calling reg
+    # 22 "voltage" in the master's map is what let a bank aggregate be decoded
+    # as the master's own pack voltage; the name is the guardrail against a
+    # future _reg("voltage") reintroducing that (#249). Kept in the map because
+    # it is real bank data that the block still reads.
+    BatteryRegister(22, "bank_min_voltage", ScaleFactor.SCALE_100, unit="V"),
     BatteryRegister(23, "current", ScaleFactor.SCALE_100, signed=True, unit="A"),
     BatteryRegister(24, "temperature", ScaleFactor.SCALE_NONE, signed=True, unit="\u00b0C"),
     BatteryRegister(28, "firmware_version", ScaleFactor.SCALE_NONE),
@@ -61,6 +71,31 @@ _RUNTIME_REGISTERS = (
 
 _RUNTIME_BLOCK = BatteryRegisterBlock(start=19, count=23, registers=_RUNTIME_REGISTERS)
 _CELL_BLOCK = BatteryRegisterBlock(start=113, count=16, registers=())
+
+# Sanity bounds against corrupt registers, not LiFePO4 specification limits.
+_MIN_PLAUSIBLE_CELL_V = 1.0
+_MAX_PLAUSIBLE_CELL_V = 5.0
+
+
+def _derive_master_voltage(cell_voltages: list[float], cell_count: int) -> float:
+    """Derive master pack voltage from a complete, plausible cell set.
+
+    Register 22 is the minimum pack voltage across the bank, not the master's
+    own pack voltage. A missing, partial, zeroed, or corrupt cell set therefore
+    returns the schema's explicit absent sentinel rather than that aggregate.
+
+    Args:
+        cell_voltages: Decoded individual cell voltages in volts.
+        cell_count: Expected cell count from register 41.
+
+    Returns:
+        Rounded sum of all cells, or 0.0 when the cell set is unusable.
+    """
+    if cell_count <= 0 or len(cell_voltages) != cell_count:
+        return 0.0
+    if not all(_MIN_PLAUSIBLE_CELL_V <= value <= _MAX_PLAUSIBLE_CELL_V for value in cell_voltages):
+        return 0.0
+    return round(sum(cell_voltages), 2)
 
 
 class EG4MasterProtocol(BatteryProtocol):
@@ -142,6 +177,14 @@ class EG4MasterProtocol(BatteryProtocol):
     def decode(self, raw_regs: dict[int, int], battery_index: int = 0) -> BatteryData:
         """Decode master battery registers into BatteryData.
 
+        Register 22 is never used as the master's own voltage because it is
+        the minimum across the whole bank. It can look correct in a genuine
+        single-battery bank, but the protocol cannot distinguish that case
+        from a multi-battery bank whose slaves failed to read. A plausible
+        aggregate mislabeled as master data is worse than the explicit 0.0
+        absent sentinel, so only a complete plausible cell set is trusted
+        (#249).
+
         Args:
             raw_regs: Dict mapping register address to raw 16-bit value.
             battery_index: 0-based index of the battery in the bank.
@@ -149,12 +192,10 @@ class EG4MasterProtocol(BatteryProtocol):
         Returns:
             BatteryData with all values properly scaled.
         """
-        voltage_reg = self._reg("voltage")
         current_reg = self._reg("current")
         max_cell_reg = self._reg("max_cell_voltage")
         min_cell_reg = self._reg("min_cell_voltage")
 
-        voltage = self.decode_register(voltage_reg, raw_regs.get(voltage_reg.address, 0))
         current = self.decode_register(current_reg, raw_regs.get(current_reg.address, 0))
 
         temperature = float(signed_int16(raw_regs.get(24, 0)))
@@ -177,6 +218,7 @@ class EG4MasterProtocol(BatteryProtocol):
         cell_voltages, fallback_min, fallback_max = self.decode_cell_voltages(
             raw_regs, start_address=113, num_cells=num_cells
         )
+        voltage = _derive_master_voltage(cell_voltages, num_cells)
 
         # Prefer dedicated max/min cell voltage registers; fall back to computed values
         max_cell_v = self.decode_register(max_cell_reg, raw_regs.get(max_cell_reg.address, 0))
@@ -262,16 +304,9 @@ class EG4MasterProtocol(BatteryProtocol):
         master_soc = round(master_remaining / designed_ah * 100) if designed_ah > 0 else 0
         master_soc = max(0, min(100, master_soc))
 
-        # Compute master voltage from cell voltages (more accurate than reg 22 = MIN all)
-        voltage = data.voltage
-        if data.cell_voltages:
-            cell_sum = sum(data.cell_voltages)
-            if cell_sum > 0:
-                voltage = round(cell_sum, 2)
-
         return BatteryData(
             battery_index=data.battery_index,
-            voltage=voltage,
+            voltage=data.voltage,
             current=data.current,
             soc=master_soc,
             soh=data.soh,

--- a/src/pylxpweb/battery_protocols/eg4_master.py
+++ b/src/pylxpweb/battery_protocols/eg4_master.py
@@ -47,11 +47,11 @@ _RUNTIME_REGISTERS = (
     BatteryRegister(19, "status", ScaleFactor.SCALE_NONE),
     BatteryRegister(20, "protection", ScaleFactor.SCALE_NONE),
     BatteryRegister(21, "soc", ScaleFactor.SCALE_NONE, unit="%"),
-    # Named for what it is, not for the field it used to populate. Calling reg
-    # 22 "voltage" in the master's map is what let a bank aggregate be decoded
-    # as the master's own pack voltage; the name is the guardrail against a
-    # future _reg("voltage") reintroducing that (#249). Kept in the map because
-    # it is real bank data that the block still reads.
+    # Named for what it is, not for the field it used to populate. Keeping this
+    # metadata distinct makes _reg("voltage") fail instead of relabeling an
+    # aggregate as master data, and supplies the scale for the physical
+    # cross-check below (#249). Register-block start/count, not this metadata,
+    # determines what the transport reads.
     BatteryRegister(22, "bank_min_voltage", ScaleFactor.SCALE_100, unit="V"),
     BatteryRegister(23, "current", ScaleFactor.SCALE_100, signed=True, unit="A"),
     BatteryRegister(24, "temperature", ScaleFactor.SCALE_NONE, signed=True, unit="\u00b0C"),
@@ -75,27 +75,67 @@ _CELL_BLOCK = BatteryRegisterBlock(start=113, count=16, registers=())
 # Sanity bounds against corrupt registers, not LiFePO4 specification limits.
 _MIN_PLAUSIBLE_CELL_V = 1.0
 _MAX_PLAUSIBLE_CELL_V = 5.0
+# Stops a transient count such as 1 from turning a truncated prefix of the
+# fixed 16-register cell block into a pack voltage. The only EG4 pack this repo
+# documents is 16S (WP-16/280, see eg4_slave); the floor is set one below that
+# rather than at 16 so a 15S variant we have not seen is not rejected outright.
+# That looseness is deliberate and costs nothing: a 16S pack whose count is
+# corrupted to 15 is caught by the cross-checks below, not by this bound.
+_MIN_PLAUSIBLE_CELL_COUNT = 15
+_MAX_PLAUSIBLE_CELL_COUNT = _CELL_BLOCK.count
+# Reg 22 and the cell block are sampled separately. Half a volt accommodates
+# that skew while still rejecting one-or-more-cell truncation by a wide margin.
+_BANK_MIN_VOLTAGE_TOLERANCE_V = 0.5
 
 
-def _derive_master_voltage(cell_voltages: list[float], cell_count: int) -> float:
+def _derive_master_voltage(
+    cell_voltages: list[float],
+    cell_count: int,
+    bank_min_voltage: float = 0.0,
+    following_cell_voltage: float = 0.0,
+) -> float:
     """Derive master pack voltage from a complete, plausible cell set.
 
     Register 22 is the minimum pack voltage across the bank, not the master's
     own pack voltage. A missing, partial, zeroed, or corrupt cell set therefore
     returns the schema's explicit absent sentinel rather than that aggregate.
+    A genuinely collapsed cell below 1.0 V also makes the whole pack voltage
+    absent by design: cell-level canaries retain the fault signal, while a pack
+    sum containing that cell would turn a serious fault into a plausible but
+    misleading low voltage.
 
     Args:
         cell_voltages: Decoded individual cell voltages in volts.
         cell_count: Expected cell count from register 41.
+        bank_min_voltage: Minimum pack voltage across the bank from register 22.
+        following_cell_voltage: Cell-block value immediately after the declared
+            cell count, or zero when the count consumes the full block.
 
     Returns:
         Rounded sum of all cells, or 0.0 when the cell set is unusable.
     """
-    if cell_count <= 0 or len(cell_voltages) != cell_count:
+    if not _MIN_PLAUSIBLE_CELL_COUNT <= cell_count <= _MAX_PLAUSIBLE_CELL_COUNT:
+        return 0.0
+    # decode_cell_voltages currently returns exactly cell_count entries. Keep
+    # this length check as defence in depth for alternate decoders/callers; the
+    # real register protections are the bounds and cross-checks below.
+    if len(cell_voltages) != cell_count:
         return 0.0
     if not all(_MIN_PLAUSIBLE_CELL_V <= value <= _MAX_PLAUSIBLE_CELL_V for value in cell_voltages):
         return 0.0
-    return round(sum(cell_voltages), 2)
+    # The physical block always has 16 registers. A plausible cell immediately
+    # after the declared count proves reg 41 under-reported, even when reg 22 is
+    # absent and cannot provide the stronger physical cross-check.
+    if _MIN_PLAUSIBLE_CELL_V <= following_cell_voltage <= _MAX_PLAUSIBLE_CELL_V:
+        return 0.0
+
+    derived_voltage = round(sum(cell_voltages), 2)
+    # The master is one of the packs contributing to reg 22's bank minimum, so
+    # its voltage cannot be materially below that minimum. This catches corrupt
+    # but superficially plausible counts such as 15 or 1 (#249).
+    if bank_min_voltage > 0 and derived_voltage + _BANK_MIN_VOLTAGE_TOLERANCE_V < bank_min_voltage:
+        return 0.0
+    return derived_voltage
 
 
 class EG4MasterProtocol(BatteryProtocol):
@@ -218,7 +258,17 @@ class EG4MasterProtocol(BatteryProtocol):
         cell_voltages, fallback_min, fallback_max = self.decode_cell_voltages(
             raw_regs, start_address=113, num_cells=num_cells
         )
-        voltage = _derive_master_voltage(cell_voltages, num_cells)
+        bank_min_reg = self._reg("bank_min_voltage")
+        bank_min_voltage = self.decode_register(bank_min_reg, raw_regs.get(bank_min_reg.address, 0))
+        following_cell_voltage = 0.0
+        if 0 <= num_cells < _CELL_BLOCK.count:
+            following_cell_voltage = raw_regs.get(_CELL_BLOCK.start + num_cells, 0) / 1000.0
+        voltage = _derive_master_voltage(
+            cell_voltages,
+            num_cells,
+            bank_min_voltage=bank_min_voltage,
+            following_cell_voltage=following_cell_voltage,
+        )
 
         # Prefer dedicated max/min cell voltage registers; fall back to computed values
         max_cell_v = self.decode_register(max_cell_reg, raw_regs.get(max_cell_reg.address, 0))

--- a/src/pylxpweb/devices/battery.py
+++ b/src/pylxpweb/devices/battery.py
@@ -117,6 +117,9 @@ class Battery(BaseDevice):
             batterySn=battery_data.serial_number or battery_key,
             batIndex=battery_data.battery_index,
             lost=False,
+            # BatteryModule's schema is non-nullable, so transport absence stays
+            # encoded as zero. Derived properties below treat it as unavailable
+            # rather than turning it into a measurement (#249).
             totalVoltage=int(battery_data.voltage * 100),  # Convert back to raw
             current=int(battery_data.current * 10),  # Convert back to raw
             soc=battery_data.soc,
@@ -237,7 +240,7 @@ class Battery(BaseDevice):
             Battery voltage (scaled from totalVoltage ÷100).
         """
         val = self._get_transport_attr("voltage")
-        if val is not None:
+        if val is not None and float(val) > 0:
             return float(val)
         return scale_battery_value("totalVoltage", self._data.totalVoltage)
 
@@ -254,18 +257,22 @@ class Battery(BaseDevice):
         return scale_battery_value("current", self._data.current)
 
     @property
-    def power(self) -> float:
+    def power(self) -> float | None:
         """Get battery power in watts (calculated from V * I).
 
         Returns:
-            Battery power in watts, rounded to voltage precision.
+            Battery power in watts rounded to voltage precision, or None when
+            neither transport nor cloud provides a usable voltage.
         """
         val = self._get_transport_attr("power")
         if val is not None:
             return float(val)
+        voltage = self.voltage
+        if voltage <= 0:
+            return None
         # Use voltage precision (2 decimals) as it's higher than current (1 decimal)
         precision = get_battery_field_precision("totalVoltage")
-        return round(self.voltage * self.current, precision)
+        return round(voltage * self.current, precision)
 
     # ========== State of Charge/Health ==========
 

--- a/src/pylxpweb/devices/battery_bank.py
+++ b/src/pylxpweb/devices/battery_bank.py
@@ -254,9 +254,10 @@ class BatteryBank(BaseDevice):
             Voltage difference in volts, or None if fewer than
             2 batteries are present.
         """
-        if len(self.batteries) < 2:
+        # Zero is the transport's absent-voltage sentinel, not a real sample.
+        voltages = [b.voltage for b in self.batteries if b.voltage > 0]
+        if len(voltages) < 2:
             return None
-        voltages = [b.voltage for b in self.batteries]
         return round(max(voltages) - min(voltages), 2)
 
     @property

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -634,13 +634,13 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         transport_battery = self._transport_battery
         if transport_battery is None:
             return True
-        # Count non-ghost slots: an empty 5002+ register slot reads 0V/0% SoC
-        # (pylxpweb's canonical ghost definition), so it must not count as a
-        # surfaced battery — otherwise the gate could never trip.
+        # Count non-ghost slots with the canonical predicate. A zero-voltage
+        # master carrying another live signal is surfaced-but-degraded; only an
+        # all-zero 5002+ slot is absent (#249/#248).
         candidates = [
             batt
             for batt in (getattr(transport_battery, "batteries", None) or [])
-            if not (batt.voltage == 0 and batt.soc == 0)
+            if not batt.is_absent()
         ]
         if not candidates:
             return True

--- a/src/pylxpweb/transports/battery_modbus.py
+++ b/src/pylxpweb/transports/battery_modbus.py
@@ -620,6 +620,17 @@ class BatteryModbusTransport:
         # so its already-individual aggregate remains unchanged. After a removed
         # battery is absent for six hours it is evicted and re-decode resumes
         # against the remaining topology; this is intentional convergence (#249).
+        #
+        # KNOWN BOUNDARY -- auto-scan cold start. Topology memory cannot
+        # remember a unit it has never seen, so on a fresh transport with
+        # unit_ids=None whose first scan misses a unit, the remembered set is
+        # already short and this gate passes on incomplete topology. It is the
+        # original defect's shape in a narrow, self-healing window: the missing
+        # unit's first genuine response is remembered permanently, after which
+        # its silence blocks the gate like any other. Explicit unit_ids have no
+        # such window because the declared list seeds memory before the first
+        # read. Closing it would need a declared expected count, which is the
+        # configuration auto-scan exists to avoid.
         remembered_unit_ids = self._remembered_unit_ids()
         required_slave_ids = (
             remembered_unit_ids - {master_uid} if master_uid is not None else remembered_unit_ids

--- a/src/pylxpweb/transports/battery_modbus.py
+++ b/src/pylxpweb/transports/battery_modbus.py
@@ -126,13 +126,18 @@ class BatteryModbusTransport:
         self.timeout = timeout
         self._client: AsyncModbusTcpClient | None = None
         self._connected = False
+        self._reconnect_lock = asyncio.Lock()
+        self._consecutive_errors = 0
+        self._max_consecutive_errors = 3
+        # Unit degradation is transition-based so persistent faults warn once (#248).
+        self._degraded_units: set[int] = set()
         # Cache detected protocols per unit ID
         self._detected_protocols: dict[int, BatteryProtocol] = {}
 
     @property
     def is_connected(self) -> bool:
         """Check if transport is connected to the RS485 bridge."""
-        return self._connected
+        return self._connected and self._client is not None and bool(self._client.connected)
 
     async def __aenter__(self) -> Self:
         """Enter async context manager, connecting the transport."""
@@ -168,12 +173,75 @@ class BatteryModbusTransport:
             self._client.close()
         self._connected = False
 
+    async def _reconnect(self) -> None:
+        """Reconnect after the consecutive-error gate trips.
+
+        The double-check under the lock prevents concurrent unit reads from
+        rebuilding the shared client more than once.
+        """
+        async with self._reconnect_lock:
+            if self._consecutive_errors < self._max_consecutive_errors:
+                return
+
+            _LOGGER.warning(
+                "Reconnecting battery RS485 bridge at %s:%d after %d consecutive errors",
+                self.host,
+                self.port,
+                self._consecutive_errors,
+            )
+            await self.disconnect()
+            await self.connect()
+            self._consecutive_errors = 0
+
+    def _degrade_unit(
+        self,
+        unit_id: int,
+        start: int,
+        expected: int,
+        got: int,
+    ) -> None:
+        """Warn once when a unit transitions into degraded reads.
+
+        Args:
+            unit_id: Modbus unit/slave ID.
+            start: First register address of the failed block.
+            expected: Minimum register count needed from the block.
+            got: Register count returned, or zero on an error/exception.
+        """
+        if unit_id in self._degraded_units:
+            return
+
+        self._degraded_units.add(unit_id)
+        _LOGGER.warning(
+            "Battery unit %d read degraded: start=%d expected=%d got=%d registers. "
+            "Possible causes: bus contention, wiring problems, a BMS that truncates "
+            "responses, or the unit powered down (#248)",
+            unit_id,
+            start,
+            expected,
+            got,
+        )
+
+    def _recover_unit(self, unit_id: int) -> None:
+        """Clear degradation after every block for a unit reads cleanly.
+
+        Args:
+            unit_id: Modbus unit/slave ID.
+        """
+        if unit_id not in self._degraded_units:
+            return
+
+        self._degraded_units.remove(unit_id)
+        # Recovery is INFO: it confirms health without repeating the fault severity (#248).
+        _LOGGER.info("Battery unit %d read recovered; all register blocks completed", unit_id)
+
     async def _read_registers(
         self,
         start: int,
         count: int,
         unit_id: int,
         minimum: int | None = None,
+        probe: bool = False,
     ) -> list[int] | None:
         """Read holding registers from a battery unit.
 
@@ -184,18 +252,32 @@ class BatteryModbusTransport:
             minimum: Registers that must come back for the response to be
                 usable. Defaults to ``count``; pass a lower value only when
                 the request deliberately over-reads what will be decoded.
+            probe: Whether this is an expected-miss discovery probe. Probe
+                failures do not affect degradation or reconnect state.
 
         Returns:
             List of register values, or None on error/timeout/short read.
         """
-        if not self._client:
-            return None
         required = count if minimum is None else minimum
+        if not self._client:
+            if not probe:
+                self._consecutive_errors += 1
+                self._degrade_unit(unit_id, start, required, 0)
+            return None
         try:
             result = await self._client.read_holding_registers(
                 start, count=count, device_id=unit_id
             )
             if result.isError():
+                _LOGGER.debug(
+                    "Modbus error response: unit=%d start=%d count=%d",
+                    unit_id,
+                    start,
+                    count,
+                )
+                if not probe:
+                    self._consecutive_errors += 1
+                    self._degrade_unit(unit_id, start, required, 0)
                 return None
             registers = list(result.registers)
             # pymodbus decodes registers from the response's own byte_count
@@ -208,8 +290,8 @@ class BatteryModbusTransport:
             # Rejecting a block does not make its fields absent: BatteryData
             # has no nullable cell fields, so a dropped block reads out as
             # zeroes or as whatever fallback the protocol has. See the note
-            # on _read_unit_raw. Callers get no signal beyond this DEBUG
-            # line; per-unit health reporting is pylxpweb#248.
+            # on _read_unit_raw. The DEBUG detail is paired with a single
+            # per-unit degradation transition WARNING (#248).
             if len(registers) < required:
                 _LOGGER.debug(
                     "Short read: unit=%d start=%d expected %d registers, got %d",
@@ -218,10 +300,18 @@ class BatteryModbusTransport:
                     required,
                     len(registers),
                 )
+                if not probe:
+                    self._consecutive_errors += 1
+                    self._degrade_unit(unit_id, start, required, len(registers))
                 return None
+            if not probe:
+                self._consecutive_errors = 0
             return registers
         except Exception:
             _LOGGER.debug("Read failed: unit=%d start=%d count=%d", unit_id, start, count)
+            if not probe:
+                self._consecutive_errors += 1
+                self._degrade_unit(unit_id, start, required, 0)
             return None
 
     def _get_protocol(self, unit_id: int, raw_regs: dict[int, int]) -> BatteryProtocol:
@@ -280,7 +370,8 @@ class BatteryModbusTransport:
 
         responding: list[int] = []
         for uid in range(1, self.max_units + 1):
-            regs = await self._read_registers(0, 1, uid)
+            # Non-responding IDs are expected discovery misses, not bus faults (#248).
+            regs = await self._read_registers(0, 1, uid, probe=True)
             if regs is not None:
                 responding.append(uid)
             await asyncio.sleep(_INTER_UNIT_DELAY)
@@ -337,9 +428,11 @@ class BatteryModbusTransport:
             await asyncio.sleep(_INTER_UNIT_DELAY)
 
         # Re-decode master with slave context for individual SOC
-        if master_uid is not None and master_data is not None and slave_results:
+        if master_uid is not None and master_data is not None:
             master_proto = self._get_protocol(master_uid, raw_by_unit[master_uid])
             if isinstance(master_proto, EG4MasterProtocol):
+                # An empty slave list is the correct single-bank context: the
+                # full unwrapped total is the master's own remaining capacity (#249).
                 master_data = master_proto.decode_with_slaves(
                     raw_by_unit[master_uid],
                     slave_results,
@@ -376,17 +469,14 @@ class BatteryModbusTransport:
 
         Note:
             An extra block that fails is dropped whole rather than partially
-            decoded, but "dropped" is not "absent" — ``BatteryData`` has no
-            nullable cell fields, and consumers publish these fields directly.
-            For the master cell block (113-128) that means sixteen 0.000 V
-            cells, a 0 V min/max wherever regs 37/38 also read zero, and --
-            via ``decode_with_slaves`` -- a master voltage that quietly
-            reverts to reg 22, the bank MINIMUM rather than the master's own
-            sum-of-cells. The first two are implausible enough to notice; the
-            last is not. Dropping the block is still right (a min/max computed
-            over half a cell block is plausible AND wrong), but it buys
-            detectability, not correctness.
+            decoded. ``BatteryData`` has no nullable cell fields, so the
+            master cell block becomes zeroed cells and the explicit 0.0
+            absent pack-voltage sentinel. The unit remains degraded until a
+            later read completes its runtime block and every extra block.
         """
+        if self._consecutive_errors >= self._max_consecutive_errors:
+            await self._reconnect()
+
         runtime_regs = await self._read_registers(
             0, _INITIAL_BLOCK_COUNT, unit_id, minimum=_MIN_INITIAL_REGISTERS
         )
@@ -412,18 +502,25 @@ class BatteryModbusTransport:
                 required,
                 len(runtime_regs),
             )
+            self._consecutive_errors += 1
+            self._degrade_unit(unit_id, 0, required, len(runtime_regs))
             return {}, None
 
+        unit_read_clean = True
         for block in protocol.register_blocks:
             if block.start >= _INITIAL_BLOCK_COUNT:
                 extra = await self._read_registers(block.start, block.count, unit_id)
-                if extra:
+                if extra is not None:
                     for i, v in enumerate(extra):
                         raw[block.start + i] = v
+                else:
+                    unit_read_clean = False
                 await asyncio.sleep(_INTER_READ_DELAY)
 
         battery_index = unit_id - 1
         data = protocol.decode(raw, battery_index=battery_index)
+        if unit_read_clean:
+            self._recover_unit(unit_id)
         return raw, data
 
     @staticmethod

--- a/src/pylxpweb/transports/battery_modbus.py
+++ b/src/pylxpweb/transports/battery_modbus.py
@@ -50,9 +50,16 @@ _INTER_READ_DELAY = 0.1
 # Delay between sequential unit reads during scan or read_all (seconds)
 _INTER_UNIT_DELAY = 0.2
 
-# Minimum interval between reconnect attempts. The first attempt uses a None
-# sentinel rather than 0.0 because monotonic time can be below this interval on
-# a freshly booted host (the failure mode fixed in EG4 PRs #378/#380).
+# A unit that stops answering must not silently shrink the remembered topology
+# and re-enable master back-calculation against a partial bank. Retention mirrors
+# the 6h battery-eviction precedent (#258/#170) so a genuinely removed battery
+# still converges instead of pinning the master to the aggregate forever (#249).
+_UNIT_TOPOLOGY_RETENTION = 6 * 3600.0
+
+# Minimum interval between reconnect attempts. This code uses an absolute
+# deadline (``now < retry_after``), so 0.0 would not throttle the first attempt.
+# None remains the honest "never attempted" state and protects a future change
+# to the delta form whose 0.0 default caused the low-uptime EG4 #378/#380 bug.
 _RECONNECT_COOLDOWN = 30.0
 
 # Protocol name -> class mapping
@@ -144,6 +151,10 @@ class BatteryModbusTransport:
         self._empty_scan_warned = False
         # Unit degradation is transition-based so persistent faults warn once (#248).
         self._degraded_units: set[int] = set()
+        self._unit_last_seen: dict[int, float] = {}
+        # Units evicted from topology memory. Only a genuine response re-admits
+        # one, which is what keeps the re-decode gate from flapping (#249).
+        self._evicted_units: set[int] = set()
         # Cache detected protocols per unit ID
         self._detected_protocols: dict[int, BatteryProtocol] = {}
 
@@ -167,7 +178,17 @@ class BatteryModbusTransport:
         await self.disconnect()
 
     async def connect(self) -> None:
-        """Establish Modbus TCP connection to the RS485 bridge."""
+        """Establish a connection while excluding shared-client operations.
+
+        Public lifecycle methods acquire the operation lock. Code that already
+        owns it, such as ``_reconnect()``, must call ``_connect_locked()`` to
+        preserve the operation -> reconnect lock order and avoid re-entry (#248).
+        """
+        async with self._operation_lock:
+            await self._connect_locked()
+
+    async def _connect_locked(self) -> None:
+        """Establish a connection while the caller holds the operation lock."""
         self._client = AsyncModbusTcpClient(self.host, port=self.port, timeout=self.timeout)
         await self._client.connect()
         self._connected = self._client.connected
@@ -181,7 +202,17 @@ class BatteryModbusTransport:
             )
 
     async def disconnect(self) -> None:
-        """Close the Modbus TCP connection."""
+        """Close the connection while excluding shared-client operations.
+
+        Public lifecycle methods acquire the operation lock. Code that already
+        owns it must call ``_disconnect_locked()`` so this non-reentrant lock is
+        never acquired twice (#248).
+        """
+        async with self._operation_lock:
+            await self._disconnect_locked()
+
+    async def _disconnect_locked(self) -> None:
+        """Close the connection while the caller holds the operation lock."""
         if self._client:
             self._client.close()
         self._connected = False
@@ -189,7 +220,7 @@ class BatteryModbusTransport:
     async def _reconnect(self) -> None:
         """Reconnect after the consecutive-error gate trips.
 
-        ``_read_unit_raw()`` and ``scan_units()`` call this while holding the
+        ``_read_unit_raw_locked()`` and ``scan_units()`` call this while holding the
         operation lock, so no public read can queue work on a client being
         closed. The distinct reconnect lock protects the threshold/cooldown
         transition itself. Locks are always acquired operation-first and never
@@ -220,9 +251,9 @@ class BatteryModbusTransport:
                     self._consecutive_errors,
                 )
 
-            await self.disconnect()
+            await self._disconnect_locked()
             try:
-                await self.connect()
+                await self._connect_locked()
             except Exception as exc:
                 # Reads are non-raising by contract. A connector implementation
                 # that raises must not crash the whole battery poll (#248).
@@ -433,6 +464,7 @@ class BatteryModbusTransport:
             List of responding unit IDs.
         """
         if self.unit_ids is not None:
+            self._remember_polled_units(self.unit_ids)
             return self.unit_ids
 
         async with self._operation_lock:
@@ -443,6 +475,7 @@ class BatteryModbusTransport:
                 regs = await self._read_registers(0, 1, uid, probe=True)
                 if regs is not None:
                     responding.append(uid)
+                    self._observe_unit(uid)
                 await asyncio.sleep(_INTER_UNIT_DELAY)
 
             if responding:
@@ -480,6 +513,59 @@ class BatteryModbusTransport:
         )
         return responding
 
+    def _remember_polled_units(self, unit_ids: list[int]) -> None:
+        """Seed topology memory for declared or discovered units.
+
+        A configured unit must count before its first successful response;
+        otherwise explicit configuration would permit the same partial-bank
+        master back-calculation that topology memory prevents (#249).
+
+        Args:
+            unit_ids: Unit IDs declared or selected for the current poll.
+        """
+        now = time.monotonic()
+        for unit_id in unit_ids:
+            if unit_id in self._evicted_units:
+                # Seeding a still-absent declared unit again would re-arm the
+                # gate one cycle after eviction, so an explicitly configured but
+                # removed battery would flap between individual and aggregate
+                # SOC once per retention window instead of converging. Only a
+                # genuine response re-admits an evicted unit (#249).
+                continue
+            self._unit_last_seen.setdefault(unit_id, now)
+
+    def _observe_unit(self, unit_id: int) -> None:
+        """Record a genuine response from a unit, re-admitting it if evicted.
+
+        Args:
+            unit_id: Modbus unit/slave ID that answered.
+        """
+        self._unit_last_seen[unit_id] = time.monotonic()
+        self._evicted_units.discard(unit_id)
+
+    def _remembered_unit_ids(self) -> set[int]:
+        """Return retained topology, evicting units absent for six hours.
+
+        Returns:
+            Unit IDs still within the topology retention window.
+        """
+        now = time.monotonic()
+        stale_units = [
+            (unit_id, last_seen)
+            for unit_id, last_seen in self._unit_last_seen.items()
+            if now - last_seen > _UNIT_TOPOLOGY_RETENTION
+        ]
+        for unit_id, last_seen in stale_units:
+            del self._unit_last_seen[unit_id]
+            self._evicted_units.add(unit_id)
+            _LOGGER.info(
+                "Battery unit %d evicted from remembered topology after %.0f seconds "
+                "without observation (#249)",
+                unit_id,
+                now - last_seen,
+            )
+        return set(self._unit_last_seen)
+
     async def read_all(
         self,
         inverter_bms_data: InverterRuntimeData | None = None,
@@ -501,10 +587,12 @@ class BatteryModbusTransport:
             List of BatteryData objects for responding units, master first.
         """
         units = self.unit_ids or await self.scan_units()
+        self._remember_polled_units(units)
 
         # Read all units, keeping track of raw registers for master re-decode
         raw_by_unit: dict[int, dict[int, int]] = {}
         slave_results: list[BatteryData] = []
+        decoded_slave_ids: set[int] = set()
         master_uid: int | None = None
         master_data: BatteryData | None = None
 
@@ -513,6 +601,7 @@ class BatteryModbusTransport:
             if data is None:
                 continue
 
+            self._observe_unit(uid)
             raw_by_unit[uid] = raw
             protocol = self._get_protocol(uid, raw)
 
@@ -521,21 +610,25 @@ class BatteryModbusTransport:
                 master_data = data
             else:
                 slave_results.append(data)
+                decoded_slave_ids.add(uid)
 
             await asyncio.sleep(_INTER_UNIT_DELAY)
 
-        # Re-decode master only with the complete slave topology. A partial set
-        # is as unsafe as an empty one: in a three-battery bank, subtracting one
-        # of two slaves over-reports the master by the missing pack's capacity.
-        # With incomplete context, reg 21 remains a real aggregate bank SOC
-        # rather than a fabricated individual number (#249). A genuine one-unit
-        # bank needs no re-decode because its aggregate is already individual.
-        expected_slaves = len(units) - 1
+        # Re-decode only when decoded slave IDs cover the retained topology.
+        # Thus a three-unit bank scanning as [1, 2] keeps aggregate reg 21, while
+        # a genuine [1, 2] bank re-decodes. A one-unit bank has no slave result,
+        # so its already-individual aggregate remains unchanged. After a removed
+        # battery is absent for six hours it is evicted and re-decode resumes
+        # against the remaining topology; this is intentional convergence (#249).
+        remembered_unit_ids = self._remembered_unit_ids()
+        required_slave_ids = (
+            remembered_unit_ids - {master_uid} if master_uid is not None else remembered_unit_ids
+        )
         if (
             master_uid is not None
             and master_data is not None
             and slave_results
-            and len(slave_results) == expected_slaves
+            and decoded_slave_ids.issuperset(required_slave_ids)
         ):
             master_proto = self._get_protocol(master_uid, raw_by_unit[master_uid])
             if isinstance(master_proto, EG4MasterProtocol):

--- a/src/pylxpweb/transports/battery_modbus.py
+++ b/src/pylxpweb/transports/battery_modbus.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Self
 
 from pymodbus.client import AsyncModbusTcpClient
@@ -48,6 +49,11 @@ _INTER_READ_DELAY = 0.1
 
 # Delay between sequential unit reads during scan or read_all (seconds)
 _INTER_UNIT_DELAY = 0.2
+
+# Minimum interval between reconnect attempts. The first attempt uses a None
+# sentinel rather than 0.0 because monotonic time can be below this interval on
+# a freshly booted host (the failure mode fixed in EG4 PRs #378/#380).
+_RECONNECT_COOLDOWN = 30.0
 
 # Protocol name -> class mapping
 _PROTOCOL_MAP: dict[str, type[BatteryProtocol]] = {
@@ -126,9 +132,16 @@ class BatteryModbusTransport:
         self.timeout = timeout
         self._client: AsyncModbusTcpClient | None = None
         self._connected = False
+        # Serializes every operation that uses the shared client across its
+        # reconnect gate and reads. It is intentionally distinct from the
+        # narrower reconnect state lock below (#248).
+        self._operation_lock = asyncio.Lock()
         self._reconnect_lock = asyncio.Lock()
+        self._reconnect_retry_after: float | None = None
+        self._reconnect_warned = False
         self._consecutive_errors = 0
         self._max_consecutive_errors = 3
+        self._empty_scan_warned = False
         # Unit degradation is transition-based so persistent faults warn once (#248).
         self._degraded_units: set[int] = set()
         # Cache detected protocols per unit ID
@@ -176,22 +189,75 @@ class BatteryModbusTransport:
     async def _reconnect(self) -> None:
         """Reconnect after the consecutive-error gate trips.
 
-        The double-check under the lock prevents concurrent unit reads from
-        rebuilding the shared client more than once.
+        ``_read_unit_raw()`` and ``scan_units()`` call this while holding the
+        operation lock, so no public read can queue work on a client being
+        closed. The distinct reconnect lock protects the threshold/cooldown
+        transition itself. Locks are always acquired operation-first and never
+        in reverse, so reconnect and read serialization cannot deadlock.
         """
         async with self._reconnect_lock:
             if self._consecutive_errors < self._max_consecutive_errors:
                 return
 
-            _LOGGER.warning(
-                "Reconnecting battery RS485 bridge at %s:%d after %d consecutive errors",
-                self.host,
-                self.port,
-                self._consecutive_errors,
-            )
+            now = time.monotonic()
+            if self._reconnect_retry_after is not None and now < self._reconnect_retry_after:
+                return
+            self._reconnect_retry_after = now + _RECONNECT_COOLDOWN
+
+            if not self._reconnect_warned:
+                self._reconnect_warned = True
+                _LOGGER.warning(
+                    "Reconnecting battery RS485 bridge at %s:%d after %d consecutive errors",
+                    self.host,
+                    self.port,
+                    self._consecutive_errors,
+                )
+            else:
+                _LOGGER.debug(
+                    "Reconnecting battery RS485 bridge at %s:%d after %d consecutive errors",
+                    self.host,
+                    self.port,
+                    self._consecutive_errors,
+                )
+
             await self.disconnect()
-            await self.connect()
-            self._consecutive_errors = 0
+            try:
+                await self.connect()
+            except Exception as exc:
+                # Reads are non-raising by contract. A connector implementation
+                # that raises must not crash the whole battery poll (#248).
+                _LOGGER.debug(
+                    "Battery RS485 bridge reconnect at %s:%d raised: %s",
+                    self.host,
+                    self.port,
+                    exc,
+                )
+                return
+
+            if self.is_connected:
+                self._consecutive_errors = 0
+            else:
+                # pymodbus normally returns False instead of raising when the
+                # network is still down. Keep the gate tripped; cooldown, not a
+                # fabricated reset, controls the next attempt (#248).
+                _LOGGER.debug(
+                    "Battery RS485 bridge reconnect at %s:%d did not connect",
+                    self.host,
+                    self.port,
+                )
+
+    def _recover_reconnect_episode(self) -> None:
+        """Clear reconnect warning/cooldown after a real Modbus response."""
+        if not self._reconnect_warned:
+            return
+
+        self._reconnect_warned = False
+        self._reconnect_retry_after = None
+        _LOGGER.info(
+            "Battery RS485 bridge at %s:%d recovered after a successful read",
+            self.host,
+            self.port,
+        )
 
     def _degrade_unit(
         self,
@@ -306,6 +372,7 @@ class BatteryModbusTransport:
                 return None
             if not probe:
                 self._consecutive_errors = 0
+                self._recover_reconnect_episode()
             return registers
         except Exception:
             _LOGGER.debug("Read failed: unit=%d start=%d count=%d", unit_id, start, count)
@@ -368,13 +435,43 @@ class BatteryModbusTransport:
         if self.unit_ids is not None:
             return self.unit_ids
 
-        responding: list[int] = []
-        for uid in range(1, self.max_units + 1):
-            # Non-responding IDs are expected discovery misses, not bus faults (#248).
-            regs = await self._read_registers(0, 1, uid, probe=True)
-            if regs is not None:
-                responding.append(uid)
-            await asyncio.sleep(_INTER_UNIT_DELAY)
+        async with self._operation_lock:
+            responding: list[int] = []
+            for uid in range(1, self.max_units + 1):
+                # Individual non-responding IDs are expected discovery misses,
+                # not unit degradation or separate bus faults (#248).
+                regs = await self._read_registers(0, 1, uid, probe=True)
+                if regs is not None:
+                    responding.append(uid)
+                await asyncio.sleep(_INTER_UNIT_DELAY)
+
+            if responding:
+                self._consecutive_errors = 0
+                if self._empty_scan_warned:
+                    self._empty_scan_warned = False
+                    _LOGGER.info(
+                        "Battery bus scan at %s:%d has units responding again",
+                        self.host,
+                        self.port,
+                    )
+                self._recover_reconnect_episode()
+            else:
+                # Previously seeing units and now seeing none is the strongest
+                # form of this signal, but a first-ever empty scan also deserves
+                # reporting as likely bridge/bus failure or misconfiguration.
+                # Count once per scan, never once per expected probe miss.
+                self._consecutive_errors += 1
+                if not self._empty_scan_warned:
+                    self._empty_scan_warned = True
+                    _LOGGER.warning(
+                        "Battery bus scan at %s:%d: no units responded while probing 1-%d; "
+                        "a bus/bridge fault or configuration error is likely (#248)",
+                        self.host,
+                        self.port,
+                        self.max_units,
+                    )
+                if self._consecutive_errors >= self._max_consecutive_errors:
+                    await self._reconnect()
 
         _LOGGER.info(
             "Battery bus scan: %d/%d units responding",
@@ -427,12 +524,21 @@ class BatteryModbusTransport:
 
             await asyncio.sleep(_INTER_UNIT_DELAY)
 
-        # Re-decode master with slave context for individual SOC
-        if master_uid is not None and master_data is not None:
+        # Re-decode master only with the complete slave topology. A partial set
+        # is as unsafe as an empty one: in a three-battery bank, subtracting one
+        # of two slaves over-reports the master by the missing pack's capacity.
+        # With incomplete context, reg 21 remains a real aggregate bank SOC
+        # rather than a fabricated individual number (#249). A genuine one-unit
+        # bank needs no re-decode because its aggregate is already individual.
+        expected_slaves = len(units) - 1
+        if (
+            master_uid is not None
+            and master_data is not None
+            and slave_results
+            and len(slave_results) == expected_slaves
+        ):
             master_proto = self._get_protocol(master_uid, raw_by_unit[master_uid])
             if isinstance(master_proto, EG4MasterProtocol):
-                # An empty slave list is the correct single-bank context: the
-                # full unwrapped total is the master's own remaining capacity (#249).
                 master_data = master_proto.decode_with_slaves(
                     raw_by_unit[master_uid],
                     slave_results,
@@ -474,6 +580,13 @@ class BatteryModbusTransport:
             absent pack-voltage sentinel. The unit remains degraded until a
             later read completes its runtime block and every extra block.
         """
+        async with self._operation_lock:
+            return await self._read_unit_raw_locked(unit_id)
+
+    async def _read_unit_raw_locked(
+        self, unit_id: int
+    ) -> tuple[dict[int, int], BatteryData | None]:
+        """Read one unit while the caller holds the shared-client operation lock."""
         if self._consecutive_errors >= self._max_consecutive_errors:
             await self._reconnect()
 

--- a/src/pylxpweb/transports/data.py
+++ b/src/pylxpweb/transports/data.py
@@ -1115,6 +1115,29 @@ class BatteryData:
             return True
         return False
 
+    def is_absent(self) -> bool:
+        """Return whether this row is an empty battery register slot.
+
+        A zero voltage and zero SOC alone are insufficient: the EG4 master can
+        lose its cell block while still carrying live current, temperature, or
+        topology data. Such a row is present-but-degraded and must remain in the
+        bank. Empty 5002+ slots carry none of these signals (#249/#248).
+
+        Returns:
+            True only when voltage, SOC, and every independent live signal are
+            zero or empty.
+        """
+        return (
+            self.voltage <= 0
+            and self.soc == 0
+            and self.current == 0
+            and self.temperature == 0
+            and self.cycle_count == 0
+            and self.cell_count == 0
+            and not self.cell_voltages
+            and not self.cell_temperatures
+        )
+
     @property
     def remaining_capacity(self) -> float | None:
         """Calculate remaining capacity in Ah from max_capacity and SOC.
@@ -1127,14 +1150,20 @@ class BatteryData:
         return None
 
     @property
-    def power(self) -> float:
+    def power(self) -> float | None:
         """Calculate battery power in watts (V * I).
 
         Positive = charging, Negative = discharging.
+        The protocol uses zero volts as its honest absent encoding. Multiplying
+        that sentinel by a live current would report plausible zero watts, so
+        power is unavailable until voltage is usable (#249).
 
         Returns:
-            Battery power in watts, rounded to 2 decimal places.
+            Battery power in watts rounded to 2 decimal places, or None when
+            voltage is absent.
         """
+        if self.voltage <= 0:
+            return None
         return round(self.voltage * self.current, 2)
 
     @property
@@ -1431,7 +1460,9 @@ class BatteryBankData:
         # canonical 2996A desync value rejected even when a garbled-but-
         # plausible count inflates the scaled cap.
         if self.current is not None:
-            present = sum(1 for b in self.batteries if not (b.voltage == 0 and b.soc == 0))
+            # A degraded zero-voltage master can now count as present. That only
+            # widens this current bound; it cannot make a reading corrupt.
+            present = sum(1 for b in self.batteries if not b.is_absent())
             count = max(self.battery_count or 0, present)
             max_amps = min(max(500.0, count * 150.0), 2000.0)
             if abs(self.current) > max_amps:
@@ -1443,11 +1474,11 @@ class BatteryBankData:
                     present,
                 )
                 return True
-        # Only cascade to batteries that actually have CAN bus data.
-        # Ghost batteries (voltage=0, soc=0) from 5002+ register failures
-        # are not corrupt — just absent.
+        # Skip only truly empty 5002+ slots. A degraded master now reaches the
+        # cascade, which is safe because BatteryData.is_corrupt() deliberately
+        # treats zero voltage as absent rather than corrupt (#249).
         for b in self.batteries:
-            if b.voltage == 0 and b.soc == 0:
+            if b.is_absent():
                 continue
             if b.is_corrupt():
                 return True
@@ -1462,7 +1493,7 @@ class BatteryBankData:
         Returns:
             Battery power in watts, or None if voltage/current unavailable.
         """
-        if self.voltage is not None and self.current is not None:
+        if self.voltage is not None and self.voltage > 0 and self.current is not None:
             return round(self.voltage * self.current, 1)
         return None
 
@@ -1517,7 +1548,7 @@ class BatteryBankData:
     @property
     def voltage_delta(self) -> float | None:
         """Voltage spread across batteries (max - min)."""
-        vals = [b.voltage for b in self.batteries if b.voltage is not None]
+        vals = [b.voltage for b in self.batteries if b.voltage > 0]
         return round(max(vals) - min(vals), 2) if len(vals) >= 2 else None
 
     @property

--- a/tests/unit/battery_protocols/test_eg4_master.py
+++ b/tests/unit/battery_protocols/test_eg4_master.py
@@ -7,7 +7,6 @@ function FUN_0001cf78.
 from __future__ import annotations
 
 import struct
-from unittest.mock import patch
 
 import pytest
 
@@ -74,14 +73,14 @@ class TestEG4MasterProtocol:
         data = self.protocol.decode(raw)
         assert data.voltage == 0.0
 
-    def test_decode_voltage_rejects_partial_cell_block(self) -> None:
-        """One missing cell invalidates the whole derived master voltage."""
+    def test_decode_voltage_rejects_implausibly_low_cell(self) -> None:
+        """A cell below the 1.0 V plausibility bound invalidates the pack sum."""
         raw = self._base_regs()
         raw[22] = 5294
         raw[41] = 16
         for i in range(16):
             raw[113 + i] = 3310
-        raw[120] = 0
+        raw[120] = 999
 
         data = self.protocol.decode(raw)
         assert data.voltage == 0.0
@@ -108,20 +107,51 @@ class TestEG4MasterProtocol:
         data = self.protocol.decode(raw)
         assert data.voltage == 0.0
 
-    def test_decode_voltage_rejects_cell_count_length_mismatch(self) -> None:
-        """A cell list shorter than reg 41 cannot be treated as a complete pack."""
+    def test_decode_voltage_rejects_sum_below_bank_minimum(self) -> None:
+        """Reg 22 rejects a truncated sum that cannot be any bank member's voltage."""
         raw = self._base_regs()
         raw[22] = 5294
-        raw[41] = 16
+        raw[41] = 15
+        for i in range(15):
+            raw[113 + i] = 3310
 
-        with patch.object(
-            self.protocol,
-            "decode_cell_voltages",
-            return_value=([3.31] * 15, 3.31, 3.31),
-        ):
-            data = self.protocol.decode(raw)
+        data = self.protocol.decode(raw)
 
         assert data.voltage == 0.0
+
+    def test_decode_voltage_rejects_implausible_cell_count(self) -> None:
+        """A transient one-cell count cannot turn one healthy cell into a pack."""
+        raw = self._base_regs()
+        raw[41] = 1
+        raw[113] = 3310
+
+        data = self.protocol.decode(raw)
+
+        assert data.voltage == 0.0
+
+    def test_decode_voltage_rejects_underreported_count_without_bank_minimum(self) -> None:
+        """A live register after cell_count catches truncation even when reg 22 is absent."""
+        raw = self._base_regs()
+        raw[22] = 0
+        raw[41] = 15
+        for i in range(16):
+            raw[113 + i] = 3310
+
+        data = self.protocol.decode(raw)
+
+        assert data.voltage == 0.0
+
+    def test_decode_voltage_accepts_consistent_fifteen_cell_pack(self) -> None:
+        """A genuine 15-cell pack with a matching bank minimum remains usable."""
+        raw = self._base_regs()
+        raw[22] = 4960
+        raw[41] = 15
+        for i in range(15):
+            raw[113 + i] = 3310
+
+        data = self.protocol.decode(raw)
+
+        assert data.voltage == pytest.approx(49.65)
 
     def test_decode_aggregate_current(self) -> None:
         """Aggregate current: reg 23 /100, signed."""

--- a/tests/unit/battery_protocols/test_eg4_master.py
+++ b/tests/unit/battery_protocols/test_eg4_master.py
@@ -7,6 +7,7 @@ function FUN_0001cf78.
 from __future__ import annotations
 
 import struct
+from unittest.mock import patch
 
 import pytest
 
@@ -33,12 +34,94 @@ class TestEG4MasterProtocol:
         assert 19 in starts  # Runtime starts at 19, not 0
         assert 113 in starts  # Cell voltage block
 
-    def test_decode_voltage(self) -> None:
-        """Pack voltage: reg 22 /100."""
+    def test_master_map_has_no_register_named_voltage(self) -> None:
+        """Reg 22 is the bank minimum and must not answer to "voltage".
+
+        The name is the guardrail: a future author reaching for
+        ``_reg("voltage")`` here -- as the slave protocol legitimately does --
+        would silently reintroduce #249 by decoding a bank aggregate as the
+        master's own pack voltage.  Failing the lookup is the point.
+        """
+        with pytest.raises(KeyError, match="voltage"):
+            self.protocol._reg("voltage")
+
+        assert self.protocol._reg("bank_min_voltage").address == 22
+
+    def test_decode_does_not_use_bank_minimum_as_master_voltage(self) -> None:
+        """Bank-minimum reg 22 is never relabeled as the master's voltage."""
         raw = self._base_regs()
         raw[22] = 5294
         data = self.protocol.decode(raw)
-        assert data.voltage == pytest.approx(52.94)
+        assert data.voltage == 0.0
+
+    def test_decode_voltage_from_complete_cell_block(self) -> None:
+        """A complete plausible cell block supplies the master's pack voltage."""
+        raw = self._base_regs()
+        raw[22] = 5200
+        raw[41] = 16
+        for i in range(16):
+            raw[113 + i] = 3310
+
+        data = self.protocol.decode(raw)
+        assert data.voltage == pytest.approx(52.96)
+
+    def test_decode_voltage_rejects_all_zero_cell_block(self) -> None:
+        """A dropped all-zero cell block yields the absent sentinel, not reg 22."""
+        raw = self._base_regs()
+        raw[22] = 5294
+        raw[41] = 16
+
+        data = self.protocol.decode(raw)
+        assert data.voltage == 0.0
+
+    def test_decode_voltage_rejects_partial_cell_block(self) -> None:
+        """One missing cell invalidates the whole derived master voltage."""
+        raw = self._base_regs()
+        raw[22] = 5294
+        raw[41] = 16
+        for i in range(16):
+            raw[113 + i] = 3310
+        raw[120] = 0
+
+        data = self.protocol.decode(raw)
+        assert data.voltage == 0.0
+
+    def test_decode_voltage_rejects_implausibly_high_cell(self) -> None:
+        """A corrupt high cell register cannot create a plausible pack voltage."""
+        raw = self._base_regs()
+        raw[22] = 5294
+        raw[41] = 16
+        for i in range(16):
+            raw[113 + i] = 3310
+        raw[120] = 60000
+
+        data = self.protocol.decode(raw)
+        assert data.voltage == 0.0
+
+    def test_decode_voltage_rejects_zero_cell_count(self) -> None:
+        """Cell count zero makes master voltage explicitly absent."""
+        raw = self._base_regs()
+        raw[22] = 5294
+        for i in range(16):
+            raw[113 + i] = 3310
+
+        data = self.protocol.decode(raw)
+        assert data.voltage == 0.0
+
+    def test_decode_voltage_rejects_cell_count_length_mismatch(self) -> None:
+        """A cell list shorter than reg 41 cannot be treated as a complete pack."""
+        raw = self._base_regs()
+        raw[22] = 5294
+        raw[41] = 16
+
+        with patch.object(
+            self.protocol,
+            "decode_cell_voltages",
+            return_value=([3.31] * 15, 3.31, 3.31),
+        ):
+            data = self.protocol.decode(raw)
+
+        assert data.voltage == 0.0
 
     def test_decode_aggregate_current(self) -> None:
         """Aggregate current: reg 23 /100, signed."""
@@ -110,11 +193,10 @@ class TestEG4MasterProtocol:
         assert data.firmware_version == "2.17"
 
     def test_regs_0_to_18_ignored(self) -> None:
-        """Regs 0-18 are unused in master protocol."""
+        """Slave voltage reg 0 is ignored and an absent cell set stays absent."""
         raw = self._base_regs()
         raw[0] = 5294  # Would be voltage in slave protocol
         data = self.protocol.decode(raw)
-        # Voltage should come from reg 22, not reg 0
         assert data.voltage == pytest.approx(0.0)
 
     def test_decode_negative_temperature(self) -> None:
@@ -145,7 +227,7 @@ class TestEG4MasterProtocol:
         assert data.battery_index == 0
 
     def test_decode_all_zeros_graceful(self) -> None:
-        """All-zero registers decode without error."""
+        """All-zero registers decode with an explicitly absent master voltage."""
         raw = self._base_regs()
         data = self.protocol.decode(raw)
         assert data.voltage == 0.0
@@ -387,7 +469,7 @@ class TestDecodeWithSlaves:
         assert data.current_capacity is None  # Not computed
 
     def test_uses_cell_voltages_for_voltage(self) -> None:
-        """When cell voltages available, voltage = sum(cells) instead of MIN(all)."""
+        """Slave-context decoding preserves the voltage derived by decode()."""
         raw = self._base_regs()
         raw[22] = 5200  # MIN voltage across all batteries (52.00V)
         raw[26] = 464
@@ -405,6 +487,24 @@ class TestDecodeWithSlaves:
 
         data = self.protocol.decode_with_slaves(raw, slave_data)
         # Should use cell sum (52.96V) not MIN voltage (52.00V)
+        assert data.voltage == pytest.approx(52.96)
+
+    def test_voltage_from_cells_when_capacity_registers_zero(self) -> None:
+        """Capacity early-return cannot skip complete-cell voltage derivation."""
+        raw = self._base_regs()
+        raw[21] = 79
+        raw[22] = 5200
+        raw[26] = 0
+        raw[27] = 0
+        raw[33] = 5600
+        raw[41] = 16
+        for i in range(16):
+            raw[113 + i] = 3310
+
+        data = self.protocol.decode_with_slaves(raw, [])
+
+        assert data.soc == 79
+        assert data.current_capacity is None
         assert data.voltage == pytest.approx(52.96)
 
     def test_preserves_other_fields(self) -> None:

--- a/tests/unit/devices/batteries/test_battery.py
+++ b/tests/unit/devices/batteries/test_battery.py
@@ -12,6 +12,7 @@ from pylxpweb import LuxpowerClient
 from pylxpweb.devices.battery import Battery
 from pylxpweb.devices.models import Entity
 from pylxpweb.models import BatteryModule
+from pylxpweb.transports.data import BatteryData
 
 
 @pytest.fixture
@@ -76,6 +77,27 @@ class TestBatteryProperties:
 
         # Power = 53.81V * 14.7A = ~791.0W (corrected with ÷10 scaling)
         assert battery.power == pytest.approx(791.0, abs=1.0)
+
+    def test_absent_transport_voltage_falls_back_to_cloud(
+        self, mock_client: LuxpowerClient, sample_battery_module: BatteryModule
+    ) -> None:
+        """The transport's zero sentinel cannot suppress a usable cloud voltage."""
+        battery = Battery(client=mock_client, battery_data=sample_battery_module)
+        battery._transport_data = BatteryData(voltage=0.0, current=-20.0)
+
+        assert battery.voltage == pytest.approx(53.81, rel=0.01)
+
+    def test_absent_transport_voltage_with_live_current_has_no_power(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A transport-only battery with no voltage reports unavailable power."""
+        battery = Battery.from_transport_data(
+            mock_client,
+            BatteryData(voltage=0.0, current=-20.0),
+            "1234567890",
+        )
+
+        assert battery.power is None
 
     def test_soc_property(
         self, mock_client: LuxpowerClient, sample_battery_module: BatteryModule

--- a/tests/unit/devices/test_battery_bank.py
+++ b/tests/unit/devices/test_battery_bank.py
@@ -831,6 +831,19 @@ class TestBatteryBankCrossBatteryDiagnostics:
         )
         assert bank.voltage_delta == 0.50
 
+    def test_voltage_delta_ignores_absent_voltage(self, mock_client, sample_battery_info):
+        """One absent and one usable pack provide fewer than two voltage samples."""
+        bank = _make_bank(
+            mock_client,
+            sample_battery_info,
+            [
+                _make_battery(mock_client, 0, total_voltage=0),
+                _make_battery(mock_client, 80, total_voltage=5294),
+            ],
+        )
+
+        assert bank.voltage_delta is None
+
     def test_cell_voltage_delta_max_no_batteries(self, mock_client, sample_battery_info):
         """Test cell_voltage_delta_max returns None with no batteries."""
         bank = _make_bank(mock_client, sample_battery_info, [])

--- a/tests/unit/devices/test_transport_link_health.py
+++ b/tests/unit/devices/test_transport_link_health.py
@@ -30,6 +30,7 @@ from pylxpweb.devices.mid_device import MIDDevice
 from pylxpweb.models import EnergyInfo, InverterRuntime, MidboxRuntime
 from pylxpweb.transports.data import (
     BatteryBankData,
+    BatteryData,
     InverterEnergyData,
     InverterRuntimeData,
 )
@@ -614,7 +615,7 @@ class TestHybridSupplementalBattery:
         stamp = datetime.now(UTC)
         transport_battery = Mock(spec=BatteryBankData)
         transport_battery.batteries = [
-            Mock(voltage=53.0, soc=80, last_seen=stamp) for _ in range(surfaced)
+            BatteryData(voltage=53.0, soc=80, last_seen=stamp) for _ in range(surfaced)
         ]
         inverter._transport_battery = transport_battery
 
@@ -650,6 +651,39 @@ class TestHybridSupplementalBattery:
         await inverter.refresh(force=True)
 
         inverter._fetch_battery_http.assert_not_awaited()
+
+    def test_degraded_zero_voltage_master_counts_as_surfaced(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A live zero-voltage master is degraded, not a missing battery."""
+        inverter = _make_inverter(client=mock_client)
+        bank = Mock()
+        bank.battery_count = 1
+        inverter._battery_bank = bank
+        inverter._transport_battery = BatteryBankData(
+            batteries=[
+                BatteryData(
+                    voltage=0.0,
+                    soc=0,
+                    current=-20.0,
+                    temperature=19.0,
+                    cell_count=16,
+                    last_seen=datetime.now(UTC),
+                )
+            ]
+        )
+
+        assert inverter._wants_hybrid_supplemental_battery is False
+
+    def test_all_zero_slot_does_not_count_as_surfaced(self, mock_client: LuxpowerClient) -> None:
+        """An empty 5002+ register slot still triggers missing-battery supplement."""
+        inverter = _make_inverter(client=mock_client)
+        bank = Mock()
+        bank.battery_count = 1
+        inverter._battery_bank = bank
+        inverter._transport_battery = BatteryBankData(batteries=[BatteryData()])
+
+        assert inverter._wants_hybrid_supplemental_battery is True
 
     @pytest.mark.asyncio
     async def test_no_battery_bank_makes_no_cloud_battery_call(
@@ -702,8 +736,8 @@ class TestHybridSupplementalBattery:
 
         fresh = datetime.now(UTC)
         frozen = fresh - timedelta(minutes=5, seconds=11)  # ~5 min stale
-        batteries = [Mock(voltage=53.0, soc=80, last_seen=fresh) for _ in range(4)]
-        batteries.append(Mock(voltage=53.0, soc=80, last_seen=frozen))
+        batteries = [BatteryData(voltage=53.0, soc=80, last_seen=fresh) for _ in range(4)]
+        batteries.append(BatteryData(voltage=53.0, soc=80, last_seen=frozen))
         transport_battery = Mock(spec=BatteryBankData)
         transport_battery.batteries = batteries
         inverter._transport_battery = transport_battery
@@ -735,8 +769,8 @@ class TestHybridSupplementalBattery:
 
         fresh = datetime.now(UTC)
         lagging = fresh - timedelta(minutes=6, seconds=39)  # > 2 min behind
-        batteries = [Mock(voltage=53.0, soc=80, last_seen=fresh) for _ in range(4)]
-        batteries += [Mock(voltage=53.0, soc=80, last_seen=lagging) for _ in range(4)]
+        batteries = [BatteryData(voltage=53.0, soc=80, last_seen=fresh) for _ in range(4)]
+        batteries += [BatteryData(voltage=53.0, soc=80, last_seen=lagging) for _ in range(4)]
         transport_battery = Mock(spec=BatteryBankData)
         transport_battery.batteries = batteries
         inverter._transport_battery = transport_battery
@@ -769,7 +803,7 @@ class TestHybridSupplementalBattery:
         # whole feed is stale: newest stamp is ~10 minutes old — far past the
         # scaled backstop for the default 30 s TTL (max(2 min, 75 s) = 2 min).
         frozen = datetime.now(UTC) - timedelta(minutes=10)
-        batteries = [Mock(voltage=53.0, soc=80, last_seen=frozen) for _ in range(8)]
+        batteries = [BatteryData(voltage=53.0, soc=80, last_seen=frozen) for _ in range(8)]
         transport_battery = Mock(spec=BatteryBankData)
         transport_battery.batteries = batteries
         inverter._transport_battery = transport_battery
@@ -794,7 +828,9 @@ class TestHybridSupplementalBattery:
         def _combined(*_args: object, **_kwargs: object) -> tuple[Mock, Mock, Mock]:
             runtime, energy, battery = _make_combined_data()
             stamp = frozen_stamp if frozen_stamp is not None else datetime.now(UTC)
-            battery.batteries = [Mock(voltage=53.0, soc=80, last_seen=stamp) for _ in range(count)]
+            battery.batteries = [
+                BatteryData(voltage=53.0, soc=80, last_seen=stamp) for _ in range(count)
+            ]
             return runtime, energy, battery
 
         transport = AsyncMock()
@@ -810,7 +846,7 @@ class TestHybridSupplementalBattery:
         bank.battery_count = count
         inverter._battery_bank = bank
         seed = Mock(spec=BatteryBankData)
-        seed.batteries = [Mock(voltage=53.0, soc=80, last_seen=stamp) for _ in range(count)]
+        seed.batteries = [BatteryData(voltage=53.0, soc=80, last_seen=stamp) for _ in range(count)]
         inverter._transport_battery = seed
 
     @pytest.mark.asyncio

--- a/tests/unit/transports/test_battery_modbus.py
+++ b/tests/unit/transports/test_battery_modbus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -35,6 +36,7 @@ def transport() -> BatteryModbusTransport:
 def connected_transport(transport: BatteryModbusTransport) -> BatteryModbusTransport:
     """Create a transport with a mocked connected client."""
     mock_client = AsyncMock()
+    mock_client.connected = True
     # close() is synchronous on real pymodbus client
     mock_client.close = MagicMock()
     transport._client = mock_client
@@ -180,6 +182,16 @@ class TestBatteryModbusTransportConnect:
         await transport.disconnect()  # Should not raise
         assert transport.is_connected is False
 
+    def test_is_connected_tracks_underlying_client(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """A mid-session socket drop is visible without explicit disconnect()."""
+        assert connected_transport.is_connected is True
+
+        connected_transport._client.connected = False
+
+        assert connected_transport.is_connected is False
+
 
 class TestBatteryModbusTransportReadUnit:
     """Tests for reading a single battery unit."""
@@ -241,7 +253,7 @@ class TestBatteryModbusTransportReadUnit:
 
         data = await connected_transport.read_unit(1)
         assert data is not None
-        assert data.voltage == pytest.approx(52.94)
+        assert data.voltage == pytest.approx(52.8)
         assert data.soc == 76
         assert data.battery_index == 0  # unit_id 1 -> index 0
 
@@ -397,13 +409,16 @@ class TestBatteryModbusTransportScanUnits:
         assert result == [1, 3]
 
     @pytest.mark.asyncio
-    async def test_scan_no_units_responding(self) -> None:
-        """Scan returns empty list when no units respond."""
+    async def test_scan_nonresponding_units_does_not_degrade_or_reconnect(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Expected scan misses stay outside health warnings and the reconnect gate."""
         transport = BatteryModbusTransport(
             host="10.100.3.27",
-            max_units=2,
+            max_units=4,
         )
         transport._client = AsyncMock()
+        transport._client.connected = True
         transport._connected = True
 
         err_result = MagicMock()
@@ -411,8 +426,17 @@ class TestBatteryModbusTransportScanUnits:
 
         transport._client.read_holding_registers = AsyncMock(return_value=err_result)
 
-        result = await transport.scan_units()
+        with (
+            caplog.at_level(logging.WARNING),
+            patch.object(transport, "_reconnect", new_callable=AsyncMock) as reconnect,
+        ):
+            result = await transport.scan_units()
+
         assert result == []
+        assert transport._consecutive_errors == 0
+        assert transport._degraded_units == set()
+        reconnect.assert_not_awaited()
+        assert not [record for record in caplog.records if "read degraded" in record.getMessage()]
 
 
 class TestBatteryModbusTransportReadAll:
@@ -511,16 +535,26 @@ class TestBatteryModbusTransportReadRegisters:
         assert result == [100, 200, 300]
 
     @pytest.mark.asyncio
-    async def test_read_registers_error(self, connected_transport: BatteryModbusTransport) -> None:
-        """Error response returns None."""
+    async def test_read_registers_error_logs_debug(
+        self,
+        connected_transport: BatteryModbusTransport,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A Modbus error response is DEBUG-visible while retaining drop semantics."""
         mock_result = MagicMock()
         mock_result.isError.return_value = True
         connected_transport._client.read_holding_registers = AsyncMock(  # type: ignore[union-attr]
             return_value=mock_result,
         )
 
-        result = await connected_transport._read_registers(0, 3, 1)
+        with caplog.at_level(logging.DEBUG):
+            result = await connected_transport._read_registers(0, 3, 1)
+
         assert result is None
+        assert any(
+            "Modbus error response: unit=1 start=0 count=3" in record.getMessage()
+            for record in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_read_registers_exception(
@@ -601,9 +635,9 @@ class TestBatteryModbusTransportShortRead:
         plausible wrong min/max computed over the surviving fragment for
         an implausible 0.0, and implausible-wrong is far easier to spot.
 
-        That trade does not hold for every field:
-        ``test_dropped_cell_block_falls_back_to_bank_minimum_voltage``
-        pins one that moves the other way.
+        ``test_dropped_cell_block_uses_absent_voltage_sentinel`` also pins
+        that the master pack voltage follows the same detectable sentinel
+        policy instead of falling back to the bank minimum.
         """
         master_regs = _make_master_regs()
         short_cell_regs = [3310] * 8  # 8 of 16 requested
@@ -759,20 +793,13 @@ class TestBatteryModbusTransportShortRead:
         assert connected_transport._detected_protocols[1].name == "eg4_master"
 
     @pytest.mark.asyncio
-    async def test_dropped_cell_block_falls_back_to_bank_minimum_voltage(self) -> None:
-        """A dropped cell block silently reverts master voltage to reg 22.
+    async def test_dropped_cell_block_uses_absent_voltage_sentinel(self) -> None:
+        """A dropped master cell block yields 0.0 instead of bank-minimum reg 22.
 
-        ``decode_with_slaves`` normally overrides reg 22 (the MINIMUM
-        across all batteries) with the sum of the master's own cells,
-        because reg 22 is not the master's individual voltage.  A
-        dropped cell block leaves ``cell_voltages`` as sixteen zeros —
-        which is a *truthy* list, so the override branch is entered and
-        then abandoned on ``cell_sum > 0``.  Voltage falls back to the
-        bank minimum.
-
-        Unlike the zeroed cells, this one is a plausible-looking number:
-        the guard makes this field *less* detectable, not more, and it
-        is pinned here so that trade is visible rather than assumed.
+        Master pack voltage is derivable only from a complete, usable cell
+        set. A short block is dropped whole and decoded as sixteen zero cells,
+        so 0.0 is the explicit absent sentinel. Returning reg 22 would attach
+        a plausible bank aggregate to the master and hide the failed block.
         """
 
         async def read(cell_regs: list[int]) -> BatteryData:
@@ -793,10 +820,104 @@ class TestBatteryModbusTransportShortRead:
         # Full block: master voltage is the sum of its own 16 cells.
         assert (await read([3310] * 16)).voltage == pytest.approx(52.96)
 
-        # Short block: falls back to reg 22 = 5294, the bank minimum.
-        # Without the guard this would be the 8-cell fragment sum, 26.48 —
-        # wrong, but obviously so.
-        assert (await read([3310] * 8)).voltage == pytest.approx(52.94)
+        # Short block: no complete master cell set, so voltage is absent.
+        assert (await read([3310] * 8)).voltage == 0.0
+
+
+class TestBatteryModbusTransportHealth:
+    """Tests for per-unit degradation and reconnect state."""
+
+    @pytest.mark.asyncio
+    async def test_repeated_unit_failures_warn_once(
+        self,
+        connected_transport: BatteryModbusTransport,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A persistently failing extra block warns only on degradation transition."""
+        connected_transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result(_make_slave_regs()),
+                _mock_error(),
+                _mock_result(_make_slave_regs()),
+                _mock_error(),
+            ],
+        )
+
+        with caplog.at_level(logging.WARNING):
+            assert await connected_transport.read_unit(2) is not None
+            assert await connected_transport.read_unit(2) is not None
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and "Battery unit 2 read degraded" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "start=105 expected=23 got=0" in warnings[0].getMessage()
+        assert connected_transport._consecutive_errors == 1
+
+    @pytest.mark.asyncio
+    async def test_clean_unit_read_recovers_and_rearms_warning(
+        self,
+        connected_transport: BatteryModbusTransport,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Only a wholly clean unit read logs recovery and permits a later warning."""
+        connected_transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result(_make_slave_regs()),
+                _mock_error(),
+                _mock_result(_make_slave_regs()),
+                _mock_result([0] * 23),
+                _mock_result(_make_slave_regs()),
+                _mock_error(),
+            ],
+        )
+
+        with caplog.at_level(logging.INFO):
+            assert await connected_transport.read_unit(2) is not None
+            assert await connected_transport.read_unit(2) is not None
+            assert await connected_transport.read_unit(2) is not None
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert sum("Battery unit 2 read degraded" in message for message in messages) == 2
+        assert sum("Battery unit 2 read recovered" in message for message in messages) == 1
+        assert connected_transport._consecutive_errors == 1
+        assert connected_transport._degraded_units == {2}
+
+    @pytest.mark.asyncio
+    async def test_max_consecutive_errors_trigger_reconnect_and_reset(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """The request after three failed unit reads reconnects before a clean read."""
+        connected_transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_error(),
+                _mock_error(),
+                _mock_error(),
+                _mock_result(_make_slave_regs()),
+                _mock_result([0] * 23),
+            ],
+        )
+
+        for _ in range(connected_transport._max_consecutive_errors):
+            assert await connected_transport.read_unit(2) is None
+
+        assert (
+            connected_transport._consecutive_errors == connected_transport._max_consecutive_errors
+        )
+
+        with (
+            patch.object(connected_transport, "disconnect", new_callable=AsyncMock) as disconnect,
+            patch.object(connected_transport, "connect", new_callable=AsyncMock) as connect,
+        ):
+            data = await connected_transport.read_unit(2)
+
+        assert data is not None
+        disconnect.assert_awaited_once()
+        connect.assert_awaited_once()
+        assert connected_transport._consecutive_errors == 0
 
 
 class TestInitialBlockRequirement:
@@ -922,28 +1043,29 @@ class TestReadAllWithSlaves:
         assert results[2].soc == 80
 
     @pytest.mark.asyncio
-    async def test_master_without_slaves_uses_aggregate(self) -> None:
-        """When no slaves respond, master keeps aggregate SOC."""
-        transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1, 2])
+    async def test_master_without_slaves_is_redecoded(self) -> None:
+        """A master-only bank still derives voltage and individual capacity."""
+        transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1])
         transport._client = AsyncMock()
         transport._client.close = MagicMock()
+        transport._client.connected = True
         transport._connected = True
 
-        master_regs = _make_master_regs(soc=79)
+        master_regs = _make_master_regs(soc=79, reg26=22400, reg27=28000)
         cell_regs = [3310] * 16
 
         transport._client.read_holding_registers = AsyncMock(
             side_effect=[
                 _mock_result(master_regs),
                 _mock_result(cell_regs),
-                _mock_error(),  # unit 2 fails
             ],
         )
 
         results = await transport.read_all()
         assert len(results) == 1
-        # No slaves → no re-decode → aggregate SOC
-        assert results[0].soc == 79
+        assert results[0].voltage == pytest.approx(52.96)
+        assert results[0].soc == 80
+        assert results[0].current_capacity == pytest.approx(224.0)
 
 
 class TestOverlayInverterBMS:

--- a/tests/unit/transports/test_battery_modbus.py
+++ b/tests/unit/transports/test_battery_modbus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +16,7 @@ from pylxpweb.transports.battery_modbus import (
     _INITIAL_BLOCK_COUNT,
     _MIN_INITIAL_REGISTERS,
     _PROTOCOL_MAP,
+    _UNIT_TOPOLOGY_RETENTION,
     BatteryModbusTransport,
     _initial_block_requirement,
 )
@@ -166,6 +168,57 @@ class TestBatteryModbusTransportConnect:
             await transport.connect()
 
         assert transport.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_waits_for_in_flight_read(self) -> None:
+        """A public connect cannot replace the client between read blocks (#248)."""
+        transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[2])
+        original_client = AsyncMock()
+        original_client.connected = True
+        original_client.close = MagicMock()
+        transport._client = original_client
+        transport._connected = True
+
+        first_block_started = asyncio.Event()
+        release_first_block = asyncio.Event()
+        original_calls = 0
+
+        async def read_original_block(*_args: object, **_kwargs: object) -> MagicMock:
+            nonlocal original_calls
+            original_calls += 1
+            if original_calls == 1:
+                first_block_started.set()
+                await release_first_block.wait()
+                return _mock_result(_make_slave_regs())
+            return _mock_result([0] * 23)
+
+        original_client.read_holding_registers = AsyncMock(side_effect=read_original_block)
+
+        replacement_client = AsyncMock()
+        replacement_client.connected = True
+        replacement_client.connect = AsyncMock()
+        replacement_client.close = MagicMock()
+        replacement_client.read_holding_registers = AsyncMock(return_value=_mock_result([0] * 23))
+
+        with patch(
+            "pylxpweb.transports.battery_modbus.AsyncModbusTcpClient",
+            return_value=replacement_client,
+        ):
+            read_task = asyncio.create_task(transport.read_unit(2))
+            await asyncio.wait_for(first_block_started.wait(), timeout=1.0)
+
+            connect_task = asyncio.create_task(transport.connect())
+            await asyncio.sleep(0)
+            connect_interleaved = connect_task.done()
+
+            release_first_block.set()
+            data = await asyncio.wait_for(read_task, timeout=1.0)
+            await asyncio.wait_for(connect_task, timeout=1.0)
+
+        assert connect_interleaved is False
+        assert data is not None
+        assert original_client.read_holding_registers.await_count == 2
+        replacement_client.read_holding_registers.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_disconnect(self, connected_transport: BatteryModbusTransport) -> None:
@@ -962,10 +1015,10 @@ class TestBatteryModbusTransportHealth:
         assert connected_transport._degraded_units == {2}
 
     @pytest.mark.asyncio
-    async def test_successful_reconnect_resets_counter(
+    async def test_successful_reconnect_completes_without_deadlock_and_resets_counter(
         self, connected_transport: BatteryModbusTransport
     ) -> None:
-        """Only a genuinely connected replacement client resets the error gate."""
+        """Locked reconnect completes and a connected client resets the gate (#248)."""
         connected_transport._client.read_holding_registers = AsyncMock(
             side_effect=[
                 _mock_error(),
@@ -984,9 +1037,11 @@ class TestBatteryModbusTransportHealth:
         )
 
         async def disconnect_side_effect() -> None:
+            assert connected_transport._operation_lock.locked()
             connected_transport._connected = False
 
         async def connect_side_effect() -> None:
+            assert connected_transport._operation_lock.locked()
             connected_transport._connected = True
             assert connected_transport._client is not None
             connected_transport._client.connected = True
@@ -994,16 +1049,16 @@ class TestBatteryModbusTransportHealth:
         with (
             patch.object(
                 connected_transport,
-                "disconnect",
+                "_disconnect_locked",
                 new=AsyncMock(side_effect=disconnect_side_effect),
             ) as disconnect,
             patch.object(
                 connected_transport,
-                "connect",
+                "_connect_locked",
                 new=AsyncMock(side_effect=connect_side_effect),
             ) as connect,
         ):
-            data = await connected_transport.read_unit(2)
+            data = await asyncio.wait_for(connected_transport.read_unit(2), timeout=1.0)
 
         assert data is not None
         disconnect.assert_awaited_once()
@@ -1019,10 +1074,10 @@ class TestBatteryModbusTransportHealth:
         connected_transport._connected = False
 
         with (
-            patch.object(connected_transport, "disconnect", new_callable=AsyncMock),
+            patch.object(connected_transport, "_disconnect_locked", new_callable=AsyncMock),
             patch.object(
                 connected_transport,
-                "connect",
+                "_connect_locked",
                 new=AsyncMock(return_value=False),
             ) as connect,
             patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0),
@@ -1044,10 +1099,10 @@ class TestBatteryModbusTransportHealth:
         connected_transport._client.read_holding_registers = AsyncMock(return_value=_mock_error())
 
         with (
-            patch.object(connected_transport, "disconnect", new_callable=AsyncMock),
+            patch.object(connected_transport, "_disconnect_locked", new_callable=AsyncMock),
             patch.object(
                 connected_transport,
-                "connect",
+                "_connect_locked",
                 new=AsyncMock(side_effect=OSError("bridge down")),
             ),
             patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0),
@@ -1066,15 +1121,18 @@ class TestBatteryModbusTransportHealth:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """A small monotonic value permits attempt one, then cooldown/dedup apply."""
+        assert connected_transport._reconnect_retry_after is None
         connected_transport._consecutive_errors = connected_transport._max_consecutive_errors
         connected_transport._connected = False
 
         with (
             caplog.at_level(logging.DEBUG),
-            patch.object(connected_transport, "disconnect", new_callable=AsyncMock) as disconnect,
+            patch.object(
+                connected_transport, "_disconnect_locked", new_callable=AsyncMock
+            ) as disconnect,
             patch.object(
                 connected_transport,
-                "connect",
+                "_connect_locked",
                 new=AsyncMock(return_value=False),
             ) as connect,
             patch(
@@ -1342,6 +1400,247 @@ class TestReadAllWithSlaves:
         assert len(results) == 2
         assert results[0].soc == 79
         assert results[0].current_capacity is None
+
+    @pytest.mark.asyncio
+    async def test_auto_scan_remembers_a_missing_slave(self) -> None:
+        """A shrunken later scan cannot validate its own partial topology (#249)."""
+        transport = BatteryModbusTransport(host="10.100.3.27", max_units=3)
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+        transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result([100]),
+                _mock_result([100]),
+                _mock_result([100]),
+                _mock_result(_make_master_regs()),
+                _mock_result([3310] * 16),
+                _mock_result(_make_slave_regs(remaining=224)),
+                _mock_result([0] * 23),
+                _mock_result(_make_slave_regs(remaining=223)),
+                _mock_result([0] * 23),
+                _mock_result([100]),
+                _mock_result([100]),
+                _mock_error(),
+                _mock_result(_make_master_regs()),
+                _mock_result([3310] * 16),
+                _mock_result(_make_slave_regs(remaining=224)),
+                _mock_result([0] * 23),
+            ]
+        )
+
+        with patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock):
+            with patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0):
+                complete_results = await transport.read_all()
+            with patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=2.0):
+                partial_results = await transport.read_all()
+
+        assert complete_results[0].soc == 76
+        assert complete_results[0].current_capacity == pytest.approx(213.0)
+        assert len(partial_results) == 2
+        assert partial_results[0].soc == 79
+        assert partial_results[0].current_capacity is None
+
+    @pytest.mark.asyncio
+    async def test_auto_scan_two_battery_bank_redecodes_master(self) -> None:
+        """Remembered topology permits a complete genuine two-unit bank (#249)."""
+        transport = BatteryModbusTransport(host="10.100.3.27", max_units=2)
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+        transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result([100]),
+                _mock_result([100]),
+                _mock_result(_make_master_regs(reg26=43700, reg27=56000)),
+                _mock_result([3310] * 16),
+                _mock_result(_make_slave_regs(remaining=224)),
+                _mock_result([0] * 23),
+            ]
+        )
+
+        with (
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+            patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0),
+        ):
+            results = await transport.read_all()
+
+        assert len(results) == 2
+        assert results[0].soc == 76
+        assert results[0].current_capacity == pytest.approx(213.0)
+
+    @pytest.mark.asyncio
+    async def test_never_seen_explicit_slave_remains_required(self) -> None:
+        """A configured slave is required even before its first response (#249)."""
+        transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1, 2, 3])
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+        transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result(_make_master_regs()),
+                _mock_result([3310] * 16),
+                _mock_result(_make_slave_regs(remaining=224)),
+                _mock_result([0] * 23),
+                _mock_error(),
+            ]
+        )
+
+        with (
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+            patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0),
+        ):
+            results = await transport.read_all()
+
+        assert len(results) == 2
+        assert results[0].soc == 79
+        assert results[0].current_capacity is None
+        assert transport._unit_last_seen == {1: 1.0, 2: 1.0, 3: 1.0}
+
+    @pytest.mark.asyncio
+    async def test_stale_topology_evicts_after_retention_from_small_monotonic(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A removed unit eventually stops pinning aggregate SOC on low uptime (#249)."""
+        transport = BatteryModbusTransport(host="10.100.3.27", max_units=3)
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+        transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result([100]),
+                _mock_result([100]),
+                _mock_result([100]),
+                _mock_result(_make_master_regs()),
+                _mock_result([3310] * 16),
+                _mock_result(_make_slave_regs(remaining=224)),
+                _mock_result([0] * 23),
+                _mock_result(_make_slave_regs(remaining=223)),
+                _mock_result([0] * 23),
+                _mock_result([100]),
+                _mock_result([100]),
+                _mock_error(),
+                _mock_result(_make_master_regs(reg26=43700, reg27=56000)),
+                _mock_result([3310] * 16),
+                _mock_result(_make_slave_regs(remaining=224)),
+                _mock_result([0] * 23),
+            ]
+        )
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0):
+                await transport.read_all()
+            with patch(
+                "pylxpweb.transports.battery_modbus.time.monotonic",
+                return_value=_UNIT_TOPOLOGY_RETENTION + 2.0,
+            ):
+                results = await transport.read_all()
+
+        assert len(results) == 2
+        assert results[0].soc == 76
+        assert results[0].current_capacity == pytest.approx(213.0)
+        assert set(transport._unit_last_seen) == {1, 2}
+        assert any(
+            record.levelno == logging.INFO
+            and "unit 3" in record.getMessage()
+            and "topology" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_evicted_declared_unit_does_not_re_arm_the_gate(self) -> None:
+        """Convergence must hold, not flap once per retention window (#249).
+
+        With explicit unit_ids, every poll re-offers the configured list to
+        topology memory.  Seeding on that offer alone would re-admit a unit the
+        previous cycle had just evicted, so an removed-but-still-configured
+        battery would hand back one cycle of individual SOC/capacity every six
+        hours and revert in between -- a periodic step in history rather than a
+        convergence.  Only a genuine response re-admits an evicted unit, so the
+        cycle after eviction must look exactly like the eviction cycle.
+        """
+        transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1, 2, 3])
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+
+        def one_poll() -> list[MagicMock]:
+            return [
+                _mock_result(_make_master_regs(soc=79, reg26=43700, reg27=56000)),
+                _mock_result([3310] * 16),
+                _mock_result(_make_slave_regs(soc=80, remaining=224)),
+                _mock_result([0] * 23),
+                _mock_error(),  # unit 3 stays dead throughout
+            ]
+
+        with patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock):
+            with patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0):
+                transport._client.read_holding_registers = AsyncMock(side_effect=one_poll())
+                first = await transport.read_all()
+            assert first[0].current_capacity is None  # aggregate held
+
+            with patch(
+                "pylxpweb.transports.battery_modbus.time.monotonic",
+                return_value=_UNIT_TOPOLOGY_RETENTION * 3,
+            ):
+                transport._client.read_holding_registers = AsyncMock(side_effect=one_poll())
+                converged = await transport.read_all()
+            assert converged[0].current_capacity == pytest.approx(213.0)
+
+            # The next poll re-offers unit 3; it must not be re-seeded.
+            with patch(
+                "pylxpweb.transports.battery_modbus.time.monotonic",
+                return_value=_UNIT_TOPOLOGY_RETENTION * 3 + 60.0,
+            ):
+                transport._client.read_holding_registers = AsyncMock(side_effect=one_poll())
+                after = await transport.read_all()
+
+        assert after[0].current_capacity == pytest.approx(213.0)
+        assert after[0].soc == converged[0].soc
+        assert set(transport._unit_last_seen) == {1, 2}
+        assert transport._evicted_units == {3}
+
+    @pytest.mark.asyncio
+    async def test_returning_unit_is_readmitted_after_eviction(self) -> None:
+        """A battery that comes back must rejoin topology and re-gate the master.
+
+        Eviction is not a permanent blacklist: a genuine response re-admits the
+        unit, which immediately makes the re-decode gate demand it again.
+        """
+        transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1, 2, 3])
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+        transport._evicted_units = {3}
+
+        with (
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+            patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=10.0),
+        ):
+            transport._client.read_holding_registers = AsyncMock(
+                side_effect=[
+                    _mock_result(_make_master_regs(soc=79, reg26=43700, reg27=56000)),
+                    _mock_result([3310] * 16),
+                    _mock_result(_make_slave_regs(soc=80, remaining=224)),
+                    _mock_result([0] * 23),
+                    _mock_result(_make_slave_regs(soc=80, remaining=223)),  # unit 3 returns
+                    _mock_result([0] * 23),
+                ]
+            )
+            results = await transport.read_all()
+
+        assert len(results) == 3
+        assert transport._evicted_units == set()
+        assert set(transport._unit_last_seen) == {1, 2, 3}
 
 
 class TestOverlayInverterBMS:

--- a/tests/unit/transports/test_battery_modbus.py
+++ b/tests/unit/transports/test_battery_modbus.py
@@ -1609,6 +1609,89 @@ class TestReadAllWithSlaves:
         assert transport._evicted_units == {3}
 
     @pytest.mark.asyncio
+    async def test_auto_scan_cold_start_boundary_is_pinned_as_is(self) -> None:
+        """Auto-scan's first scan cannot protect against a unit never seen (#249).
+
+        Topology memory is built from observation, so a fresh transport with
+        unit_ids=None whose very first scan misses a unit has nothing to compare
+        against: the remembered set is already short and the re-decode gate
+        passes on incomplete topology.  This is the original defect's shape in a
+        narrow, self-healing window, and it is pinned deliberately rather than
+        fixed -- closing it would require a declared expected unit count, which
+        is exactly the configuration auto-scan exists to avoid.  The second half
+        of this test is the self-heal: once the missing unit answers even once,
+        it is remembered and its later silence blocks the gate.
+        """
+        transport = BatteryModbusTransport(host="10.100.3.27", max_units=3)
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+
+        with (
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+            patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0),
+        ):
+            transport._client.read_holding_registers = AsyncMock(
+                side_effect=[
+                    _mock_result([100]),  # scan: unit 1 answers
+                    _mock_result([100]),  # scan: unit 2 answers
+                    _mock_error(),  # scan: unit 3 silent on the very first scan
+                    _mock_result(_make_master_regs(soc=79, reg26=43700, reg27=56000)),
+                    _mock_result([3310] * 16),
+                    _mock_result(_make_slave_regs(soc=80, remaining=224)),
+                    _mock_result([0] * 23),
+                ]
+            )
+            cold = await transport.read_all()
+
+        # Boundary: the gate passed, because unit 3 was never observed.
+        assert cold[0].current_capacity == pytest.approx(213.0)
+        assert set(transport._unit_last_seen) == {1, 2}
+
+        # Self-heal: unit 3 answers once, so it joins remembered topology...
+        with (
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+            patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=2.0),
+        ):
+            transport._client.read_holding_registers = AsyncMock(
+                side_effect=[
+                    _mock_result([100]),
+                    _mock_result([100]),
+                    _mock_result([100]),  # unit 3 present this time
+                    _mock_result(_make_master_regs(soc=79, reg26=43700, reg27=56000)),
+                    _mock_result([3310] * 16),
+                    _mock_result(_make_slave_regs(soc=80, remaining=224)),
+                    _mock_result([0] * 23),
+                    _mock_result(_make_slave_regs(soc=80, remaining=223)),
+                    _mock_result([0] * 23),
+                ]
+            )
+            await transport.read_all()
+        assert set(transport._unit_last_seen) == {1, 2, 3}
+
+        # ...and from now on its silence keeps the master on the aggregate.
+        with (
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+            patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=3.0),
+        ):
+            transport._client.read_holding_registers = AsyncMock(
+                side_effect=[
+                    _mock_result([100]),
+                    _mock_result([100]),
+                    _mock_error(),  # unit 3 silent again, but now remembered
+                    _mock_result(_make_master_regs(soc=79, reg26=43700, reg27=56000)),
+                    _mock_result([3310] * 16),
+                    _mock_result(_make_slave_regs(soc=80, remaining=224)),
+                    _mock_result([0] * 23),
+                ]
+            )
+            healed = await transport.read_all()
+
+        assert healed[0].current_capacity is None
+        assert healed[0].soc == 79
+
+    @pytest.mark.asyncio
     async def test_returning_unit_is_readmitted_after_eviction(self) -> None:
         """A battery that comes back must rejoin topology and re-gate the master.
 

--- a/tests/unit/transports/test_battery_modbus.py
+++ b/tests/unit/transports/test_battery_modbus.py
@@ -409,10 +409,10 @@ class TestBatteryModbusTransportScanUnits:
         assert result == [1, 3]
 
     @pytest.mark.asyncio
-    async def test_scan_nonresponding_units_does_not_degrade_or_reconnect(
+    async def test_individual_scan_misses_on_responding_bus_do_not_escalate(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Expected scan misses stay outside health warnings and the reconnect gate."""
+        """Expected per-ID misses stay silent when at least one unit proves the bus is live."""
         transport = BatteryModbusTransport(
             host="10.100.3.27",
             max_units=4,
@@ -423,8 +423,13 @@ class TestBatteryModbusTransportScanUnits:
 
         err_result = MagicMock()
         err_result.isError.return_value = True
+        ok_result = MagicMock()
+        ok_result.isError.return_value = False
+        ok_result.registers = [100]
 
-        transport._client.read_holding_registers = AsyncMock(return_value=err_result)
+        transport._client.read_holding_registers = AsyncMock(
+            side_effect=[err_result, ok_result, err_result, err_result]
+        )
 
         with (
             caplog.at_level(logging.WARNING),
@@ -432,11 +437,81 @@ class TestBatteryModbusTransportScanUnits:
         ):
             result = await transport.scan_units()
 
-        assert result == []
+        assert result == [2]
         assert transport._consecutive_errors == 0
         assert transport._degraded_units == set()
         reconnect.assert_not_awaited()
-        assert not [record for record in caplog.records if "read degraded" in record.getMessage()]
+        assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+
+    @pytest.mark.asyncio
+    async def test_empty_scan_warns_once_and_reaches_reconnect_gate(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A wholly silent scan is one bus failure and eventually reconnects (#248)."""
+        transport = BatteryModbusTransport(host="10.100.3.27", max_units=2)
+        transport._client = AsyncMock()
+        transport._client.connected = False
+        transport._connected = False
+        transport._client.read_holding_registers = AsyncMock(return_value=_mock_error())
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+            patch.object(transport, "_reconnect", new_callable=AsyncMock) as reconnect,
+        ):
+            for _ in range(transport._max_consecutive_errors):
+                assert await transport.scan_units() == []
+
+        assert transport._consecutive_errors == transport._max_consecutive_errors
+        reconnect.assert_awaited_once()
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "no units responded" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "10.100.3.27:502" in warnings[0].getMessage()
+        assert "1-2" in warnings[0].getMessage()
+        assert transport._degraded_units == set()
+
+    @pytest.mark.asyncio
+    async def test_nonempty_scan_logs_recovery_and_resets_bus_fault(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The first responding unit clears the empty-scan episode and counter."""
+        transport = BatteryModbusTransport(host="10.100.3.27", max_units=1)
+        transport._client = AsyncMock()
+        transport._client.connected = True
+        transport._connected = True
+        transport._client.read_holding_registers = AsyncMock(
+            side_effect=[_mock_error(), _mock_result([100])]
+        )
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            assert await transport.scan_units() == []
+            assert await transport.scan_units() == [1]
+
+        assert transport._consecutive_errors == 0
+        assert sum("no units responded" in r.getMessage() for r in caplog.records) == 1
+        assert sum("responding again" in r.getMessage() for r in caplog.records) == 1
+
+    @pytest.mark.asyncio
+    async def test_scan_holds_operation_lock_across_all_probes(self) -> None:
+        """A public unit read cannot race the shared client during a scan loop."""
+        transport = BatteryModbusTransport(host="10.100.3.27", max_units=2)
+
+        async def probe(*_args: object, **_kwargs: object) -> list[int]:
+            assert transport._operation_lock.locked()
+            return [100]
+
+        with (
+            patch.object(transport, "_read_registers", side_effect=probe),
+            patch("pylxpweb.transports.battery_modbus.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            assert await transport.scan_units() == [1, 2]
 
 
 class TestBatteryModbusTransportReadAll:
@@ -887,10 +962,10 @@ class TestBatteryModbusTransportHealth:
         assert connected_transport._degraded_units == {2}
 
     @pytest.mark.asyncio
-    async def test_max_consecutive_errors_trigger_reconnect_and_reset(
+    async def test_successful_reconnect_resets_counter(
         self, connected_transport: BatteryModbusTransport
     ) -> None:
-        """The request after three failed unit reads reconnects before a clean read."""
+        """Only a genuinely connected replacement client resets the error gate."""
         connected_transport._client.read_holding_registers = AsyncMock(
             side_effect=[
                 _mock_error(),
@@ -908,9 +983,25 @@ class TestBatteryModbusTransportHealth:
             connected_transport._consecutive_errors == connected_transport._max_consecutive_errors
         )
 
+        async def disconnect_side_effect() -> None:
+            connected_transport._connected = False
+
+        async def connect_side_effect() -> None:
+            connected_transport._connected = True
+            assert connected_transport._client is not None
+            connected_transport._client.connected = True
+
         with (
-            patch.object(connected_transport, "disconnect", new_callable=AsyncMock) as disconnect,
-            patch.object(connected_transport, "connect", new_callable=AsyncMock) as connect,
+            patch.object(
+                connected_transport,
+                "disconnect",
+                new=AsyncMock(side_effect=disconnect_side_effect),
+            ) as disconnect,
+            patch.object(
+                connected_transport,
+                "connect",
+                new=AsyncMock(side_effect=connect_side_effect),
+            ) as connect,
         ):
             data = await connected_transport.read_unit(2)
 
@@ -918,6 +1009,142 @@ class TestBatteryModbusTransportHealth:
         disconnect.assert_awaited_once()
         connect.assert_awaited_once()
         assert connected_transport._consecutive_errors == 0
+
+    @pytest.mark.asyncio
+    async def test_reconnect_returning_false_does_not_reset_counter(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """pymodbus returns False on normal network failure, which is not recovery."""
+        connected_transport._consecutive_errors = connected_transport._max_consecutive_errors
+        connected_transport._connected = False
+
+        with (
+            patch.object(connected_transport, "disconnect", new_callable=AsyncMock),
+            patch.object(
+                connected_transport,
+                "connect",
+                new=AsyncMock(return_value=False),
+            ) as connect,
+            patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0),
+        ):
+            await connected_transport._reconnect()
+
+        connect.assert_awaited_once()
+        assert (
+            connected_transport._consecutive_errors == connected_transport._max_consecutive_errors
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconnect_exception_does_not_escape_read_all(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """A raising connect cannot crash a poll or reset the failed gate."""
+        connected_transport.unit_ids = [2]
+        connected_transport._consecutive_errors = connected_transport._max_consecutive_errors
+        connected_transport._client.read_holding_registers = AsyncMock(return_value=_mock_error())
+
+        with (
+            patch.object(connected_transport, "disconnect", new_callable=AsyncMock),
+            patch.object(
+                connected_transport,
+                "connect",
+                new=AsyncMock(side_effect=OSError("bridge down")),
+            ),
+            patch("pylxpweb.transports.battery_modbus.time.monotonic", return_value=1.0),
+        ):
+            results = await connected_transport.read_all()
+
+        assert results == []
+        assert (
+            connected_transport._consecutive_errors >= connected_transport._max_consecutive_errors
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconnect_cooldown_and_warning_dedup_start_at_small_monotonic(
+        self,
+        connected_transport: BatteryModbusTransport,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A small monotonic value permits attempt one, then cooldown/dedup apply."""
+        connected_transport._consecutive_errors = connected_transport._max_consecutive_errors
+        connected_transport._connected = False
+
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch.object(connected_transport, "disconnect", new_callable=AsyncMock) as disconnect,
+            patch.object(
+                connected_transport,
+                "connect",
+                new=AsyncMock(return_value=False),
+            ) as connect,
+            patch(
+                "pylxpweb.transports.battery_modbus.time.monotonic",
+                side_effect=[1.0, 2.0, 32.0],
+            ),
+        ):
+            await connected_transport._reconnect()
+            await connected_transport._reconnect()
+            await connected_transport._reconnect()
+
+        assert disconnect.await_count == 2
+        assert connect.await_count == 2
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "Reconnecting battery" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert any(
+            record.levelno == logging.DEBUG and "Reconnecting battery" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_successful_read_recovers_reconnect_warning_episode(
+        self,
+        connected_transport: BatteryModbusTransport,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A real response clears warning dedup/cooldown and logs one recovery."""
+        connected_transport._reconnect_warned = True
+        connected_transport._reconnect_retry_after = 60.0
+        connected_transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result(_make_slave_regs()),
+                _mock_result([0] * 23),
+            ]
+        )
+
+        with caplog.at_level(logging.INFO):
+            assert await connected_transport.read_unit(2) is not None
+
+        assert connected_transport._reconnect_warned is False
+        assert connected_transport._reconnect_retry_after is None
+        recoveries = [
+            r for r in caplog.records if "recovered after a successful read" in r.getMessage()
+        ]
+        assert len(recoveries) == 1
+
+    @pytest.mark.asyncio
+    async def test_unit_read_holds_operation_lock_across_gate_and_reads(
+        self, connected_transport: BatteryModbusTransport
+    ) -> None:
+        """The reconnect gate and register reads share one client-operation lock."""
+        connected_transport._consecutive_errors = connected_transport._max_consecutive_errors
+
+        async def reconnect() -> None:
+            assert connected_transport._operation_lock.locked()
+            connected_transport._consecutive_errors = 0
+
+        async def read_registers(*_args: object, **_kwargs: object) -> None:
+            assert connected_transport._operation_lock.locked()
+            return None
+
+        with (
+            patch.object(connected_transport, "_reconnect", side_effect=reconnect),
+            patch.object(connected_transport, "_read_registers", side_effect=read_registers),
+        ):
+            assert await connected_transport.read_unit(2) is None
 
 
 class TestInitialBlockRequirement:
@@ -1006,8 +1233,8 @@ class TestReadAllWithSlaves:
     """Tests for read_all() master SOC back-calculation using slave context."""
 
     @pytest.mark.asyncio
-    async def test_master_redecoded_with_slave_context(self) -> None:
-        """Master SOC is back-calculated from slave remaining capacities."""
+    async def test_full_slave_context_redecodes_master(self) -> None:
+        """A complete slave set back-calculates master remaining capacity."""
         transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1, 2, 3])
         transport._client = AsyncMock()
         transport._client.close = MagicMock()
@@ -1043,8 +1270,8 @@ class TestReadAllWithSlaves:
         assert results[2].soc == 80
 
     @pytest.mark.asyncio
-    async def test_master_without_slaves_is_redecoded(self) -> None:
-        """A master-only bank still derives voltage and individual capacity."""
+    async def test_single_battery_keeps_aggregate_soc_and_derives_voltage(self) -> None:
+        """A genuine one-battery bank needs no capacity back-calculation."""
         transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1])
         transport._client = AsyncMock()
         transport._client.close = MagicMock()
@@ -1064,8 +1291,57 @@ class TestReadAllWithSlaves:
         results = await transport.read_all()
         assert len(results) == 1
         assert results[0].voltage == pytest.approx(52.96)
-        assert results[0].soc == 80
-        assert results[0].current_capacity == pytest.approx(224.0)
+        assert results[0].soc == 79
+        assert results[0].current_capacity is None
+
+    @pytest.mark.asyncio
+    async def test_failed_only_slave_keeps_master_aggregate_soc(self) -> None:
+        """An empty slave result is failed topology, not proof of one battery (#249)."""
+        transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1, 2])
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+
+        transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result(_make_master_regs(soc=79, reg26=22400, reg27=28000)),
+                _mock_result([3310] * 16),
+                _mock_error(),
+            ]
+        )
+
+        results = await transport.read_all()
+
+        assert len(results) == 1
+        assert results[0].voltage == pytest.approx(52.96)
+        assert results[0].soc == 79
+        assert results[0].current_capacity is None
+
+    @pytest.mark.asyncio
+    async def test_partial_slave_context_keeps_master_aggregate_soc(self) -> None:
+        """One missing battery from a three-unit bank makes subtraction unsafe (#249)."""
+        transport = BatteryModbusTransport(host="10.100.3.27", unit_ids=[1, 2, 3])
+        transport._client = AsyncMock()
+        transport._client.close = MagicMock()
+        transport._client.connected = True
+        transport._connected = True
+
+        transport._client.read_holding_registers = AsyncMock(
+            side_effect=[
+                _mock_result(_make_master_regs(soc=79, reg26=464, reg27=18464)),
+                _mock_result([3310] * 16),
+                _mock_result(_make_slave_regs(soc=80, remaining=224)),
+                _mock_result([0] * 23),
+                _mock_error(),
+            ]
+        )
+
+        results = await transport.read_all()
+
+        assert len(results) == 2
+        assert results[0].soc == 79
+        assert results[0].current_capacity is None
 
 
 class TestOverlayInverterBMS:

--- a/tests/unit/transports/test_data.py
+++ b/tests/unit/transports/test_data.py
@@ -409,6 +409,22 @@ class TestBatteryData:
         assert data.soc == 85
         assert data.cycle_count == 150
 
+    def test_power_none_when_voltage_absent_with_live_current(self) -> None:
+        """Zero-voltage sentinel times live current is unknown power, not zero watts."""
+        data = BatteryData(voltage=0.0, current=-20.0)
+
+        assert data.power is None
+
+    def test_all_zero_register_slot_is_absent(self) -> None:
+        """An empty 5002+ slot remains absent under the named predicate."""
+        assert BatteryData().is_absent() is True
+
+    def test_dropped_cell_master_with_live_current_is_not_absent(self) -> None:
+        """A master with absent voltage but a live current is degraded, not a ghost."""
+        data = BatteryData(voltage=0.0, soc=0, current=-20.0, temperature=19.0)
+
+        assert data.is_absent() is False
+
     def test_from_modbus_registers_cell_numbers_not_crossed(self) -> None:
         """Cell-number registers: offset 14 = temp numbers, offset 15 = voltage numbers.
 
@@ -500,6 +516,23 @@ class TestBatteryBankData:
         assert len(bank.batteries) == 2
         assert bank.batteries[0].serial_number == "BAT001"
         assert bank.batteries[1].serial_number == "BAT002"
+
+    def test_voltage_delta_ignores_absent_voltage(self) -> None:
+        """One absent and one usable pack cannot manufacture a 52.94 V spread."""
+        bank = BatteryBankData(
+            batteries=[
+                BatteryData(voltage=0.0, current=-20.0),
+                BatteryData(voltage=52.94),
+            ]
+        )
+
+        assert bank.voltage_delta is None
+
+    def test_battery_power_none_when_bank_voltage_absent(self) -> None:
+        """A live bank current cannot turn the zero-voltage sentinel into zero watts."""
+        bank = BatteryBankData(voltage=0.0, current=-20.0)
+
+        assert bank.battery_power is None
 
 
 class TestBatteryBankDataBMSFallback:

--- a/tests/unit/transports/test_data_corruption.py
+++ b/tests/unit/transports/test_data_corruption.py
@@ -409,6 +409,21 @@ class TestBatteryBankDataCorruption:
         data = BatteryBankData(soc=85, soh=95, current=750.0, battery_count=3, batteries=ghosts)
         assert data.is_corrupt() is True  # count stays 3 -> 500A floor
 
+    def test_degraded_zero_voltage_batteries_count_as_present(self) -> None:
+        """Live signals keep dropped-cell masters present and widen only the current cap."""
+        degraded = [
+            BatteryData(voltage=0.0, soc=0, current=-20.0, temperature=19.0) for _ in range(4)
+        ]
+        data = BatteryBankData(
+            soc=0,
+            soh=95,
+            current=600.0,
+            battery_count=0,
+            batteries=degraded,
+        )
+
+        assert data.is_corrupt() is False
+
 
 class TestMidboxRuntimeDataCorruption:
     """Corruption detection for MidboxRuntimeData."""


### PR DESCRIPTION
Fixes #249, Fixes #248

Both issues live in the RS485 battery subsystem and are fixed together on one branch. Neither is user-facing today — `BatteryModbusTransport` has no consumer in the integration yet — which is exactly why they should land before eg4_web_monitor#176 wires it up.

## #249 — master voltage silently substituted the bank minimum

`EG4MasterProtocol` reported register 22 as the master battery's own pack voltage. Reg 22 is documented **in this same module** as the MINIMUM across the whole bank, so on any multi-battery chain the master published a plausible-looking number that was not its voltage.

`decode_with_slaves()` had an override meant to replace it with the sum of the master's own cells, but it was unreachable in the cases that mattered:

- It sat *after* the capacity early-returns, so a perfect cell block still yielded the bank minimum whenever regs 26/27 read zero. This is the larger defect and the original issue body missed it — it means the wrong value appeared even with a completely healthy cell block.
- A dropped cell block leaves sixteen `0.0` entries. That is a **truthy** list, so `if data.cell_voltages:` was entered and then abandoned on `cell_sum > 0`, falling through to reg 22.

### Fix

- Master voltage is derived in `decode()` by a new `_derive_master_voltage()`, independent of the SOC/capacity back-calculation. The ordering bug disappears because the early returns now only skip SOC/capacity work.
- The cell sum is used **only** when the set is complete and usable: positive `cell_count`, matching length, every cell positive and within named plausibility bounds (sanity guards against corrupt registers, not spec limits). Otherwise the value is `0.0`, which `transports/data.py` already documents as "absent, not corrupt".
- Reg 22 is never used as master voltage — including in a genuine single-battery bank where it would happen to be right. The protocol cannot distinguish that case from a multi-battery bank whose slaves failed to read, and a wrong-but-plausible voltage is worse than an obviously absent one. This trade is documented in the code.
- **Register 22 is renamed `bank_min_voltage` in the master map.** The name `voltage` is what permitted the mislabeling in the first place; a future `_reg("voltage")` on the master now fails loudly instead of silently reintroducing the bug. A test pins that lookup failing.
- `read_all()` re-decodes the master through `decode_with_slaves` even when no slave decoded, decoupling master-voltage correctness from slave availability. An empty slave list is the correct single-bank context: the full unwrapped total *is* the master's own remaining capacity.
- min/max cell voltage siblings are untouched — they prefer dedicated registers 37/38 and never relabel bank data. Confirmed not affected.

`test_dropped_cell_block_falls_back_to_bank_minimum_voltage` enshrined the wrong behaviour by pinning 52.94. It is renamed and now pins the sentinel.

## #248 — no error escalation, no reconnect, stale `is_connected`

A unit that failed or truncated every read was indistinguishable at INFO from a unit that was simply absent. The error branch was quieter still: `if result.isError(): return None` logged nothing at all.

### Fix

- DEBUG log on the `isError()` branch — it no longer returns silently.
- Once-per-unit transition WARNING on first failure, in the `_degrade_coalescing` style: names the unit, block start, expected vs got register counts, and likely causes. Cleared with an INFO recovery line only when an entire unit read completes (runtime block **and** every extra block), so a unit whose cell block keeps failing does not flap warn/recover every cycle.
- Consecutive-error tracking plus a reconnect gate mirroring `_ModbusBase._consecutive_errors` / `_reconnect`, including the lock and double-check.
- `is_connected` is re-derived from the client instead of trusting a cached flag, so a mid-session socket drop is visible.
- **Discovery probes in `scan_units()` are exempt from all three.** Non-responding IDs are expected misses; counting them would turn every scan into a burst of warnings plus a spurious reconnect.
- Per-read behaviour stays DEBUG-and-drop. The non-raising contract of this transport is deliberate and unchanged.

## Validation

- `uv run pytest tests/` — 2870 passed, 5 skipped (2858 before; **+12 tests**)
  - the two touched test files go 94 → 106
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean
- `uv run mypy src/pylxpweb/ --strict` — clean, 94 source files

## Points worth adversarial scrutiny

1. **The 0.0 sentinel costs a real value in one case**: a single-battery bank whose cell block drops now reports absent instead of reg 22, which would have been correct there. Deliberate — see above — but it is a genuine trade, not a free win.
2. **Plausibility bounds are judgement calls** (1.0–5.0 V per cell). Wide enough not to reject real LiFePO4 data, narrow enough to catch corruption.
3. **Consecutive errors reset on any successful read**, so a unit whose extra block always fails never reaches the reconnect threshold — the link is demonstrably alive. Intentional, but it means that failure mode escalates only to the once-per-unit WARNING.
4. **`_reconnect` resets the error counter even if `connect()` fails**, matching `_ModbusBase` exactly. Consistent with the existing pattern rather than better than it.
5. `test_decode_voltage_rejects_cell_count_length_mismatch` patches `decode_cell_voltages` to force a length mismatch the real function cannot currently produce — a contract guard on an unreachable branch, kept as defence in depth.
6. `read_all` now always re-decodes the master. Worth confirming the empty-slave capacity path is right for a genuine one-battery bank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Fix round — tri-model adversarial review (commit `bb9f013`)

A tri-model review (Codex gpt-5.6-sol, Gemini 3.1 Pro, Fable) returned **FIX-FIRST** with 5 blockers and 5 should-fix items, every one reproduced by at least two reviewers. All 10 are addressed here. The original scrutiny list above is superseded by the one at the bottom.

## Blockers

**1. Empty slave list was treated as proof of a single-battery bank.** Dropping the `and slave_results` guard meant that when slaves *failed* on a multi-battery bank, the bank's aggregate remaining was reported as the master's own — reproduced at 71%/200Ah against a true ~36%/100Ah, and worse at mid/low SOC. The guard removal bought nothing for #249, because voltage is derived in `decode()` and `decode_with_slaves` passes it straight through.

Fixed with a condition stricter than the original: the master is re-decoded only when **every** polled non-master unit decoded. A partial set is as unsafe as an empty one — in a three-battery bank, subtracting one of two slaves over-reports the master by the missing pack's capacity. With incomplete context, reg 21 remains a real aggregate bank SOC instead of a fabricated individual number.

**Trade, stated explicitly:** if explicit `unit_ids` names a battery that is permanently removed, the master now reports aggregate SOC indefinitely rather than its individual value. That is deliberate — a real bank number beats a fabricated individual one, and blocker 2's escalation makes the missing unit visible rather than silent. Pinned by `test_failed_only_slave_keeps_master_aggregate_soc`.

**2. Default auto-scan mode could never escalate or reconnect.** With `unit_ids=None` every read is probe-exempt, so a dead bridge yielded `errors=0`, no warning and no reconnect *forever*, while `read_all` logged "Read 0 batteries" at INFO. Individual probe misses stay exempt (that judgement was endorsed), but a scan where **nothing** responded now counts once as a bus fault, warns once per episode, reaches the reconnect gate, and logs recovery. The old test pinned the broken behaviour and has been split.

**3. The 0.0 absent sentinel leaked downstream as real measurements.** Reproduced: 0 W beside a live −20 A, and a 52.94 V "spread" against a healthy sibling. Zero voltage is now treated as absent everywhere it feeds a derived value — `BatteryData.power` and `Battery.power` return `None`, bank `voltage_delta` and `battery_power` exclude it, and `Battery.voltage` lets the cloud `totalVoltage` fallback engage instead of being suppressed by a `0.0`.

**4. Reconnect warnings had no dedup or cooldown** — measured 13 warnings per 10 cycles with 4 units (~300/hr at a 30s poll with 8 units). Now transition-warned with a 30s monotonic cooldown, using a `None` sentinel rather than `0.0`: `monotonic()` is host uptime, so a `0.0` default makes the first attempt on a freshly booted host look throttled and it silently never fires. That exact bug hit eg4 PRs #378/#380; there is a regression test with `monotonic` patched to a small value.

**5. The error counter reset even when `connect()` failed.** pymodbus returns `False` on ordinary network failure rather than raising, so a failed reconnect looked successful and re-armed the gate from scratch; and a raising `connect()` would have escaped `_read_unit_raw` and crashed the whole poll. `connect()` is now guarded and the counter resets only on a confirmed connection, with the cooldown preventing thrash.

## Should-fix

**6.** Added a canonical `BatteryData.is_absent()` used at all three ghost sites. A master with a dropped cell block but live current or temperature is present-but-degraded and no longer vanishes from the bank; all-zero 5002+ slots classify exactly as before, both directions tested.

**7.** A corrupted low cell count passed the completeness guard (`reg41=15` with sixteen good cells → a plausible, wrong 49.65 V). Two independent cross-checks now apply: a plausible cell sitting immediately past the declared count proves the count under-reported, and the derived sum cannot sit materially below register 22, since the master is one of the packs that bank minimum is taken over. This gives the renamed register a real job, which also retires the separate finding that it was decoded but discarded.

**8.** `scripts/decode_master_battery.py` still printed reg 22 as the master's pack voltage — the exact bug the library just fixed. It now reuses the library helper and labels the bank minimum as such.

**9.** Two tests advertised protection they did not provide: one mocked out the function under test to exercise dead logic, the other patched both `connect` and `disconnect` so a failing reconnect was never exercised (it is what masked blocker 5). Both reworked against real register and connection states.

**10.** Corrected the `bank_min_voltage` comment — register metadata does not drive reads, block start/count does — and added an operation lock spanning the reconnect gate and the reads, so a concurrent public `read_unit` cannot queue work on a client about to be closed. Fixed rather than documented away.

## Validation

- `uv run pytest tests/` — **2894 passed, 5 skipped** (2870 at the previous commit, **+24 tests**)
- `uv run ruff check src/ tests/ scripts/` — clean
- `uv run ruff format --check src/ tests/ scripts/` — clean, 227 files
- `uv run mypy src/pylxpweb/ --strict` — clean, 94 source files

## Scrutiny points for the re-review

1. **Blast radius beyond the RS485 transport.** Blocker 3 changes shared types: `BatteryData.power` and `Battery.power` become `float | None`, and `BatteryBankData.battery_power` returns `None` when bank voltage is 0. That affects the **cloud path too**, not just this transport — a bank legitimately reporting 0 V now yields unavailable instead of 0 W. Intended and consistent with `data.py`'s existing "voltage 0 = absent" contract, but it is a user-visible change on a path this PR was not otherwise touching.
2. **The removed-battery trade in blocker 1** (above) — the deliberate choice to hold aggregate SOC forever when a configured unit never returns.
3. **`_MIN_PLAUSIBLE_CELL_COUNT = 15`** is a judgement call. The only EG4 pack documented in this repo is 16S (WP-16/280); the floor sits one below so an unseen 15S variant is not rejected outright. A 16S pack whose count corrupts to 15 is caught by the cross-checks, not by this bound. The comment was corrected from an earlier draft that asserted "EG4 master packs are 15S or 16S" as established fact — it is not.
4. **`is_absent()` includes `temperature == 0`**, so a battery genuinely at exactly 0 °C with no other live signal still classifies absent. No regression (it was already ghost-classified under the old predicate), but it is an inherited sharp edge.
5. **The 0.5 V reg-22 tolerance** is unvalidated against hardware sampling skew.
6. **Operation-lock granularity**: `read_all` acquires and releases per unit, so a concurrent `read_unit` can still interleave between units. No worse than before, and lock order (operation → reconnect) is documented as never reversed.


---

# Round 3 — delta review (commit `875c515`)

**1. [P1] The all-slaves-decoded gate was self-referential in auto-scan mode.** `expected_slaves = len(units) - 1`, where `units` is whatever the scan just found — so in default mode the gate validated the topology against itself. A 3-battery bank transiently scanning as `[1, 2]` passed the gate on incomplete context and re-decoded the master wrong (aggregate 79% → 0%/0.0 Ah). Every existing gate test used explicit `unit_ids`; that is precisely how this survived round 2.

The gate now has **topology memory**: units are stamped when genuinely observed, remembered for 6h (mirroring the #258/#170 eviction precedent), and the gate compares **ID sets** — re-decode only when the decoded slave IDs cover the remembered topology. Counts are what let a shrunken scan look complete. A removed battery evicts after 6h so the bank converges rather than pinning to the aggregate forever, which supersedes the earlier "aggregate indefinitely" trade.

**Anti-flap, found by probing the built branch rather than reading it.** The first implementation re-seeded an evicted unit as soon as the configured `unit_ids` were offered again on the next poll. That re-armed the gate one cycle after eviction, so an explicitly configured but physically removed battery handed back a single cycle of individual SOC/capacity every six hours and reverted in between — a periodic step in history rather than a convergence, the same flapping class as #258/#261. Only a genuine response now re-admits an evicted unit; a returning battery is re-admitted immediately. Both properties are pinned by tests.

**2. [P2] Public `connect()`/`disconnect()` reassigned the shared client outside the operation lock,** so a caller invoking them mid-read could have later blocks land on a replacement connection. They now acquire the lock and delegate to `_connect_locked()`/`_disconnect_locked()`, which `_reconnect()` calls directly — `asyncio.Lock` is not reentrant, and having `_reconnect()` go through the public methods would have deadlocked the reconnect path outright, since its callers already hold the lock.

**3. [P3] The cooldown test passed even with `_reconnect_retry_after = 0.0`,** so it did not enforce the contract it advertised. The test now asserts the sentinel directly, and the constant's comment states the real reason `0.0` is harmless *here*: this is the absolute-deadline form (`now < deadline`), not the delta form (`now - last < INTERVAL`) whose `0.0` default caused the low-uptime bug in eg4 #378/#380. The `None` sentinel stays as the honest "never attempted" encoding and as protection if anyone later refactors to the delta form.

## Validation

- `uv run pytest tests/` — **2901 passed, 5 skipped** (2894 at the previous commit, **+7 tests**)
- `uv run ruff check src/ tests/ scripts/` — clean
- `uv run ruff format --check src/ tests/ scripts/` — clean, 227 files
- `uv run mypy src/pylxpweb/ --strict` — clean, 94 source files

## Updated scrutiny points

The round-2 list stands except for item 2, which is superseded: a removed battery now converges after 6h instead of holding the aggregate indefinitely. Added:

7. **Topology retention is 6h by analogy**, borrowed from the battery-eviction precedent in #258/#170. Nothing validates that this is the right window for *unit* topology specifically — it is a reasoned borrow, not a measured value.
8. **Eviction is time-based, so a bank polled less often than the retention window** would evict units between polls. Not reachable at any sane poll interval, but the coupling is real.
9. **`_evicted_units` grows unboundedly** in principle; bounded in practice by `max_units` and the configured `unit_ids`.


---

# Final touch — auto-scan cold-start boundary (commit `fd616f6`)

**No behaviour change.** Topology memory is built from observation, so it cannot remember a unit it has never seen. On a fresh transport with `unit_ids=None` whose *very first* scan misses a unit, the remembered set is already short and the re-decode gate passes on incomplete topology — the original #249 shape, in a narrow and self-healing window.

It self-heals permanently: the missing unit's first genuine response is remembered, after which its silence blocks the gate like any other unit's. Explicit `unit_ids` have no such window, because the declared list seeds memory before the first read. Closing it would require a declared expected unit count — precisely the configuration auto-scan exists to avoid — so it is documented at the gate and pinned by a test rather than fixed.

`test_auto_scan_cold_start_boundary_is_pinned_as_is` asserts all three phases: the cold-start gate pass, the self-heal once the unit answers once, and the aggregate hold on its later silence.

**Final gates:** 2902 passed / 5 skipped (**+1 test**); ruff check clean; format clean, 227 files; `mypy --strict` clean, 94 source files.
