### PR TITLE
fix: run firmware chains past an already-current component (eg4_web_monitor#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reproduced the same loop (a 6000XP stuck at `ccaa-1E1415` with target
   `ccaa-1E1515`, [eg4_web_monitor#353](https://github.com/joyfulhouse/eg4_web_monitor/issues/353)).
   `run_firmware_update_to_completion` now tolerates a bounded number of
-  consecutive completed-but-unchanged steps (`no_progress_grace`, default 1),
+  consecutive steps that ran without changing the version
+  (`no_progress_grace`, default 1),
   and only when the step was actually observed installing and did not report
-  FAILED. A genuinely stuck device still stops, and all writes stay bounded by
-  `max_steps`. The `needRunStep2..5` flags are logged (not used as a gate —
+  FAILED. A genuinely stuck device still stops, and accepted update steps stay
+  bounded by `max_steps`. The `needRunStep2..5` flags are logged (not used as a gate —
   their firmware semantics remain unverified) so the next field report
   captures them.
 - **A device that is busy before the update starts now fails fast**: busy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the device, not one that implies failure. Version comparison is
   case-insensitive, and a device that demonstrably moved is accepted even if
   it does not string-match the target, because the target can be a
-  reconstruction the server never echoes.
+  reconstruction the server never echoes. That movement test compares the
+  runtime code against a baseline read from the SAME endpoint at the start of
+  the run: comparing it against the check endpoint's version string would be
+  a cross-source comparison, and if the two shapes ever differed by more than
+  case, "not equal" would be permanently true and every sentinel would report
+  converged on its first occurrence. Without a same-source baseline the run
+  reports indeterminate rather than treating inequality as movement.
 - **Mid-chain activity attribution no longer demands a new status row**: the
   stale-row guard added for the previous release compared each step's status
   row against a pre-POST snapshot. That is right for the FIRST step, where the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ccaa-1E1515`, [eg4_web_monitor#353](https://github.com/joyfulhouse/eg4_web_monitor/issues/353)).
   `run_firmware_update_to_completion` now tolerates a bounded number of
   consecutive steps that ran without changing the version
-  (`no_progress_grace`, default 1),
-  and only when the step was actually observed installing and did not report
-  FAILED. A genuinely stuck device still stops, and accepted update steps stay
-  bounded by `max_steps`. The `needRunStep2..5` flags are logged (not used as a gate —
-  their firmware semantics remain unverified) so the next field report
-  captures them.
+  (`no_progress_grace`, **default 2**), and only when that step's OWN start was
+  observed installing — evidence attributed to our start POST, not any
+  in-progress row for the serial, since a leftover row from an earlier run
+  reads identically — and did not report FAILED. **Honest residual: this
+  converges only while the server does not select more than
+  `no_progress_grace` already-current components in a row.** The default is 2
+  rather than 1 because a device can have several already-current components
+  and the server picks the order; with 1, a device whose first two selections
+  are already-current fails with the identical symptom one step later. The
+  same number sets the blind-reflash exposure on a genuinely stuck device:
+  `no_progress_grace + 1` accepted writes (3). A step only counts as progress
+  if it reaches a version state not already seen in this run, so a check
+  endpoint flapping between two stale snapshots cannot reset the grace
+  indefinitely. Accepted update steps stay bounded by `max_steps`, and refused
+  starts are separately capped per step so the write endpoint cannot be called
+  without bound inside the busy budget. The `needRunStep2..5` flags are logged
+  (not used as a gate — their firmware semantics remain unverified) so the next
+  field report captures them.
+- **Convergence now requires evidence, not just the absence of an update**:
+  "no update available" was treated as success, and an empty installed version
+  in the up-to-date sentinel was backfilled with the target — so a device still
+  sitting on the old firmware could be reported as successfully updated to a
+  version it never reached, silently reintroducing the partial upgrade this
+  release exists to fix. Convergence now requires a concrete installed version
+  equal to the target the run set out to reach (pinned from the first check, so
+  a later answer cannot redefine the goal); anything else is reported as a
+  possible partial upgrade with only what is actually known.
 - **A device that is busy before the update starts now fails fast**: busy
   tolerance was introduced for inter-component settling of a chain already in
   flight, but it also applied before the first step, so a device still
@@ -36,7 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shortly. The deliberate mid-chain tolerance is unchanged and now runs on its
   own wider budget (`busy_grace`, default 900s, bounded by `step_timeout`),
   because a component reboot can outlast the post-start visibility grace and
-  giving up there strands the device mid-chain.
+  giving up there strands the device mid-chain. Busy classification is now
+  matched against the known busy codes instead of any message containing
+  "updating": a permanent failure like "Failed updating firmware: invalid
+  checksum" was being retried for the whole budget and then reported as "device
+  remained busy", burying the real cause — which mattered more once that budget
+  tripled. A structurally permanent eligibility refusal (`notAllowedInParallel`)
+  is likewise surfaced at once instead of polled, since waiting cannot clear it.
 - **An "already the latest version" refusal mid-chain no longer surfaces as a
   raw error**: if the check endpoint lags a successful final step past the
   settle window, the no-progress grace can ask for one step too many. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without bound inside the busy budget. The `needRunStep2..5` flags are logged
   (not used as a gate — their firmware semantics remain unverified) so the next
   field report captures them.
+- **Convergence is corroborated against the device, not inferred from the
+  check endpoint alone**: `checkUpdates` answers an up-to-date device with
+  success:false "already the latest version", which the client synthesizes
+  into a record whose installed version is EMPTY — so neither trusting that
+  answer (a partially upgraded device reads as success) nor rejecting it (a
+  genuinely converged device reads as FAILURE, at the exact moment it
+  succeeded) is correct on its own. The orchestrator now reads the device's
+  actual `fwCode` from the runtime endpoint to decide: on the target →
+  converged; still on the version the run started from → the answer was
+  transient, keep going rather than abandoning the chain; unreadable →
+  reported as indeterminate with a message that says to verify the version on
+  the device, not one that implies failure. Version comparison is
+  case-insensitive, and a device that demonstrably moved is accepted even if
+  it does not string-match the target, because the target can be a
+  reconstruction the server never echoes.
+- **Mid-chain activity attribution no longer demands a new status row**: the
+  stale-row guard added for the previous release compared each step's status
+  row against a pre-POST snapshot. That is right for the FIRST step, where the
+  threat — a leftover row from an earlier run — actually lives, but on a
+  portal that keeps one row per update session and updates it in place, step 2
+  would find an unchanged in-progress row, be refused the grace, and fail with
+  the original reported symptom. From step 2 onward an in-progress row is this
+  run's own activity and counts; the grace and step budget bound it regardless.
 - **Convergence now requires evidence, not just the absence of an update**:
   "no update available" was treated as success, and an empty installed version
   in the up-to-date sentinel was backfilled with the target — so a device still
@@ -62,8 +85,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "updating": a permanent failure like "Failed updating firmware: invalid
   checksum" was being retried for the whole budget and then reported as "device
   remained busy", burying the real cause — which mattered more once that budget
-  tripled. A structurally permanent eligibility refusal (`notAllowedInParallel`)
-  is likewise surfaced at once instead of polled, since waiting cannot clear it.
+  tripled. Classification is two-stage: failure prose (failed/error/invalid/
+  checksum/corrupt/timeout) is permanent even when the message also says
+  "updating"; otherwise any busy/updating wording counts as busy, so portal
+  phrasings nobody has catalogued (`systemBusy`, "Device is updating, please
+  try again") are still waited out rather than aborting a chain that would
+  have succeeded moments later. A `notAllowedInParallel` eligibility refusal is
+  surfaced at once instead of polled for the full budget, worded as a likely
+  parallel-group conflict to retry after — our own run can induce it, so it is
+  not claimed to be permanent.
 - **An "already the latest version" refusal mid-chain no longer surfaces as a
   raw error**: if the check endpoint lags a successful final step past the
   settle window, the no-progress grace can ask for one step too many. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Firmware chains no longer stall on a component that is already at the
+  target version**: `standardUpdate/run` takes no component selector, so the
+  server chooses which component a run installs. On a partially upgraded
+  device it can choose one that is already current — that run downloads and
+  flashes normally but cannot move the version string. The orchestrator
+  treated the first unchanged version as a dead chain and aborted, so the
+  component that actually needed upgrading never ran and every retry
+  reproduced the same loop (a 6000XP stuck at `ccaa-1E1415` with target
+  `ccaa-1E1515`, [eg4_web_monitor#353](https://github.com/joyfulhouse/eg4_web_monitor/issues/353)).
+  `run_firmware_update_to_completion` now tolerates a bounded number of
+  consecutive completed-but-unchanged steps (`no_progress_grace`, default 1),
+  and only when the step was actually observed installing and did not report
+  FAILED. A genuinely stuck device still stops, and all writes stay bounded by
+  `max_steps`. The `needRunStep2..5` flags are logged (not used as a gate —
+  their firmware semantics remain unverified) so the next field report
+  captures them.
+- **A device that is busy before the update starts now fails fast**: busy
+  tolerance was introduced for inter-component settling of a chain already in
+  flight, but it also applied before the first step, so a device still
+  recovering from an earlier update held the caller for the whole retry budget
+  (~5 minutes of "Installing") before failing. Busy responses — from the
+  eligibility probe or the start call — now return immediately while
+  `steps_run == 0`, with a message saying the device is busy and to retry
+  shortly. The deliberate mid-chain tolerance is unchanged and now runs on its
+  own wider budget (`busy_grace`, default 900s, bounded by `step_timeout`),
+  because a component reboot can outlast the post-start visibility grace and
+  giving up there strands the device mid-chain.
+- **An "already the latest version" refusal mid-chain is reported as
+  convergence**: if the check endpoint lags a successful final step past the
+  settle window, the no-progress grace can ask for one step too many; the
+  server's refusal is convergence, not an error to surface after a successful
+  update. Before any step, the same response still propagates — that is a
+  genuine disagreement between the check and run endpoints about a device we
+  have not touched.
+
 ## [0.9.39b5] - 2026-07-27
 
 This section accumulates the whole 0.9.39 beta line: b1 through b4 were tagged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   successful update as failed**: the corroboration read is retried a bounded
   number of times before settling on indeterminate, because the most likely
   moment for it to fail is while the device reboots after its final component
-  — exactly when the update has in fact succeeded. `ValidationError` is caught
+  — exactly when the update has in fact succeeded. The pre-run baseline read
+  gets the same retry: run start is a transient-failure moment in its own
+  right (a device recovering from an earlier attempt), and a failed baseline
+  disables the movement check for the entire run. `ValidationError` is caught
   alongside API errors, since `fwCode` is a required field and a device
   omitting it mid-reboot would otherwise raise straight out of the install
   action.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own wider budget (`busy_grace`, default 900s, bounded by `step_timeout`),
   because a component reboot can outlast the post-start visibility grace and
   giving up there strands the device mid-chain.
-- **An "already the latest version" refusal mid-chain is reported as
-  convergence**: if the check endpoint lags a successful final step past the
-  settle window, the no-progress grace can ask for one step too many; the
-  server's refusal is convergence, not an error to surface after a successful
-  update. Before any step, the same response still propagates — that is a
+- **An "already the latest version" refusal mid-chain no longer surfaces as a
+  raw error**: if the check endpoint lags a successful final step past the
+  settle window, the no-progress grace can ask for one step too many. The
+  refusal now triggers a forced re-check, and convergence is reported only if
+  that check agrees no update remains; otherwise the run reports a possible
+  partial upgrade with the real installed version, because the two endpoints
+  can genuinely disagree and a false success would hide exactly the failure
+  this fix is about. Before any step, the same response still propagates — that is a
   genuine disagreement between the check and run endpoints about a device we
   have not touched.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would find an unchanged in-progress row, be refused the grace, and fail with
   the original reported symptom. From step 2 onward an in-progress row is this
   run's own activity and counts; the grace and step budget bound it regardless.
+- **An opening "already up to date" answer in the sentinel shape is confirmed
+  before it is believed**: the pre-flight check returned success on "no update
+  available" with no corroboration, so a partially updated device whose first
+  check blinked was told it needed no update at all. An empty-version answer
+  now gets one confirming re-check after a short delay; both agreeing reports
+  up-to-date, disagreement proceeds into the chain. A concrete version with
+  nothing newer is still trusted on one read. Residual: two consecutive blinks
+  would still slip through — this is a confirmation, not a proof.
+- **A transient failure to read back the device's version no longer reports a
+  successful update as failed**: the corroboration read is retried a bounded
+  number of times before settling on indeterminate, because the most likely
+  moment for it to fail is while the device reboots after its final component
+  — exactly when the update has in fact succeeded. `ValidationError` is caught
+  alongside API errors, since `fwCode` is a required field and a device
+  omitting it mid-reboot would otherwise raise straight out of the install
+  action.
 - **Convergence now requires evidence, not just the absence of an update**:
   "no update available" was treated as success, and an empty installed version
   in the up-to-date sentinel was backfilled with the target — so a device still
@@ -96,7 +112,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "updating"; otherwise any busy/updating wording counts as busy, so portal
   phrasings nobody has catalogued (`systemBusy`, "Device is updating, please
   try again") are still waited out rather than aborting a chain that would
-  have succeeded moments later. A `notAllowedInParallel` eligibility refusal is
+  have succeeded moments later. Classification runs on the SERVER's message,
+  with the client's wrapper stripped first: `LuxpowerClient` raises
+  "API error (HTTP {status}): {msg}" and "Unexpected error: {msg}", both of
+  which contain the word "error" — so classifying the wrapped string matched
+  the wrapper, ruled every busy response permanent, and left the busy path
+  dead in production while unit tests injecting a bare "deviceBusy" passed. A `notAllowedInParallel` eligibility refusal is
   surfaced at once instead of polled for the full budget, worded as a likely
   parallel-group conflict to retry after — our own run can induce it, so it is
   not claimed to be permanent.

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -574,13 +574,14 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         re-flashed the already-current component, and aborting on the first
         unchanged version meant the component that actually needed upgrading
         never ran (eg4_web_monitor#353). ``no_progress_grace`` therefore
-        tolerates a bounded number of *consecutive* completed-but-unchanged
-        steps before declaring the chain dead.
+        tolerates a bounded number of *consecutive* steps that ran without
+        changing the version before declaring the chain dead.
 
         Busy handling is deliberately asymmetric. Before this invocation has
         started anything, a busy device means "not now" and fails fast — the
-        caller has written nothing, and making the user wait out a multi-minute
-        retry budget only to fail is worse than telling them immediately.
+        server has accepted no update start from us, and making the user wait out
+        a multi-minute retry budget only to fail is worse than saying so
+        immediately.
         Once a component HAS been started, busy means the chain we started is
         still settling, and the bounded retry budget applies.
 
@@ -737,7 +738,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             # split by whether THIS invocation has already started something:
             #
             #   steps_run == 0 (pre-flight): the device was busy before we
-            #     wrote anything — someone/something else is using it, or it is
+            #     had a start accepted — someone/something else is using it, or it is
             #     still recovering from an earlier update. Fail fast on both
             #     not-eligible and any busy-family error, from the eligibility
             #     probe or the start call. Burning the whole retry budget here
@@ -788,24 +789,41 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                         break
                     except LuxpowerAPIError as err:
                         if steps_run > 0 and _is_already_latest_error(err):
-                            # The check endpoint lagged a successful final step
-                            # past the settle window and the no-progress grace
-                            # asked for one step too many: the device is
-                            # converged. Report that rather than surfacing a raw
-                            # API error after a successful update. Only mid-chain
-                            # — the same response BEFORE any step means the check
-                            # and run endpoints disagree about a device we have
-                            # not touched, which must still surface.
+                            # The run endpoint says there is nothing left to
+                            # install while the check endpoint still advertises
+                            # an update. That is expected when the check lagged
+                            # a successful final step past the settle window and
+                            # the loop asked for one step too many — but it is
+                            # NOT self-evidently convergence: the two endpoints
+                            # can genuinely disagree about a partially upgraded
+                            # device, and reporting success there would hide the
+                            # exact partial-upgrade failure this issue is about.
+                            # Re-check and let the check endpoint confirm; never
+                            # declare convergence on the refusal alone.
+                            # (Pre-flight, this still propagates untouched.)
+                            info = await self.check_firmware_updates(force=True)
+                            if info.latest_version:
+                                last_target = info.latest_version
+                            if not info.update_available:
+                                return FirmwareUpdateRunResult(
+                                    success=True,
+                                    converged=True,
+                                    steps_run=steps_run,
+                                    message=(f"Firmware update complete after {steps_run} step(s)"),
+                                    final_version=info.installed_version or last_target,
+                                )
                             return FirmwareUpdateRunResult(
-                                success=True,
-                                converged=True,
+                                success=False,
+                                converged=False,
                                 steps_run=steps_run,
-                                message=(f"Firmware update complete after {steps_run} step(s)"),
-                                # The server asserts convergence, so the target
-                                # is the truthful version here; the lagging
-                                # check's installed_version is stale by
-                                # definition.
-                                final_version=last_target or info.installed_version,
+                                message=(
+                                    "Server refused a further update step as "
+                                    "'already the latest version', but the update "
+                                    "check still reports one available — the device "
+                                    "may be partially upgraded; re-check in a few "
+                                    "minutes before retrying"
+                                ),
+                                final_version=info.installed_version,
                             )
                         if not _is_device_busy_error(err):
                             raise
@@ -928,8 +946,10 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 # deliberately weaker signal used here, because a stronger one
                 # risks a fix that never fires in the field.
                 #
-                # Consecutive excuses are capped by no_progress_grace (and all
-                # writes by max_steps), so a genuinely stuck device still stops.
+                # Consecutive excuses are capped by no_progress_grace, and
+                # accepted update steps by max_steps (busy retries can issue
+                # more standardUpdate/run POSTs than that, but a refused one
+                # installs nothing), so a stuck device still stops.
                 if saw_in_progress and consecutive_no_progress < no_progress_grace:
                     consecutive_no_progress += 1
                     _LOGGER.info(

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -9,29 +9,40 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 _LOGGER = logging.getLogger(__name__)
 
-# Busy-family API responses that the update orchestrator waits out mid-chain.
-# Deliberately an explicit list: matching a bare "updating" substring also
-# caught permanent failures ("Failed updating firmware: invalid checksum"),
-# which were then retried for the whole busy budget instead of surfacing.
-_BUSY_ERROR_STEMS: tuple[str, ...] = (
-    "devicebusy",
-    "device_busy",
-    "deviceupdating",
-    "device_updating",
-    "parallelgroupupdating",
-    "parallel_group_updating",
-    "already updating",
-    "parallel group is updating",
+# Classifying an update-API error as "busy" decides whether the orchestrator
+# waits (up to busy_grace) or surfaces it. Both directions have a real cost, so
+# the test runs in two stages rather than matching one substring:
+#
+#   1. Failure prose wins outright. "Failed updating firmware: invalid
+#      checksum" contains "updating", and a one-substring test waited out the
+#      whole budget on it and then reported "device remained busy", burying
+#      the real cause.
+#   2. Otherwise any busy/updating wording counts as busy. An enumerated list
+#      of known codes is too narrow the other way: the portal also emits
+#      phrasings we have never seen (systemBusy, "Device is updating, please
+#      try again"), and treating an unrecognised busy response as permanent
+#      aborts a chain that would have succeeded moments later.
+#
+# Anything matching neither is treated as permanent and surfaced with its own
+# message, which is the safe default for an unknown write failure.
+_PERMANENT_FAILURE_PROSE: tuple[str, ...] = (
+    "failed",
+    "failure",
+    "error",
+    "invalid",
+    "checksum",
+    "corrupt",
+    "not support",
+    "unsupported",
+    "timeout",
+    "timed out",
 )
-# The transport also emits a bare ``BUSY`` / ``DEVICE BUSY`` code. Whole-word
-# so it cannot match inside unrelated prose.
-_BARE_BUSY_RE = re.compile(r"\bbusy\b")
+_BUSY_PROSE: tuple[str, ...] = ("busy", "updating")
 
 # Hard cap on ``standardUpdate/run`` POSTs issued for a single step. The busy
 # budget bounds elapsed time, not request count: at a 0.05s floor a 15-minute
@@ -64,8 +75,11 @@ def _is_fresh_step_evidence(
     * ``startTime`` changed → the server opened a new update record.
 
     An unchanged, already-installing row is the stale case and is refused.
-    Being wrong in the conservative direction only forfeits the grace, which
-    costs a retry; being wrong the other way authorises a real firmware write.
+    The asymmetry is deliberate but NOT free: being wrong the permissive way
+    authorises a real firmware write, while being wrong the conservative way
+    forfeits the grace and ENDS the run (the user sees the no-progress error
+    and has to press Install again). That is why this strict form is applied
+    only to the first step, where the stale-leftover threat actually lives.
     """
     if row is None or not row.is_in_progress:
         return False
@@ -142,6 +156,9 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         self._firmware_update_cache_time: datetime | None = None
         self._firmware_update_cache_ttl = timedelta(hours=24)  # 24-hour TTL
         self._firmware_update_cache_lock = asyncio.Lock()
+        # Raw status row from the most recent progress poll, kept so the
+        # update orchestrator can attribute activity without a second call.
+        self._last_status_row: FirmwareDeviceInfo | None = None
 
     @property
     def firmware_update_available(self) -> bool | None:
@@ -428,6 +445,10 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             (info for info in status.deviceInfos if info.inverterSn == serial),
             None,
         )
+        # Keep the raw row: the orchestrator needs its timing fields to
+        # attribute activity, and re-fetching it would both double the call
+        # rate and risk the two reads disagreeing about the same instant.
+        self._last_status_row = device_info
 
         # Determine progress state
         in_progress = False
@@ -603,6 +624,12 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         state to ``in_progress=False`` and drops the timing fields, so callers
         that need the terminal status or need to tell one update run from the
         next have to read the raw row.
+
+        Returns the FIRST row matching this serial. The API has never been
+        observed returning more than one per device, but ``packageIndex``
+        hints that per-component rows may exist; if a device ever reports
+        several, this picks whichever the server listed first rather than the
+        most recent, and the caller's attribution would need revisiting.
         """
         client: LuxpowerClient = self._client
         serial: str = self.serial_number
@@ -611,6 +638,33 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             (item for item in status.deviceInfos if item.inverterSn == serial),
             None,
         )
+
+    async def _read_device_firmware_code(self) -> str | None:
+        """Live firmware code from a source OTHER than ``checkUpdates``.
+
+        ``checkUpdates`` answers an up-to-date device with a synthesized
+        sentinel whose installed version is EMPTY (see
+        :meth:`FirmwareUpdateCheck.create_up_to_date`), so it cannot by itself
+        say which version a converged device is actually running. The runtime
+        endpoint reports ``fwCode`` unconditionally, which is what lets the
+        orchestrator tell "converged on the target" from "the check endpoint
+        blinked" without trusting either source alone.
+
+        Best-effort: any API/connection failure returns None, and the caller
+        reports an indeterminate result rather than guessing. Inverter-shaped
+        by default; MID devices may need their own override.
+        """
+        from pylxpweb.exceptions import LuxpowerError
+
+        client: LuxpowerClient = self._client
+        serial: str = self.serial_number
+        try:
+            runtime = await client.api.devices.get_inverter_runtime(serial)
+        except LuxpowerError:
+            _LOGGER.debug("Firmware corroboration read failed for %s", serial, exc_info=True)
+            return None
+        code: str | None = getattr(runtime, "fwCode", None)
+        return code or None
 
     async def _update_step_reported_failed(self) -> bool:
         """Whether ``remoteUpdate/info`` reports this device's update as FAILED.
@@ -754,26 +808,14 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             )
 
         def _is_device_busy_error(err: LuxpowerAPIError) -> bool:
-            # Matched against the KNOWN busy codes only, never a bare
-            # "updating" substring. The loose version classified anything
-            # containing "updating" as transient, so a permanent failure like
-            # "Failed updating firmware: invalid checksum" was retried for the
-            # whole busy budget and then reported as "device remained busy" —
-            # burying the real cause. That mattered more once this budget grew
-            # to busy_grace (15 min), so the matcher is now explicit:
-            #   - ``deviceBusy`` / ``device_busy`` / ``DEVICE_BUSY`` and the
-            #     bare ``BUSY`` transport transient code, as a whole word so
-            #     "invalid checksum" prose cannot match;
-            #   - the eligibility enum codes ``deviceUpdating`` /
-            #     ``parallelGroupUpdating``;
-            #   - the ``standardUpdate/run`` prose variants "Device is already
-            #     updating" / "Another device in the parallel group is
-            #     updating".
-            # Anything else propagates or is surfaced with its real message.
+            # Two stages, in order: failure prose wins outright, then any
+            # busy/updating wording counts as busy. See the module constants
+            # for why neither a bare substring nor an enumerated code list is
+            # right on its own.
             message = str(err).casefold()
-            if any(stem in message for stem in _BUSY_ERROR_STEMS):
-                return True
-            return _BARE_BUSY_RE.search(message) is not None
+            if any(prose in message for prose in _PERMANENT_FAILURE_PROSE):
+                return False
+            return any(prose in message for prose in _BUSY_PROSE)
 
         def _is_already_latest_error(err: LuxpowerAPIError) -> bool:
             # ``standardUpdate/run`` refuses a device it considers converged
@@ -809,6 +851,10 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         # the server contradicting itself, and re-deriving the target from
         # that same answer would turn the contradiction into a success.
         driving_target = info.latest_version or None
+        # The version the device was on when this run began. Corroborating a
+        # sentinel against this distinguishes "moved, and the server says
+        # nothing is left" from "never moved, the server just blinked".
+        started_from = info.installed_version or None
         loop = asyncio.get_running_loop()
         # Smallest wait between busy/eligibility re-polls. Floors poll_interval
         # so neither a degenerate 0 nor a small positive value (0.001) can
@@ -822,43 +868,103 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         # 0x14<->0x13 alternation spent five accepted flashes that way.
         seen_progress_keys: set[tuple[str | None, int | None, int | None]] = {_progress_key(info)}
 
-        def _converged_or_indeterminate(
+        def _same_version(left: str | None, right: str | None) -> bool:
+            # Firmware codes are hex-ish strings whose case the API is not
+            # consistent about ("ccaa-1E1515" vs "CCAA-1E1515"); a case
+            # difference is not a version difference.
+            return (
+                left is not None
+                and right is not None
+                and left.strip().casefold() == right.strip().casefold()
+            )
+
+        async def _convergence_verdict(
             step_index: int,
             check: FirmwareUpdateInfo,
             target: str | None,
-        ) -> FirmwareUpdateRunResult:
-            # "No update available" is necessary but NOT sufficient evidence of
-            # convergence. The check endpoint answers a converged device with a
-            # bare sentinel whose installed_version is EMPTY, and it can also
-            # answer that way transiently. Substituting the remembered target
-            # for an empty installed version — which this code used to do —
-            # lets a device still sitting on the old firmware be reported as
-            # success with the target as its version: the partial-upgrade
-            # failure this whole change exists to prevent, now silent.
+        ) -> tuple[FirmwareUpdateRunResult | None, str | None]:
+            # Called when the check endpoint says no update remains. That is
+            # necessary but NOT sufficient: a converged device is answered with
+            # a synthesized sentinel whose installed version is EMPTY (see
+            # FirmwareUpdateCheck.create_up_to_date), and the same shape can
+            # appear transiently mid-chain. Neither trusting it (reports a
+            # partially upgraded device as success) nor rejecting it (reports
+            # a genuinely converged device as failure, at the exact moment of
+            # success) is right on its own.
             #
-            # Convergence therefore requires a concrete installed version that
-            # equals the target we were driving toward. Anything else is
-            # reported as indeterminate, with only what is actually known.
+            # So corroborate from a source that always carries a version: the
+            # runtime endpoint's fwCode.
+            #
+            # Returns (verdict, corroborated_version). A verdict of None means
+            # "not converged, keep going" — the sentinel was transient.
             installed = check.installed_version or None
-            if installed is not None and (target is None or installed == target):
-                return FirmwareUpdateRunResult(
-                    success=True,
-                    converged=True,
-                    steps_run=step_index,
-                    message=f"Firmware update complete after {step_index} step(s)",
-                    final_version=installed,
+            if _same_version(installed, target) or (installed is not None and target is None):
+                return (
+                    FirmwareUpdateRunResult(
+                        success=True,
+                        converged=True,
+                        steps_run=step_index,
+                        message=f"Firmware update complete after {step_index} step(s)",
+                        final_version=installed,
+                    ),
+                    installed,
                 )
-            return FirmwareUpdateRunResult(
-                success=False,
-                converged=False,
-                steps_run=step_index,
-                message=(
-                    "Server reports no update available, but it did not confirm "
-                    f"the device reached {target or 'the target version'} "
-                    f"(it reports {installed or 'no version'}) — the device may be "
-                    "partially upgraded; re-check in a few minutes before retrying"
+
+            corroborated = await self._read_device_firmware_code()
+            if corroborated is not None:
+                if _same_version(corroborated, target) or target is None:
+                    return (
+                        FirmwareUpdateRunResult(
+                            success=True,
+                            converged=True,
+                            steps_run=step_index,
+                            message=f"Firmware update complete after {step_index} step(s)",
+                            final_version=corroborated,
+                        ),
+                        corroborated,
+                    )
+                if not _same_version(corroborated, started_from):
+                    # The device moved and the server says nothing further is
+                    # available. The target string can be a reconstruction
+                    # (from_api_response splices version bytes onto the code,
+                    # and for unverified layouts that splice is a guess the
+                    # server never echoes), so demanding an exact match here
+                    # would fail a real convergence. Accept the device's own
+                    # reported version as the outcome.
+                    return (
+                        FirmwareUpdateRunResult(
+                            success=True,
+                            converged=True,
+                            steps_run=step_index,
+                            message=(
+                                f"Firmware update complete after {step_index} step(s); "
+                                f"device reports {corroborated}"
+                            ),
+                            final_version=corroborated,
+                        ),
+                        corroborated,
+                    )
+                # Corroborated as still on the version we started from: the
+                # "no update available" answer was transient. Keep going.
+                return (None, corroborated)
+
+            # No corroboration available. Do not claim success, but do not
+            # imply the update failed either — say what is and is not known.
+            return (
+                FirmwareUpdateRunResult(
+                    success=False,
+                    converged=False,
+                    steps_run=step_index,
+                    message=(
+                        "Server reports no update remaining, but the device's "
+                        f"version could not be read back to confirm it reached "
+                        f"{target or 'the target'} — the update may well have "
+                        "completed; verify the firmware version on the device "
+                        "before running this again"
+                    ),
+                    final_version=installed,
                 ),
-                final_version=installed,
+                None,
             )
 
         def _budget_spent(
@@ -961,8 +1067,9 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                         converged=False,
                         steps_run=steps_run,
                         message=(
-                            f"Device refused the firmware update ({denial.value}); "
-                            "this will not clear on its own"
+                            f"Device refused the firmware update ({denial.value}) — "
+                            "this may indicate another update is running in its "
+                            "parallel group; retry once that completes"
                         ),
                         final_version=info.installed_version,
                     )
@@ -1012,7 +1119,11 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                             # (Pre-flight, this still propagates untouched.)
                             info = await self.check_firmware_updates(force=True)
                             if not info.update_available:
-                                return _converged_or_indeterminate(steps_run, info, driving_target)
+                                verdict, _ = await _convergence_verdict(
+                                    steps_run, info, driving_target
+                                )
+                                if verdict is not None:
+                                    return verdict
                             return FirmwareUpdateRunResult(
                                 success=False,
                                 converged=False,
@@ -1043,6 +1154,9 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     )
                 await asyncio.sleep(min(retry_backoff, max(0.0, busy_deadline - loop.time())))
 
+            # Captured BEFORE the increment: strict evidence attribution
+            # applies only to the first step of this invocation.
+            is_first_step = steps_run == 0
             if not started:
                 # steps_run counts steps the SERVER ACCEPTED, per this
                 # method's contract and FirmwareUpdateRunResult's — a refused
@@ -1075,21 +1189,32 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             saw_in_progress = False
             # Governs whether this step may spend the no-progress grace. The
             # aggregated in_progress flag matches ANY in-progress row for the
-            # serial, including one left over from an earlier run — which
-            # would forge the grace's evidence for a step the server never
-            # ran. Only evidence that appeared or transitioned AFTER our start
-            # POST counts, established from the raw row's identity against the
-            # pre-POST baseline. Latched, so it costs one extra status read
-            # per step in the normal case.
+            # serial, including one left over from an earlier run.
+            #
+            # The threat is PRE-RUN leftovers, so strict attribution is only
+            # needed for the FIRST step: before we have written anything, an
+            # in-progress row is someone else's by definition. From step 2 on,
+            # this run has already had a start accepted, so an in-progress row
+            # is our own session's activity — and demanding a fresh startTime
+            # there would break on a portal that keeps ONE row per update
+            # session and updates it in place (plausible; packageIndex hints
+            # at per-component rows but that is unverified). Getting that
+            # wrong reintroduces the exact reported failure, so steps 2+ accept
+            # the in-progress reading; the grace and max_steps bound it either
+            # way. Latched, so attribution costs one extra status read per
+            # step at most.
             attributed_in_progress = False
             while True:
                 progress = await self.get_firmware_update_progress(force=True)
                 if progress.in_progress:
                     saw_in_progress = True
                     if not attributed_in_progress:
-                        attributed_in_progress = _is_fresh_step_evidence(
-                            await self._current_status_row(), step_baseline
-                        )
+                        if is_first_step:
+                            attributed_in_progress = _is_fresh_step_evidence(
+                                self._last_status_row, step_baseline
+                            )
+                        else:
+                            attributed_in_progress = True
                 elif saw_in_progress or loop.time() >= grace_deadline:
                     break
                 if loop.time() >= deadline:
@@ -1132,9 +1257,34 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     await asyncio.sleep(settle_interval)
                 info = await self.check_firmware_updates(force=True)
                 if not info.update_available:
-                    return _converged_or_indeterminate(steps_run, info, driving_target)
+                    verdict, corroborated = await _convergence_verdict(
+                        steps_run, info, driving_target
+                    )
+                    if verdict is not None:
+                        return verdict
+                    # Transient sentinel: the server said "nothing available"
+                    # but the device is corroborated as still on the version
+                    # this run started from. Do NOT abandon the chain on a
+                    # blink — fall through to the rest of the settle window
+                    # (which may yet return real data) and, failing that, to
+                    # the no-progress path, where the grace decides whether to
+                    # run another component. Identical handling to "the
+                    # version did not move", because that is what it is.
+                    _LOGGER.info(
+                        "Firmware step %d for %s: check reported no update while the "
+                        "device still reads %s — treating as a transient answer, not "
+                        "as convergence",
+                        steps_run,
+                        self.serial_number,
+                        corroborated,
+                    )
+                    continue
                 key = _progress_key(info)
-                if key != before and key not in seen_progress_keys:
+                # A blank installed version is the sentinel shape, not a
+                # distinct firmware state; counting it as novel would let an
+                # endpoint alternating between real data and the sentinel
+                # reset the grace forever.
+                if key[0] is not None and key != before and key not in seen_progress_keys:
                     # Movement to a state never seen in this run. Requiring
                     # novelty, not mere difference, is what stops a check
                     # endpoint flapping between two stale snapshots from

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -9,14 +9,81 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 _LOGGER = logging.getLogger(__name__)
 
+# Busy-family API responses that the update orchestrator waits out mid-chain.
+# Deliberately an explicit list: matching a bare "updating" substring also
+# caught permanent failures ("Failed updating firmware: invalid checksum"),
+# which were then retried for the whole busy budget instead of surfacing.
+_BUSY_ERROR_STEMS: tuple[str, ...] = (
+    "devicebusy",
+    "device_busy",
+    "deviceupdating",
+    "device_updating",
+    "parallelgroupupdating",
+    "parallel_group_updating",
+    "already updating",
+    "parallel group is updating",
+)
+# The transport also emits a bare ``BUSY`` / ``DEVICE BUSY`` code. Whole-word
+# so it cannot match inside unrelated prose.
+_BARE_BUSY_RE = re.compile(r"\bbusy\b")
+
+# Hard cap on ``standardUpdate/run`` POSTs issued for a single step. The busy
+# budget bounds elapsed time, not request count: at a 0.05s floor a 15-minute
+# budget would allow thousands of write-endpoint calls. Retries exist to ride
+# out a settling device, and a device that has refused this many starts is not
+# settling.
+_MAX_START_ATTEMPTS_PER_STEP = 12
+
+# Floor for the wait between busy/eligibility re-polls. Applies to any
+# poll_interval, not just zero: a small positive value (0.001) previously
+# slipped past the zero-check and hot-looped the API.
+_MIN_RETRY_BACKOFF = 0.05
+
+
+def _is_fresh_step_evidence(
+    row: FirmwareDeviceInfo | None,
+    baseline: FirmwareDeviceInfo | None,
+) -> bool:
+    """Whether ``row`` shows an update this run started, not a leftover one.
+
+    ``remoteUpdate/info`` rows carry no run identity, so a stale ``UPLOADING``
+    row from a previous update reads exactly like a live one — enough to spend
+    the orchestrator's no-progress grace on a step the server never ran.
+    Comparing against a snapshot taken immediately before the start POST
+    recovers the missing attribution:
+
+    * no row before, a row now → this run created it;
+    * the row was idle before and is installing now → it transitioned after
+      our start;
+    * ``startTime`` changed → the server opened a new update record.
+
+    An unchanged, already-installing row is the stale case and is refused.
+    Being wrong in the conservative direction only forfeits the grace, which
+    costs a retry; being wrong the other way authorises a real firmware write.
+    """
+    if row is None or not row.is_in_progress:
+        return False
+    if baseline is None:
+        return True
+    if row.startTime != baseline.startTime:
+        return True
+    return not baseline.is_in_progress
+
+
 if TYPE_CHECKING:
     from pylxpweb import LuxpowerClient
-    from pylxpweb.models import FirmwareUpdateInfo, FirmwareUpdateRunResult
+    from pylxpweb.models import (
+        FirmwareDeviceInfo,
+        FirmwareUpdateInfo,
+        FirmwareUpdateRunResult,
+        UpdateEligibilityStatus,
+    )
 
     class _FirmwareMixinBase:
         """Typed stubs so mypy sees attributes provided by the host class."""
@@ -513,11 +580,37 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             >>> else:
             ...     print("Device is not eligible for update (may be updating already)")
         """
+        eligibility = await self._update_eligibility_status()
+        return eligibility.is_allowed
+
+    async def _update_eligibility_status(self) -> UpdateEligibilityStatus:
+        """This device's raw eligibility status.
+
+        The orchestrator needs the eligibility *message*, not just the boolean
+        :meth:`check_update_eligibility` derives from it: a device that is
+        momentarily updating should be waited out, while a structural refusal
+        like ``notAllowedInParallel`` will never clear and must be surfaced
+        immediately rather than polled for the whole busy budget.
+        """
         client: LuxpowerClient = self._client
         serial: str = self.serial_number
+        return await client.api.firmware.check_update_eligibility(serial)
 
-        eligibility = await client.api.firmware.check_update_eligibility(serial)
-        return eligibility.is_allowed
+    async def _current_status_row(self) -> FirmwareDeviceInfo | None:
+        """This device's raw ``remoteUpdate/info`` row, or None if absent.
+
+        The aggregated progress conversion collapses every non-installing
+        state to ``in_progress=False`` and drops the timing fields, so callers
+        that need the terminal status or need to tell one update run from the
+        next have to read the raw row.
+        """
+        client: LuxpowerClient = self._client
+        serial: str = self.serial_number
+        status = await client.api.firmware.get_firmware_update_status()
+        return next(
+            (item for item in status.deviceInfos if item.inverterSn == serial),
+            None,
+        )
 
     async def _update_step_reported_failed(self) -> bool:
         """Whether ``remoteUpdate/info`` reports this device's update as FAILED.
@@ -527,13 +620,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         state to ``in_progress=False``, so the terminal FAILED status must be
         read from the raw status row.
         """
-        client: LuxpowerClient = self._client
-        serial: str = self.serial_number
-        status = await client.api.firmware.get_firmware_update_status()
-        row = next(
-            (item for item in status.deviceInfos if item.inverterSn == serial),
-            None,
-        )
+        row = await self._current_status_row()
         return row is not None and row.is_failed
 
     async def run_firmware_update_to_completion(
@@ -546,7 +633,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         start_grace: float = 300.0,
         settle_checks: int = 3,
         settle_interval: float = 30.0,
-        no_progress_grace: int = 1,
+        no_progress_grace: int = 2,
         busy_grace: float = 900.0,
     ) -> FirmwareUpdateRunResult:
         """Run firmware updates until the device converges on the latest version.
@@ -590,9 +677,10 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             poll_interval: Seconds between progress polls while a step is
                 installing.
             max_steps: Upper bound on ACCEPTED update steps (the API defines
-                steps 2-5, so 5 covers every known chain). Busy retries can
-                issue additional ``standardUpdate/run`` POSTs beyond this,
-                but a refused call installs nothing.
+                steps 2-5, so 5 covers every known chain). Refused starts do
+                not count against it, but they are separately capped per step
+                at ``_MAX_START_ATTEMPTS_PER_STEP`` so the write endpoint
+                cannot be called without bound inside the busy budget.
             step_timeout: Seconds to wait for a single step to finish
                 installing before aborting.
             start_grace: Seconds to keep polling for the update to become
@@ -604,11 +692,20 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 unchanged version is declared "no progress" (the check
                 endpoint can lag the status endpoint's terminal state).
             settle_interval: Seconds between those settle re-checks.
-            no_progress_grace: How many *consecutive* steps may complete
-                without moving the version before the chain is abandoned.
-                Only steps that were actually observed installing are
-                excused (see the loop body); 0 restores the pre-#353
-                abort-on-first-unchanged-version behaviour.
+            no_progress_grace: How many *consecutive* steps may run without
+                moving the version before the chain is abandoned. Only steps
+                whose own start was observed installing are excused (see the
+                loop body); 0 restores the pre-#353
+                abort-on-first-unchanged-version behaviour. Default 2 because
+                a device can have more than one already-current component and
+                the server picks the order: with 1, a device whose first TWO
+                selections are already-current fails with the identical
+                symptom one step later. This is the honest bound on the
+                feature — convergence is guaranteed only while the server does
+                not pick more than ``no_progress_grace`` already-current
+                components in a row. It also sets the blind-reflash exposure
+                on a genuinely stuck device: ``no_progress_grace + 1``
+                accepted writes.
             busy_grace: Seconds to keep re-polling a busy device BETWEEN
                 components before giving up on the chain (bounded by
                 ``step_timeout``). Only applies once a step has been started:
@@ -629,7 +726,18 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         # Import here to avoid circular imports
         from pylxpweb.endpoints.firmware import FIRMWARE_UP_TO_DATE_MESSAGES
         from pylxpweb.exceptions import LuxpowerAPIError
-        from pylxpweb.models import FirmwareUpdateRunResult
+        from pylxpweb.models import FirmwareUpdateRunResult, UpdateEligibilityMessage
+
+        # Eligibility refusals that waiting cannot clear. deviceUpdating /
+        # parallelGroupUpdating describe a device that is busy right now and
+        # will free up; this one describes a configuration the device will
+        # keep refusing, so it is surfaced at once instead of being polled for
+        # the whole busy budget. UNKNOWN is deliberately absent: undocumented
+        # codes (a literal ``deviceBusy`` among them) land there, and calling
+        # those permanent would undo the mid-chain tolerance.
+        _PERMANENT_ELIGIBILITY_DENIALS = frozenset(
+            {UpdateEligibilityMessage.NOT_ALLOWED_IN_PARALLEL}
+        )
 
         def _progress_key(
             info: FirmwareUpdateInfo,
@@ -646,21 +754,26 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             )
 
         def _is_device_busy_error(err: LuxpowerAPIError) -> bool:
-            # A start/eligibility call can lose a TOCTOU race and come back busy
-            # under any of the API's busy-ish codes, not just the observed
-            # ``deviceBusy``. Match on two stems that cover the whole family:
-            #   - ``busy``: ``deviceBusy`` / ``device_busy`` / ``DEVICE_BUSY`` /
-            #     bare ``BUSY`` (the transport transient code).
-            #   - ``updating``: the eligibility enum codes ``deviceUpdating`` /
-            #     ``parallelGroupUpdating`` AND the ``standardUpdate/run`` prose
-            #     variants ("Device is already updating", "Another device in the
-            #     parallel group is updating"). A non-busy start error ("no
-            #     update available", bad serial, etc.) does not contain either
-            #     stem, so it still propagates.
-            # Treat all busy-ish responses as transient so the bounded
-            # busy-retry tolerates the race instead of escaping raw.
+            # Matched against the KNOWN busy codes only, never a bare
+            # "updating" substring. The loose version classified anything
+            # containing "updating" as transient, so a permanent failure like
+            # "Failed updating firmware: invalid checksum" was retried for the
+            # whole busy budget and then reported as "device remained busy" —
+            # burying the real cause. That mattered more once this budget grew
+            # to busy_grace (15 min), so the matcher is now explicit:
+            #   - ``deviceBusy`` / ``device_busy`` / ``DEVICE_BUSY`` and the
+            #     bare ``BUSY`` transport transient code, as a whole word so
+            #     "invalid checksum" prose cannot match;
+            #   - the eligibility enum codes ``deviceUpdating`` /
+            #     ``parallelGroupUpdating``;
+            #   - the ``standardUpdate/run`` prose variants "Device is already
+            #     updating" / "Another device in the parallel group is
+            #     updating".
+            # Anything else propagates or is surfaced with its real message.
             message = str(err).casefold()
-            return "busy" in message or "updating" in message
+            if any(stem in message for stem in _BUSY_ERROR_STEMS):
+                return True
+            return _BARE_BUSY_RE.search(message) is not None
 
         def _is_already_latest_error(err: LuxpowerAPIError) -> bool:
             # ``standardUpdate/run`` refuses a device it considers converged
@@ -690,12 +803,63 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         # The converged version to report: once the device is up to date the
         # check endpoint answers with the bare "already latest" sentinel
         # (empty fwCodeBeforeUpload), so remember the target we converged to.
-        last_target = info.latest_version or None
+        # The version we set out to reach, pinned from the FIRST check and
+        # never rewritten. Convergence is judged against this: a later check
+        # that both claims "no update available" AND reports a lower target is
+        # the server contradicting itself, and re-deriving the target from
+        # that same answer would turn the contradiction into a success.
+        driving_target = info.latest_version or None
         loop = asyncio.get_running_loop()
         # Smallest wait between busy/eligibility re-polls. Floors poll_interval
-        # so a degenerate poll_interval=0 cannot hot-loop eligibility/start
-        # calls at the API; never exceeds the time left in the budget.
-        retry_backoff = poll_interval if poll_interval > 0 else 0.05
+        # so neither a degenerate 0 nor a small positive value (0.001) can
+        # hot-loop eligibility/start calls at the API; never exceeds the time
+        # left in the budget.
+        retry_backoff = max(poll_interval, _MIN_RETRY_BACKOFF)
+        # Every progress key observed in this run. A step only counts as
+        # progress if it reaches a state never seen before: the check endpoint
+        # can flap between two stale snapshots, and treating each flap as
+        # "movement" reset the no-progress grace indefinitely — an adversarial
+        # 0x14<->0x13 alternation spent five accepted flashes that way.
+        seen_progress_keys: set[tuple[str | None, int | None, int | None]] = {_progress_key(info)}
+
+        def _converged_or_indeterminate(
+            step_index: int,
+            check: FirmwareUpdateInfo,
+            target: str | None,
+        ) -> FirmwareUpdateRunResult:
+            # "No update available" is necessary but NOT sufficient evidence of
+            # convergence. The check endpoint answers a converged device with a
+            # bare sentinel whose installed_version is EMPTY, and it can also
+            # answer that way transiently. Substituting the remembered target
+            # for an empty installed version — which this code used to do —
+            # lets a device still sitting on the old firmware be reported as
+            # success with the target as its version: the partial-upgrade
+            # failure this whole change exists to prevent, now silent.
+            #
+            # Convergence therefore requires a concrete installed version that
+            # equals the target we were driving toward. Anything else is
+            # reported as indeterminate, with only what is actually known.
+            installed = check.installed_version or None
+            if installed is not None and (target is None or installed == target):
+                return FirmwareUpdateRunResult(
+                    success=True,
+                    converged=True,
+                    steps_run=step_index,
+                    message=f"Firmware update complete after {step_index} step(s)",
+                    final_version=installed,
+                )
+            return FirmwareUpdateRunResult(
+                success=False,
+                converged=False,
+                steps_run=step_index,
+                message=(
+                    "Server reports no update available, but it did not confirm "
+                    f"the device reached {target or 'the target version'} "
+                    f"(it reports {installed or 'no version'}) — the device may be "
+                    "partially upgraded; re-check in a few minutes before retrying"
+                ),
+                final_version=installed,
+            )
 
         def _budget_spent(
             step_index: int, installed_version: str | None
@@ -761,6 +925,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
 
             started = False
             attempted = False
+            start_attempts = 0
             while True:
                 # Never issue a RETRY start write once the budget is spent
                 # (checked before the attempt; the first genuine try is exempt
@@ -773,7 +938,9 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 # The eligibility probe is itself a network call that can come
                 # back busy (transport BUSY / deviceUpdating / parallelGroup).
                 try:
-                    eligible = await self.check_update_eligibility()
+                    eligibility = await self._update_eligibility_status()
+                    eligible = eligibility.is_allowed
+                    denial = eligibility.msg
                 except LuxpowerAPIError as err:
                     if not _is_device_busy_error(err):
                         raise
@@ -782,13 +949,51 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     # Mid-chain: still working — fall through to the bounded
                     # retry below rather than letting it escape raw.
                     eligible = False
+                    denial = None
+
+                if not eligible and denial in _PERMANENT_ELIGIBILITY_DENIALS:
+                    # Structural refusal: this will not clear by waiting, so
+                    # polling it for the whole busy budget only delays a
+                    # failure the user could act on now. Report the real
+                    # reason instead of "device remained busy".
+                    return FirmwareUpdateRunResult(
+                        success=False,
+                        converged=False,
+                        steps_run=steps_run,
+                        message=(
+                            f"Device refused the firmware update ({denial.value}); "
+                            "this will not clear on its own"
+                        ),
+                        final_version=info.installed_version,
+                    )
 
                 if eligible:
                     # The eligibility call can straddle the deadline; never fire
                     # a RETRY write past it (the first genuine try is exempt).
                     if not first_attempt and loop.time() >= busy_deadline:
                         return _budget_spent(steps_run, info.installed_version)
+                    if start_attempts >= _MAX_START_ATTEMPTS_PER_STEP:
+                        # The elapsed budget alone does not bound request
+                        # count; a device refusing this many starts is not
+                        # settling, it is refusing.
+                        return FirmwareUpdateRunResult(
+                            success=False,
+                            converged=False,
+                            steps_run=steps_run,
+                            message=(
+                                "Device refused "
+                                f"{_MAX_START_ATTEMPTS_PER_STEP} consecutive attempts to "
+                                f"start firmware update step {steps_run + 1}; giving up "
+                                "rather than continuing to call the update endpoint"
+                            ),
+                            final_version=info.installed_version,
+                        )
+                    start_attempts += 1
                     try:
+                        # Snapshot the status row BEFORE the write: the poll
+                        # loop needs to tell in-progress evidence caused by
+                        # THIS start from a leftover row of an earlier run.
+                        step_baseline = await self._current_status_row()
                         started = await self.start_firmware_update(try_fast_mode=try_fast_mode)
                         break
                     except LuxpowerAPIError as err:
@@ -806,16 +1011,8 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                             # declare convergence on the refusal alone.
                             # (Pre-flight, this still propagates untouched.)
                             info = await self.check_firmware_updates(force=True)
-                            if info.latest_version:
-                                last_target = info.latest_version
                             if not info.update_available:
-                                return FirmwareUpdateRunResult(
-                                    success=True,
-                                    converged=True,
-                                    steps_run=steps_run,
-                                    message=(f"Firmware update complete after {steps_run} step(s)"),
-                                    final_version=info.installed_version or last_target,
-                                )
+                                return _converged_or_indeterminate(steps_run, info, driving_target)
                             return FirmwareUpdateRunResult(
                                 success=False,
                                 converged=False,
@@ -846,8 +1043,10 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     )
                 await asyncio.sleep(min(retry_backoff, max(0.0, busy_deadline - loop.time())))
 
-            steps_run += 1
             if not started:
+                # steps_run counts steps the SERVER ACCEPTED, per this
+                # method's contract and FirmwareUpdateRunResult's — a refused
+                # start installed nothing, so it must not be counted.
                 return FirmwareUpdateRunResult(
                     success=False,
                     converged=False,
@@ -855,6 +1054,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     message="API refused to start the firmware update",
                     final_version=info.installed_version,
                 )
+            steps_run += 1
 
             # Poll the step to completion in two phases. The server registers
             # an accepted run in remoteUpdate/info asynchronously, so an idle
@@ -870,11 +1070,26 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             # comparable to the portal's own polling).
             deadline = loop.time() + step_timeout
             grace_deadline = loop.time() + start_grace
+            # Governs when polling STOPS (any in-progress reading means the
+            # device is working; unchanged behaviour).
             saw_in_progress = False
+            # Governs whether this step may spend the no-progress grace. The
+            # aggregated in_progress flag matches ANY in-progress row for the
+            # serial, including one left over from an earlier run — which
+            # would forge the grace's evidence for a step the server never
+            # ran. Only evidence that appeared or transitioned AFTER our start
+            # POST counts, established from the raw row's identity against the
+            # pre-POST baseline. Latched, so it costs one extra status read
+            # per step in the normal case.
+            attributed_in_progress = False
             while True:
                 progress = await self.get_firmware_update_progress(force=True)
                 if progress.in_progress:
                     saw_in_progress = True
+                    if not attributed_in_progress:
+                        attributed_in_progress = _is_fresh_step_evidence(
+                            await self._current_status_row(), step_baseline
+                        )
                 elif saw_in_progress or loop.time() >= grace_deadline:
                     break
                 if loop.time() >= deadline:
@@ -897,8 +1112,6 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 # Re-check so the reported version reflects any partial
                 # advance the failed step made before stopping.
                 info = await self.check_firmware_updates(force=True)
-                if info.latest_version:
-                    last_target = info.latest_version
                 return FirmwareUpdateRunResult(
                     success=False,
                     converged=False,
@@ -918,19 +1131,19 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 if settle:
                     await asyncio.sleep(settle_interval)
                 info = await self.check_firmware_updates(force=True)
-                if info.latest_version:
-                    last_target = info.latest_version
                 if not info.update_available:
-                    return FirmwareUpdateRunResult(
-                        success=True,
-                        converged=True,
-                        steps_run=steps_run,
-                        message=(f"Firmware update complete after {steps_run} step(s)"),
-                        final_version=info.installed_version or last_target,
-                    )
-                if _progress_key(info) != before:
+                    return _converged_or_indeterminate(steps_run, info, driving_target)
+                key = _progress_key(info)
+                if key != before and key not in seen_progress_keys:
+                    # Movement to a state never seen in this run. Requiring
+                    # novelty, not mere difference, is what stops a check
+                    # endpoint flapping between two stale snapshots from
+                    # resetting the grace on every flap and spending the whole
+                    # step budget on blind reflashes.
+                    seen_progress_keys.add(key)
                     consecutive_no_progress = 0
                     break  # component advanced — continue the chain
+                seen_progress_keys.add(key)
             else:
                 # No version movement across the settle window. This is NOT
                 # automatically a dead chain: standardUpdate/run takes no
@@ -940,21 +1153,23 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 # 6000XP stuck at ccaa-1E1415 re-flashed its already-current
                 # component as step 1 and the remaining one never ran).
                 #
-                # Excuse such a step only with positive evidence that it really
-                # ran: `saw_in_progress` means the status endpoint reported the
-                # device installing, and the FAILED check above already passed.
-                # A terminal SUCCESS/COMPLETE row would be stronger evidence,
-                # but it is not reliably observable on the reporting hardware —
-                # the poll loop exits as soon as in_progress goes false — so
-                # "was seen installing and did not report FAILED" is the
-                # deliberately weaker signal used here, because a stronger one
-                # risks a fix that never fires in the field.
+                # Excuse such a step only with positive evidence that THIS
+                # step really ran: an in-progress row that appeared or
+                # transitioned after our start POST (a leftover row from an
+                # earlier run reads identically and must not count), and the
+                # FAILED check above already passed. A terminal
+                # SUCCESS/COMPLETE row would be stronger still, but it is not
+                # reliably observable — the poll loop exits as soon as
+                # in_progress goes false — so "our own start was seen
+                # installing and did not report FAILED" is the deliberately
+                # weaker signal used here, because a stronger one risks a fix
+                # that never fires in the field.
                 #
                 # Consecutive excuses are capped by no_progress_grace, and
                 # accepted update steps by max_steps (busy retries can issue
                 # more standardUpdate/run POSTs than that, but a refused one
                 # installs nothing), so a stuck device still stops.
-                if saw_in_progress and consecutive_no_progress < no_progress_grace:
+                if attributed_in_progress and consecutive_no_progress < no_progress_grace:
                     consecutive_no_progress += 1
                     _LOGGER.info(
                         "Firmware step %d for %s completed without changing the "

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -936,13 +936,33 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         # by more than case, "not equal" would be permanently true and every
         # sentinel would report converged on its first occurrence — silent, and
         # one-directional toward false success.
-        started_from_code = await self._read_device_firmware_code()
+        started_from_code: str | None = None  # read below, once retry_backoff exists
         loop = asyncio.get_running_loop()
         # Smallest wait between busy/eligibility re-polls. Floors poll_interval
         # so neither a degenerate 0 nor a small positive value (0.001) can
         # hot-loop eligibility/start calls at the API; never exceeds the time
         # left in the budget.
         retry_backoff = max(poll_interval, _MIN_RETRY_BACKOFF)
+
+        async def _read_firmware_code_with_retry() -> str | None:
+            # The runtime read fails transiently at exactly the moments this
+            # orchestrator cares about — a device rebooting from a previous
+            # update attempt, or from the step just finished. One unlucky read
+            # must not decide the run's outcome.
+            code = await self._read_device_firmware_code()
+            for _attempt in range(corroboration_retries):
+                if code is not None:
+                    return code
+                await asyncio.sleep(retry_backoff)
+                code = await self._read_device_firmware_code()
+            return code
+
+        # The pre-run baseline gets the SAME retry as the corroboration reads.
+        # Run start is a transient-failure moment in its own right (the
+        # reporter's device was literally recovering from an earlier attempt),
+        # and a failed baseline disables the movement test for the WHOLE run —
+        # turning a successful update into an indeterminate red error.
+        started_from_code = await _read_firmware_code_with_retry()
         # Every progress key observed in this run. A step only counts as
         # progress if it reaches a state never seen before: the check endpoint
         # can flap between two stale snapshots, and treating each flap as
@@ -996,12 +1016,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             # rebooting after its final component — would report a SUCCESSFUL
             # update as indeterminate, which Home Assistant surfaces as a red
             # error. Retry a bounded number of times before settling for that.
-            corroborated = await self._read_device_firmware_code()
-            for _attempt in range(corroboration_retries):
-                if corroborated is not None:
-                    break
-                await asyncio.sleep(retry_backoff)
-                corroborated = await self._read_device_firmware_code()
+            corroborated = await _read_firmware_code_with_retry()
             if corroborated is not None:
                 if _same_version(corroborated, target) or target is None:
                     return (
@@ -1049,21 +1064,28 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     # "no update available" answer was transient. Keep going.
                     return (None, corroborated)
 
-            # No corroboration available. Do not claim success, but do not
-            # imply the update failed either — say what is and is not known.
+            # Either the device's version could not be read at all, or it was
+            # read but there is no same-source baseline to compare it against.
+            # Do not claim success, and do not imply failure — report exactly
+            # what is and is not known, including the version if we have it.
             return (
                 FirmwareUpdateRunResult(
                     success=False,
                     converged=False,
                     steps_run=step_index,
                     message=(
-                        "Server reports no update remaining, but the device's "
-                        f"version could not be read back to confirm it reached "
-                        f"{target or 'the target'} — the update may well have "
-                        "completed; verify the firmware version on the device "
-                        "before running this again"
+                        "Server reports no update remaining, but this run could "
+                        f"not confirm the device reached {target or 'the target'} "
+                        + (
+                            f"(the device reports {corroborated}, with no "
+                            "pre-run version to compare it against)"
+                            if corroborated is not None
+                            else "(the device's version could not be read back)"
+                        )
+                        + " — the update may well have completed; verify the "
+                        "firmware version on the device before running this again"
                     ),
-                    final_version=installed,
+                    final_version=corroborated or installed,
                 ),
                 None,
             )

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -43,6 +44,31 @@ _PERMANENT_FAILURE_PROSE: tuple[str, ...] = (
     "timed out",
 )
 _BUSY_PROSE: tuple[str, ...] = ("busy", "updating")
+
+# LuxpowerClient wraps every failure before it reaches here, and two of the
+# three wrappers contain the word "error" ("API error (HTTP 200): deviceBusy",
+# "Unexpected error: ..."). Classifying the wrapped string directly made stage
+# 1 match on the WRAPPER, so every busy response was ruled permanent and the
+# busy path was dead in production — while unit tests that inject a bare
+# "deviceBusy" passed, because that shape is one the client never emits.
+# Strip the known wrappers precisely (anchored, not by substring search) and
+# classify the server's own message.
+_ERROR_WRAPPERS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^API error \(HTTP \d+\):\s*", re.IGNORECASE),
+    re.compile(r"^HTTP \d+:\s*", re.IGNORECASE),
+    re.compile(r"^Unexpected error:\s*", re.IGNORECASE),
+)
+
+
+def _server_message(err: Exception) -> str:
+    """The server's own message, with the client's wrapper removed."""
+    message = str(err)
+    for wrapper in _ERROR_WRAPPERS:
+        stripped = wrapper.sub("", message, count=1)
+        if stripped != message:
+            return stripped.strip()
+    return message.strip()
+
 
 # Hard cap on ``standardUpdate/run`` POSTs issued for a single step. The busy
 # budget bounds elapsed time, not request count: at a 0.05s floor a 15-minute
@@ -651,16 +677,21 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         blinked" without trusting either source alone.
 
         Best-effort: any API/connection failure returns None, and the caller
-        reports an indeterminate result rather than guessing. Inverter-shaped
-        by default; MID devices may need their own override.
+        reports an indeterminate result rather than guessing. ValidationError
+        is caught too — ``fwCode`` is a required str, so a device answering
+        with it absent (plausible mid-reboot) would otherwise raise straight
+        out of a Home Assistant install action. Inverter-shaped by default;
+        MID devices may need their own override.
         """
+        from pydantic import ValidationError
+
         from pylxpweb.exceptions import LuxpowerError
 
         client: LuxpowerClient = self._client
         serial: str = self.serial_number
         try:
             runtime = await client.api.devices.get_inverter_runtime(serial)
-        except LuxpowerError:
+        except (LuxpowerError, ValidationError):
             _LOGGER.debug("Firmware corroboration read failed for %s", serial, exc_info=True)
             return None
         code: str | None = getattr(runtime, "fwCode", None)
@@ -689,6 +720,8 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         settle_interval: float = 30.0,
         no_progress_grace: int = 2,
         busy_grace: float = 900.0,
+        corroboration_retries: int = 3,
+        preflight_confirm_delay: float = 10.0,
     ) -> FirmwareUpdateRunResult:
         """Run firmware updates until the device converges on the latest version.
 
@@ -760,6 +793,17 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 components in a row. It also sets the blind-reflash exposure
                 on a genuinely stuck device: ``no_progress_grace + 1``
                 accepted writes.
+            corroboration_retries: Extra attempts to read the device's own
+                firmware version before reporting an unconfirmable result. The
+                read can fail transiently at exactly the wrong moment — while
+                the device reboots after its final component — and a single
+                failure there turns a successful update into a red error in
+                Home Assistant.
+            preflight_confirm_delay: Seconds to wait before re-checking an
+                opening "already up to date" answer that arrives in the
+                empty-version sentinel shape. One confirmation is cheap;
+                trusting a single blink reports a partially updated device as
+                needing no update at all.
             busy_grace: Seconds to keep re-polling a busy device BETWEEN
                 components before giving up on the chain (bounded by
                 ``step_timeout``). Only applies once a step has been started:
@@ -812,7 +856,8 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             # busy/updating wording counts as busy. See the module constants
             # for why neither a bare substring nor an enumerated code list is
             # right on its own.
-            message = str(err).casefold()
+            # Classify the SERVER's message, never the client's wrapper.
+            message = _server_message(err).casefold()
             if any(prose in message for prose in _PERMANENT_FAILURE_PROSE):
                 return False
             return any(prose in message for prose in _BUSY_PROSE)
@@ -825,18 +870,50 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             # no-progress grace lets the loop ask for one step too many.
             # The refusal alone does NOT establish convergence — the caller
             # confirms with a forced re-check before reporting success.
-            message = str(err).casefold()
+            message = _server_message(err).casefold()
             return any(stem in message for stem in FIRMWARE_UP_TO_DATE_MESSAGES)
 
         info = await self.check_firmware_updates(force=True)
         if not info.update_available:
-            return FirmwareUpdateRunResult(
-                success=True,
-                converged=True,
-                steps_run=0,
-                message="Firmware already up to date",
-                final_version=info.installed_version,
+            # A CONCRETE version with nothing newer is a plain up-to-date
+            # answer and is trusted as-is. The empty-version sentinel is not:
+            # it is the same shape a blinking endpoint returns, and trusting a
+            # single one here reports a partially updated device as needing no
+            # update at all — the round-2 false-positive, surviving at the
+            # front door because this path never went through the corroborated
+            # verdict. Confirm it once before believing it.
+            if info.installed_version:
+                return FirmwareUpdateRunResult(
+                    success=True,
+                    converged=True,
+                    steps_run=0,
+                    message="Firmware already up to date",
+                    final_version=info.installed_version,
+                )
+            await asyncio.sleep(preflight_confirm_delay)
+            confirmation = await self.check_firmware_updates(force=True)
+            if not confirmation.update_available:
+                # Two independent reads agree. Residual: two consecutive
+                # blinks would still slip through, which is why this is a
+                # confirmation and not a proof.
+                return FirmwareUpdateRunResult(
+                    success=True,
+                    converged=True,
+                    steps_run=0,
+                    message="Firmware already up to date",
+                    final_version=(
+                        confirmation.installed_version or info.installed_version or None
+                    ),
+                )
+            # The two disagree: the first answer was a blink. Continue into
+            # the chain using the answer that reports work to do.
+            _LOGGER.info(
+                "Firmware pre-flight for %s: first check reported no update in the "
+                "empty-version sentinel shape, re-check reports one available — "
+                "proceeding with the update",
+                self.serial_number,
             )
+            info = confirmation
 
         steps_run = 0
         # Consecutive steps that completed without moving the version. Reset
@@ -851,10 +928,15 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         # the server contradicting itself, and re-deriving the target from
         # that same answer would turn the contradiction into a success.
         driving_target = info.latest_version or None
-        # The version the device was on when this run began. Corroborating a
-        # sentinel against this distinguishes "moved, and the server says
-        # nothing is left" from "never moved, the server just blinked".
-        started_from = info.installed_version or None
+        # The version the device was on when this run began, read from the
+        # SAME source the corroboration uses. Comparing a runtime fwCode
+        # against the check endpoint's fwCodeBeforeUpload would be a
+        # cross-endpoint comparison, and this file already documents check-side
+        # strings as synthesized reconstructions: if the two shapes ever differ
+        # by more than case, "not equal" would be permanently true and every
+        # sentinel would report converged on its first occurrence — silent, and
+        # one-directional toward false success.
+        started_from_code = await self._read_device_firmware_code()
         loop = asyncio.get_running_loop()
         # Smallest wait between busy/eligibility re-polls. Floors poll_interval
         # so neither a degenerate 0 nor a small positive value (0.001) can
@@ -910,7 +992,16 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                     installed,
                 )
 
+            # A single failed read at exactly the wrong moment — the device
+            # rebooting after its final component — would report a SUCCESSFUL
+            # update as indeterminate, which Home Assistant surfaces as a red
+            # error. Retry a bounded number of times before settling for that.
             corroborated = await self._read_device_firmware_code()
+            for _attempt in range(corroboration_retries):
+                if corroborated is not None:
+                    break
+                await asyncio.sleep(retry_backoff)
+                corroborated = await self._read_device_firmware_code()
             if corroborated is not None:
                 if _same_version(corroborated, target) or target is None:
                     return (
@@ -923,7 +1014,13 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                         ),
                         corroborated,
                     )
-                if not _same_version(corroborated, started_from):
+                if started_from_code is None:
+                    # No same-source baseline, so "did it move?" is not a
+                    # question this run can answer. Treating inequality as
+                    # movement here would be guessing in the direction of
+                    # success; fall through to the indeterminate verdict.
+                    pass
+                elif not _same_version(corroborated, started_from_code):
                     # The device moved and the server says nothing further is
                     # available. The target string can be a reconstruction
                     # (from_api_response splices version bytes onto the code,
@@ -938,15 +1035,19 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                             steps_run=step_index,
                             message=(
                                 f"Firmware update complete after {step_index} step(s); "
-                                f"device reports {corroborated}"
+                                "server reports no further updates and the device is "
+                                f"now at {corroborated} (this run targeted "
+                                f"{target or 'the latest version'}, which the server "
+                                "did not echo back for comparison)"
                             ),
                             final_version=corroborated,
                         ),
                         corroborated,
                     )
-                # Corroborated as still on the version we started from: the
-                # "no update available" answer was transient. Keep going.
-                return (None, corroborated)
+                elif _same_version(corroborated, started_from_code):
+                    # Corroborated as still on the version we started from: the
+                    # "no update available" answer was transient. Keep going.
+                    return (None, corroborated)
 
             # No corroboration available. Do not claim success, but do not
             # imply the update failed either — say what is and is not known.

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -589,8 +589,10 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             try_fast_mode: Attempt fast update mode on each run.
             poll_interval: Seconds between progress polls while a step is
                 installing.
-            max_steps: Upper bound on ``standardUpdate/run`` invocations
-                (the API defines steps 2-5, so 5 covers every known chain).
+            max_steps: Upper bound on ACCEPTED update steps (the API defines
+                steps 2-5, so 5 covers every known chain). Busy retries can
+                issue additional ``standardUpdate/run`` POSTs beyond this,
+                but a refused call installs nothing.
             step_timeout: Seconds to wait for a single step to finish
                 installing before aborting.
             start_grace: Seconds to keep polling for the update to become
@@ -661,11 +663,13 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             return "busy" in message or "updating" in message
 
         def _is_already_latest_error(err: LuxpowerAPIError) -> bool:
-            # ``standardUpdate/run`` refuses a converged device with the same
-            # "already the latest version" prose the check endpoint uses. That
-            # is convergence, not a failure — reachable when the check endpoint
-            # lags a successful final step past the settle window and the
+            # ``standardUpdate/run`` refuses a device it considers converged
+            # with the same "already the latest version" prose the check
+            # endpoint uses. Reachable when the check endpoint lags a
+            # successful final step past the settle window and the
             # no-progress grace lets the loop ask for one step too many.
+            # The refusal alone does NOT establish convergence — the caller
+            # confirms with a forced re-check before reporting success.
             message = str(err).casefold()
             return any(stem in message for stem in FIRMWARE_UP_TO_DATE_MESSAGES)
 

--- a/src/pylxpweb/devices/_firmware_update_mixin.py
+++ b/src/pylxpweb/devices/_firmware_update_mixin.py
@@ -8,8 +8,11 @@ detection capabilities with caching and Home Assistant compatibility.
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
+
+_LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pylxpweb import LuxpowerClient
@@ -543,6 +546,8 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         start_grace: float = 300.0,
         settle_checks: int = 3,
         settle_interval: float = 30.0,
+        no_progress_grace: int = 1,
+        busy_grace: float = 900.0,
     ) -> FirmwareUpdateRunResult:
         """Run firmware updates until the device converges on the latest version.
 
@@ -556,10 +561,28 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
         advertises the chain via ``needRunStep2``..``needRunStep5``.
 
         This orchestrator loops: check → start → poll to completion →
-        re-check, until no update remains, a step makes no version progress
+        re-check, until no update remains, the no-progress grace is spent
         (fail-safe against server-side loops), the step budget is exhausted,
         or a step times out. Each iteration re-verifies eligibility before
         issuing the next run.
+
+        A component that is ALREADY at the target version still flashes when
+        the server selects it — ``standardUpdate/run`` takes no step/component
+        parameter, so which component a run installs is the server's choice.
+        Such a run completes normally and cannot move the version string,
+        which is exactly how a partially-upgraded 6000XP got stuck: step 1
+        re-flashed the already-current component, and aborting on the first
+        unchanged version meant the component that actually needed upgrading
+        never ran (eg4_web_monitor#353). ``no_progress_grace`` therefore
+        tolerates a bounded number of *consecutive* completed-but-unchanged
+        steps before declaring the chain dead.
+
+        Busy handling is deliberately asymmetric. Before this invocation has
+        started anything, a busy device means "not now" and fails fast — the
+        caller has written nothing, and making the user wait out a multi-minute
+        retry budget only to fail is worse than telling them immediately.
+        Once a component HAS been started, busy means the chain we started is
+        still settling, and the bounded retry budget applies.
 
         Args:
             try_fast_mode: Attempt fast update mode on each run.
@@ -578,6 +601,18 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 unchanged version is declared "no progress" (the check
                 endpoint can lag the status endpoint's terminal state).
             settle_interval: Seconds between those settle re-checks.
+            no_progress_grace: How many *consecutive* steps may complete
+                without moving the version before the chain is abandoned.
+                Only steps that were actually observed installing are
+                excused (see the loop body); 0 restores the pre-#353
+                abort-on-first-unchanged-version behaviour.
+            busy_grace: Seconds to keep re-polling a busy device BETWEEN
+                components before giving up on the chain (bounded by
+                ``step_timeout``). Only applies once a step has been started:
+                a device that is busy before the first step fails fast. A
+                component reboot/settle can outlast ``start_grace``, and
+                giving up there strands the device mid-chain, so this budget
+                is deliberately wider than the post-start visibility grace.
 
         Returns:
             FirmwareUpdateRunResult describing convergence, steps run, and a
@@ -589,6 +624,7 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             LuxpowerConnectionError: If connection fails.
         """
         # Import here to avoid circular imports
+        from pylxpweb.endpoints.firmware import FIRMWARE_UP_TO_DATE_MESSAGES
         from pylxpweb.exceptions import LuxpowerAPIError
         from pylxpweb.models import FirmwareUpdateRunResult
 
@@ -623,6 +659,15 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             message = str(err).casefold()
             return "busy" in message or "updating" in message
 
+        def _is_already_latest_error(err: LuxpowerAPIError) -> bool:
+            # ``standardUpdate/run`` refuses a converged device with the same
+            # "already the latest version" prose the check endpoint uses. That
+            # is convergence, not a failure — reachable when the check endpoint
+            # lags a successful final step past the settle window and the
+            # no-progress grace lets the loop ask for one step too many.
+            message = str(err).casefold()
+            return any(stem in message for stem in FIRMWARE_UP_TO_DATE_MESSAGES)
+
         info = await self.check_firmware_updates(force=True)
         if not info.update_available:
             return FirmwareUpdateRunResult(
@@ -634,6 +679,9 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
             )
 
         steps_run = 0
+        # Consecutive steps that completed without moving the version. Reset
+        # on any version movement; compared against no_progress_grace.
+        consecutive_no_progress = 0
         # The converged version to report: once the device is up to date the
         # check endpoint answers with the bare "already latest" sentinel
         # (empty fwCodeBeforeUpload), so remember the target we converged to.
@@ -658,47 +706,77 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                 final_version=installed_version,
             )
 
+        def _busy_before_any_step(installed_version: str | None) -> FirmwareUpdateRunResult:
+            # Nothing has been written yet, so there is no chain of ours to
+            # protect: report immediately instead of holding the caller (and
+            # the HA install action) for the whole retry budget only to fail.
+            return FirmwareUpdateRunResult(
+                success=False,
+                converged=False,
+                steps_run=0,
+                message=(
+                    "Device is busy and cannot start a firmware update right now "
+                    "(it may still be installing, or recovering from a previous "
+                    "update); wait a few minutes and try again"
+                ),
+                final_version=installed_version,
+            )
+
         for _ in range(max_steps):
             before = _progress_key(info)
+            _LOGGER.debug(
+                "Firmware chain for %s: step %d, installed=%s, target=%s, needRunStep flags=%s",
+                self.serial_number,
+                steps_run + 1,
+                info.installed_version,
+                info.latest_version,
+                info.needs_run_steps,
+            )
 
-            # Become eligible and start the next component, tolerating a
-            # transient busy race. After a component finishes uploading, the
-            # device can still be settling/rebooting, so both the eligibility
-            # gate AND the start call may briefly report the device busy — the
-            # multi-step chain (issue #353) must not abort in that window.
-            # First step: a not-eligible result is a genuine pre-flight
-            # rejection (fail fast, no write). Later steps, or once a start has
-            # already raced busy: treat not-eligible/deviceBusy as "still
-            # working" and re-poll within a bounded budget. A non-busy API
-            # error still propagates. Bounded by min(start_grace, step_timeout).
-            busy_deadline = loop.time() + min(start_grace, step_timeout)
+            # Become eligible and start the next component. Busy handling is
+            # split by whether THIS invocation has already started something:
+            #
+            #   steps_run == 0 (pre-flight): the device was busy before we
+            #     wrote anything — someone/something else is using it, or it is
+            #     still recovering from an earlier update. Fail fast on both
+            #     not-eligible and any busy-family error, from the eligibility
+            #     probe or the start call. Burning the whole retry budget here
+            #     only to fail is strictly worse UX than saying so immediately
+            #     (eg4_web_monitor#353: a user watched "Installing" for five
+            #     minutes before being told the device was busy the whole time).
+            #
+            #   steps_run > 0 (mid-chain): the device is settling/rebooting
+            #     between components of a chain WE started, so both the
+            #     eligibility gate and the start call may briefly report busy —
+            #     the multi-step chain must not abort in that window. Re-poll
+            #     within a bounded budget of min(busy_grace, step_timeout).
+            #
+            # A non-busy API error still propagates in both cases.
+            busy_deadline = loop.time() + min(busy_grace, step_timeout)
 
             started = False
-            saw_busy = False
             attempted = False
             while True:
                 # Never issue a RETRY start write once the budget is spent
                 # (checked before the attempt; the first genuine try is exempt
-                # so a zero/expired start_grace still gets one shot).
+                # so a zero/expired busy_grace still gets one shot).
                 if attempted and loop.time() >= busy_deadline:
                     return _budget_spent(steps_run, info.installed_version)
                 first_attempt = not attempted
                 attempted = True
 
                 # The eligibility probe is itself a network call that can come
-                # back busy (transport BUSY / deviceUpdating / parallelGroup);
-                # treat that as "still working" and retry within budget rather
-                # than letting it escape raw and abort the chain. A non-busy
-                # API error still propagates.
+                # back busy (transport BUSY / deviceUpdating / parallelGroup).
                 try:
                     eligible = await self.check_update_eligibility()
-                    busy = False
                 except LuxpowerAPIError as err:
                     if not _is_device_busy_error(err):
                         raise
+                    if steps_run == 0:
+                        return _busy_before_any_step(info.installed_version)
+                    # Mid-chain: still working — fall through to the bounded
+                    # retry below rather than letting it escape raw.
                     eligible = False
-                    busy = True
-                    saw_busy = True
 
                 if eligible:
                     # The eligibility call can straddle the deadline; never fire
@@ -709,10 +787,31 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                         started = await self.start_firmware_update(try_fast_mode=try_fast_mode)
                         break
                     except LuxpowerAPIError as err:
+                        if steps_run > 0 and _is_already_latest_error(err):
+                            # The check endpoint lagged a successful final step
+                            # past the settle window and the no-progress grace
+                            # asked for one step too many: the device is
+                            # converged. Report that rather than surfacing a raw
+                            # API error after a successful update. Only mid-chain
+                            # — the same response BEFORE any step means the check
+                            # and run endpoints disagree about a device we have
+                            # not touched, which must still surface.
+                            return FirmwareUpdateRunResult(
+                                success=True,
+                                converged=True,
+                                steps_run=steps_run,
+                                message=(f"Firmware update complete after {steps_run} step(s)"),
+                                # The server asserts convergence, so the target
+                                # is the truthful version here; the lagging
+                                # check's installed_version is stale by
+                                # definition.
+                                final_version=last_target or info.installed_version,
+                            )
                         if not _is_device_busy_error(err):
                             raise
-                        saw_busy = True
-                elif not busy and steps_run == 0 and not saw_busy:
+                        if steps_run == 0:
+                            return _busy_before_any_step(info.installed_version)
+                elif steps_run == 0:
                     # Genuine pre-flight rejection on the very first step.
                     return FirmwareUpdateRunResult(
                         success=False,
@@ -808,16 +907,49 @@ class FirmwareUpdateMixin(_FirmwareMixinBase):
                         final_version=info.installed_version or last_target,
                     )
                 if _progress_key(info) != before:
+                    consecutive_no_progress = 0
                     break  # component advanced — continue the chain
             else:
-                # No version movement across the settle window — do not
-                # keep issuing writes against an unresponsive chain.
+                # No version movement across the settle window. This is NOT
+                # automatically a dead chain: standardUpdate/run takes no
+                # component selector, so the server can pick a component that
+                # is already at the target version, which flashes normally and
+                # cannot move the version string (eg4_web_monitor#353 — the
+                # 6000XP stuck at ccaa-1E1415 re-flashed its already-current
+                # component as step 1 and the remaining one never ran).
+                #
+                # Excuse such a step only with positive evidence that it really
+                # ran: `saw_in_progress` means the status endpoint reported the
+                # device installing, and the FAILED check above already passed.
+                # A terminal SUCCESS/COMPLETE row would be stronger evidence,
+                # but it is not reliably observable on the reporting hardware —
+                # the poll loop exits as soon as in_progress goes false — so
+                # "was seen installing and did not report FAILED" is the
+                # deliberately weaker signal used here, because a stronger one
+                # risks a fix that never fires in the field.
+                #
+                # Consecutive excuses are capped by no_progress_grace (and all
+                # writes by max_steps), so a genuinely stuck device still stops.
+                if saw_in_progress and consecutive_no_progress < no_progress_grace:
+                    consecutive_no_progress += 1
+                    _LOGGER.info(
+                        "Firmware step %d for %s completed without changing the "
+                        "version (%s) — a component already at the target flashes "
+                        "as a no-op; continuing the chain (needRunStep flags=%s)",
+                        steps_run,
+                        self.serial_number,
+                        info.installed_version,
+                        info.needs_run_steps,
+                    )
+                    continue
+                # Do not keep issuing writes against an unresponsive chain.
                 return FirmwareUpdateRunResult(
                     success=False,
                     converged=False,
                     steps_run=steps_run,
                     message=(
-                        f"No firmware version progress after step {steps_run}; "
+                        f"No firmware version progress after step {steps_run} "
+                        f"(needRunStep flags: {info.needs_run_steps or 'none'}); "
                         "stopping to avoid repeated update commands (if the "
                         "device is still installing, wait for it to finish "
                         "before retrying)"

--- a/src/pylxpweb/models.py
+++ b/src/pylxpweb/models.py
@@ -1608,7 +1608,8 @@ class FirmwareUpdateRunResult(BaseModel):
         converged: Same signal as success for completed runs; False when the
             run stopped early (start refused, timeout, no progress, or step
             budget exhausted).
-        steps_run: Number of ``standardUpdate/run`` invocations issued.
+        steps_run: Number of update steps the server accepted (refused
+            busy retries are not counted).
         message: Human-readable outcome summary (safe to surface in UI/logs).
         final_version: The device's firmware code after the run, when known.
     """

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -33,10 +33,11 @@ def _info(
     in_progress: bool = False,
     app_current: int | None = None,
     param_current: int | None = None,
+    latest_override: str | None = None,
 ) -> FirmwareUpdateInfo:
     return FirmwareUpdateInfo(
         installed_version=installed,
-        latest_version=latest,
+        latest_version=latest_override if latest_override is not None else latest,
         title="Test Firmware",
         release_summary=None,
         release_url=None,
@@ -86,6 +87,7 @@ class ScriptedDevice(FirmwareUpdateMixin):
         eligibility: list[bool | LuxpowerAPIError | UpdateEligibilityMessage] | None = None,
         failed_statuses: list[bool] | None = None,
         status_rows: list[FirmwareDeviceInfo | None] | None = None,
+        firmware_codes: list[str | None] | None = None,
     ) -> None:
         self._init_firmware_update_cache()
         # The orchestrator logs against the host's serial (issue #353 chain
@@ -102,6 +104,8 @@ class ScriptedDevice(FirmwareUpdateMixin):
         # Tests that need a misbehaving server (a stale row that never
         # changes) script the rows explicitly.
         self._status_rows = status_rows
+        self._firmware_codes = firmware_codes
+        self._device_code: str | None = None
         self._run_seq = 0
         self._last_progress_in_progress = False
         self.start_calls = 0
@@ -113,11 +117,19 @@ class ScriptedDevice(FirmwareUpdateMixin):
     async def check_firmware_updates(self, force: bool = False) -> FirmwareUpdateInfo:
         self.check_calls += 1
         self.check_force_flags.append(force)
-        return self._checks.pop(0)
+        info = self._checks.pop(0)
+        if info.installed_version:
+            # A device whose runtime endpoint agrees with the check endpoint.
+            self._device_code = info.installed_version
+        return info
 
     async def get_firmware_update_progress(self, force: bool = False) -> FirmwareUpdateInfo:
         info = self._progresses.pop(0) if self._progresses else _info("X-0000", "X-0000")
         self._last_progress_in_progress = info.in_progress
+        # Production caches the raw row it just fetched so the orchestrator can
+        # attribute activity without a second call; the harness must too, or it
+        # tests a seam the real code does not have.
+        self._last_status_row = await self._next_status_row()
         return info
 
     async def start_firmware_update(self, try_fast_mode: bool = False) -> bool:
@@ -152,13 +164,27 @@ class ScriptedDevice(FirmwareUpdateMixin):
             ),
         )
 
-    async def _current_status_row(self) -> FirmwareDeviceInfo | None:
+    async def _next_status_row(self) -> FirmwareDeviceInfo | None:
         if self._status_rows is not None:
             return self._status_rows.pop(0) if self._status_rows else None
         return _row(
             start_time=f"run-{self._run_seq}",
             in_progress=self._last_progress_in_progress,
         )
+
+    async def _current_status_row(self) -> FirmwareDeviceInfo | None:
+        return await self._next_status_row()
+
+    async def _read_device_firmware_code(self) -> str | None:
+        """The version the DEVICE reports, independent of checkUpdates.
+
+        Scripted when a test needs the two sources to disagree; otherwise it
+        models a device that agrees with the last concrete version the check
+        endpoint reported (the sentinel's empty string is not a version).
+        """
+        if self._firmware_codes is not None:
+            return self._firmware_codes.pop(0) if self._firmware_codes else None
+        return self._device_code
 
     async def _update_step_reported_failed(self) -> bool:
         if self._failed_statuses:
@@ -567,39 +593,97 @@ def test_scripted_device_is_mixin() -> None:
 
 
 @pytest.mark.asyncio
-async def test_up_to_date_sentinel_alone_is_not_convergence() -> None:
-    """An empty 'already latest' sentinel must NOT be reported as success.
+async def test_up_to_date_sentinel_with_corroboration_is_convergence() -> None:
+    """The sentinel IS the documented answer for a converged device.
 
-    This test previously asserted the opposite: that the remembered target be
-    substituted for the sentinel's empty installed_version. That is precisely
-    how a partially upgraded device could be reported as converged on a
-    version it never reached — the failure this whole change exists to
-    prevent, with the evidence blanked out. "No update available" is
-    necessary but not sufficient; convergence needs a concrete installed
-    version matching the target.
+    ``checkUpdates`` answers an up-to-date device with success:false "already
+    the latest version", which the client synthesizes into a record whose
+    installed_version is EMPTY. Demanding a concrete version from that answer
+    alone reported a device as FAILED at the exact moment it succeeded. The
+    sentinel is corroborated against the runtime endpoint's fwCode instead: if
+    the device really is on the target, that is convergence.
     """
     sentinel = _info("", "")  # create_up_to_date shape: both fields empty
-    device = ScriptedDevice(checks=[STEP2_PENDING, sentinel])
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel],
+        firmware_codes=["ccaa-1E1515"],  # the device really did converge
+    )
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
-    assert not result.success and not result.converged
-    assert result.final_version is None
-    assert "partially upgraded" in result.message
+    assert result.success and result.converged
+    assert result.final_version == "ccaa-1E1515"
 
 
 @pytest.mark.asyncio
-async def test_convergence_requires_the_target_version() -> None:
-    """A check that reports no update while still on the OLD version is not
-    convergence either — it is the indeterminate case, reported honestly."""
-    stale = _info("ccaa-1E1415", "ccaa-1E1415")  # no update "available", old version
-    device = ScriptedDevice(checks=[STEP2_PENDING, stale])
+async def test_sentinel_is_not_trusted_when_the_device_says_otherwise() -> None:
+    """The complement, and the round-2 finding this must not undo: a sentinel
+    while the device is still on the version we started from is a transient
+    answer, not convergence — so it must not be reported as success."""
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel, sentinel, sentinel],
+        # Device still reads the pre-run version every time it is asked.
+        firmware_codes=["ccaa-1E1415"] * 6,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
+
+    assert not result.success and not result.converged
+
+
+@pytest.mark.asyncio
+async def test_corroborated_move_counts_even_if_it_misses_the_target_string() -> None:
+    """The target can be a reconstruction the server never echoes.
+
+    ``from_api_response`` splices version bytes onto the firmware code, and for
+    unverified layouts that splice is a guess. If the device moved and the
+    server says nothing further is available, accept the device's own reported
+    version rather than failing on a string mismatch with our own guess.
+    """
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel],
+        firmware_codes=["ccaa-1E15FF"],  # moved, but not the spliced target
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+    assert result.success and result.converged
+    assert result.final_version == "ccaa-1E15FF"
+
+
+@pytest.mark.asyncio
+async def test_convergence_is_indeterminate_without_corroboration() -> None:
+    """If the device's version cannot be read back, say so — without implying
+    the update failed, because it most likely did not."""
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel],
+        firmware_codes=[None],  # runtime read unavailable
+    )
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert not result.success and not result.converged
-    assert result.final_version == "ccaa-1E1415"  # what it actually reports
-    assert "ccaa-1E1515" in result.message  # the target it could not confirm
+    assert "verify the firmware version on the device" in result.message
+    assert "may well have completed" in result.message
+
+
+@pytest.mark.asyncio
+async def test_version_match_is_case_insensitive() -> None:
+    """The API is not consistent about case; that is not a version difference."""
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel],
+        firmware_codes=["CCAA-1E1515"],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+    assert result.success and result.converged
 
 
 @pytest.mark.asyncio
@@ -1045,7 +1129,7 @@ async def test_permanent_eligibility_denial_surfaces_immediately() -> None:
     assert device.start_calls == 1  # step 1 only; step 2 never attempted
     assert device.eligibility_calls == 2  # probed once, not re-polled
     assert "notAllowedInParallel" in result.message
-    assert "will not clear" in result.message
+    assert "retry once that completes" in result.message
 
 
 @pytest.mark.asyncio
@@ -1147,3 +1231,157 @@ async def test_small_positive_poll_interval_does_not_hot_loop() -> None:
     # At a 0.05s floor, a 0.3s budget allows a handful of attempts — not the
     # hundreds an unfloored 0.001s interval would have issued.
     assert device.start_calls <= 1 + _MAX_START_ATTEMPTS_PER_STEP
+
+
+# --- Round 3: false-negative closures -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mid_chain_attribution_tolerates_a_single_session_row() -> None:
+    """Steps 2+ must not demand a NEW status row.
+
+    The portal may keep ONE row per update session and update it in place, in
+    which case step 2's baseline is already an in-progress row with an
+    unchanged startTime — all three freshness clauses fail, the grace is
+    refused, and the reporter's verbatim error comes back. The stale-row
+    threat is PRE-run leftovers, so strict attribution applies only to step 1;
+    from step 2 on, an in-progress row is this run's own activity.
+    """
+    one_session_row = _row(start_time="session-1", in_progress=True)
+    device = ScriptedDevice(
+        # Step 1 advances; step 2 is a no-op component; step 3 finishes.
+        checks=[STEP1_PENDING, STEP2_PENDING, STEP2_PENDING, UP_TO_DATE],
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 3,
+        # The same row throughout, exactly as an in-place portal would report.
+        status_rows=[one_session_row] * 12,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert device.start_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_first_step_attribution_is_still_strict() -> None:
+    """The complement: a pre-run leftover row still buys nothing on step 1."""
+    leftover = _row(start_time="yesterday", in_progress=True)
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING] * 4,
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 4,
+        status_rows=[leftover] * 8,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert not result.success
+    assert device.start_calls == 1  # no second blind write
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "systemBusy",
+        "Device is updating, please try again",
+        "SYSTEM_BUSY",
+        "The inverter is busy",
+    ],
+)
+@pytest.mark.asyncio
+async def test_unrecognised_busy_phrasings_are_still_tolerated(message: str) -> None:
+    """Breadth restored: an enumerated code list was too narrow.
+
+    The portal emits phrasings we have never catalogued. Treating an
+    unrecognised busy response as permanent aborts a chain that would have
+    succeeded moments later, so any busy/updating wording without failure
+    prose counts as busy.
+    """
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
+        start_results=[True, LuxpowerAPIError(message), True],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, busy_grace=60, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert device.start_calls == 3
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Failed updating firmware: invalid checksum",
+        "Error updating firmware image",
+        "Firmware image corrupt",
+        "Update timed out while updating",
+    ],
+)
+@pytest.mark.asyncio
+async def test_failure_prose_beats_busy_wording(message: str) -> None:
+    """Stage 1 wins: failure prose is permanent even when it says "updating"."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING],
+        start_results=[True, LuxpowerAPIError(message)],
+    )
+
+    with pytest.raises(LuxpowerAPIError):
+        await device.run_firmware_update_to_completion(
+            poll_interval=0, start_grace=0, busy_grace=60, settle_checks=0
+        )
+
+
+@pytest.mark.asyncio
+async def test_attribution_reuses_the_polled_row() -> None:
+    """Attribution must not issue its own remoteUpdate/info call.
+
+    A second read doubles the call rate and can disagree with the progress
+    call about the same instant. The row cached by the progress poll is the
+    one used.
+    """
+    extra_reads = 0
+
+    class RowCallCounting(ScriptedDevice):
+        async def _current_status_row(self) -> FirmwareDeviceInfo | None:
+            nonlocal extra_reads
+            extra_reads += 1
+            return await super()._current_status_row()
+
+    device = RowCallCounting(
+        checks=[STEP2_PENDING, STEP2_PENDING, UP_TO_DATE],
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 2,
+    )
+
+    await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60, settle_checks=0)
+
+    # One pre-POST baseline read per accepted step, and nothing more: the
+    # polling path reads the cached row instead of calling again.
+    assert extra_reads == device.start_calls
+
+
+@pytest.mark.asyncio
+async def test_blank_installed_version_is_not_novel_progress() -> None:
+    """A sentinel is not a distinct firmware state.
+
+    An endpoint alternating between real data and the sentinel would otherwise
+    look like movement on every other check and reset the grace forever.
+    """
+    sentinel = _info("", "", latest_override="ccaa-1E1515")
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel, STEP2_PENDING, sentinel, STEP2_PENDING, sentinel],
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 6,
+        firmware_codes=["ccaa-1E1415"] * 12,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert not result.success
+    # grace(2) + 1 — the alternating sentinel never bought an extra step.
+    assert device.start_calls == 3

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -606,7 +606,10 @@ async def test_up_to_date_sentinel_with_corroboration_is_convergence() -> None:
     sentinel = _info("", "")  # create_up_to_date shape: both fields empty
     device = ScriptedDevice(
         checks=[STEP2_PENDING, sentinel],
-        firmware_codes=["ccaa-1E1515"],  # the device really did converge
+        # First read is the pre-run baseline (same source as the
+        # corroboration, so the movement test is fwCode-to-fwCode); then the
+        # device really did converge.
+        firmware_codes=["ccaa-1E1415", "ccaa-1E1515"],
     )
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
@@ -646,13 +649,19 @@ async def test_corroborated_move_counts_even_if_it_misses_the_target_string() ->
     sentinel = _info("", "")
     device = ScriptedDevice(
         checks=[STEP2_PENDING, sentinel],
-        firmware_codes=["ccaa-1E15FF"],  # moved, but not the spliced target
+        # Baseline, then moved — but not to the spliced target string.
+        firmware_codes=["ccaa-1E1415", "ccaa-1E15FF"],
     )
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert result.success and result.converged
     assert result.final_version == "ccaa-1E15FF"
+    # The message must report what was actually observed and must NOT claim
+    # the device reached the target, which this path never verified.
+    assert "no further updates" in result.message
+    assert "now at ccaa-1E15FF" in result.message
+    assert "did not echo back" in result.message
 
 
 @pytest.mark.asyncio
@@ -662,7 +671,7 @@ async def test_convergence_is_indeterminate_without_corroboration() -> None:
     sentinel = _info("", "")
     device = ScriptedDevice(
         checks=[STEP2_PENDING, sentinel],
-        firmware_codes=[None],  # runtime read unavailable
+        firmware_codes=[None, None],  # runtime read unavailable throughout
     )
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
@@ -678,7 +687,7 @@ async def test_version_match_is_case_insensitive() -> None:
     sentinel = _info("", "")
     device = ScriptedDevice(
         checks=[STEP2_PENDING, sentinel],
-        firmware_codes=["CCAA-1E1515"],
+        firmware_codes=["ccaa-1E1415", "CCAA-1E1515"],
     )
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
@@ -1385,3 +1394,227 @@ async def test_blank_installed_version_is_not_novel_progress() -> None:
     assert not result.success
     # grace(2) + 1 — the alternating sentinel never bought an extra step.
     assert device.start_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_sentinel_does_not_converge_on_a_cross_source_shape_difference() -> None:
+    """The movement test must compare like with like.
+
+    The runtime endpoint's fwCode and the check endpoint's fwCodeBeforeUpload
+    are different sources, and this repo documents check-side strings as
+    synthesized reconstructions. If their shapes differ by more than case, a
+    check-vs-runtime movement test is PERMANENTLY unequal, so every sentinel
+    would report converged on its first occurrence — silent, and always toward
+    false success. Baselining from the same source removes the mismatch.
+    """
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        # Check-side strings carry a prefix the runtime endpoint omits.
+        checks=[
+            _info("PFX/ccaa-1E1415", "PFX/ccaa-1E1515", app_current=0x14, param_current=0x15),
+            sentinel,
+            sentinel,
+            sentinel,
+        ],
+        # Runtime consistently reports the short form, and never moves.
+        firmware_codes=["ccaa-1E1415"] * 8,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
+
+    assert not result.success and not result.converged
+    assert "complete" not in result.message
+
+
+@pytest.mark.asyncio
+async def test_no_same_source_baseline_is_indeterminate_not_movement() -> None:
+    """If the pre-run baseline read failed, "did it move?" is unanswerable.
+
+    Counting inequality as movement there would be guessing in the direction
+    of success, so the run reports indeterminate instead.
+    """
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel],
+        # Baseline read fails; later reads succeed with some other value.
+        firmware_codes=[None, "ccaa-1E9999", "ccaa-1E9999", "ccaa-1E9999", "ccaa-1E9999"],
+    )
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+    assert not result.success and not result.converged
+    assert "verify the firmware version on the device" in result.message
+
+
+# --- Round 4 ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("wrapped", "is_busy"),
+    [
+        # The EXACT shapes LuxpowerClient emits — bare codes never reach here.
+        ("API error (HTTP 200): deviceBusy", True),
+        ("API error (HTTP 200): systemBusy", True),
+        ("API error (HTTP 200): Device is updating, please try again", True),
+        ("HTTP 500: deviceBusy", True),
+        ("API error (HTTP 200): Failed updating firmware: invalid checksum", False),
+        ("API error (HTTP 200): Firmware image corrupt", False),
+        ("Unexpected error: boom", False),
+    ],
+)
+def test_busy_classification_uses_the_real_client_error_shape(wrapped: str, is_busy: bool) -> None:
+    """Regression: the classifier ran against the client's WRAPPER.
+
+    LuxpowerClient raises "API error (HTTP {status}): {msg}" and "Unexpected
+    error: {err}" — both contain the word "error", which the permanent-failure
+    stage matched, so EVERY busy response was ruled permanent and the busy
+    path was dead in production. Unit tests passed only because they injected
+    a bare "deviceBusy", a shape the client never emits.
+    """
+    from pylxpweb.devices._firmware_update_mixin import (
+        _BUSY_PROSE,
+        _PERMANENT_FAILURE_PROSE,
+        _server_message,
+    )
+
+    message = _server_message(LuxpowerAPIError(wrapped)).casefold()
+    permanent = any(p in message for p in _PERMANENT_FAILURE_PROSE)
+    classified_busy = (not permanent) and any(p in message for p in _BUSY_PROSE)
+
+    assert classified_busy is is_busy
+
+
+@pytest.mark.asyncio
+async def test_wrapped_busy_error_is_tolerated_end_to_end() -> None:
+    """The production error shape must actually drive the busy path."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
+        start_results=[
+            True,
+            LuxpowerAPIError("API error (HTTP 200): deviceBusy"),
+            True,
+        ],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, busy_grace=60, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert device.start_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_wrapped_permanent_failure_still_propagates() -> None:
+    """...without letting the wrapper make everything permanent again."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING],
+        start_results=[
+            True,
+            LuxpowerAPIError("API error (HTTP 200): Failed updating firmware: invalid checksum"),
+        ],
+    )
+
+    with pytest.raises(LuxpowerAPIError, match="invalid checksum"):
+        await device.run_firmware_update_to_completion(
+            poll_interval=0, start_grace=0, busy_grace=60, settle_checks=0
+        )
+
+
+@pytest.mark.asyncio
+async def test_preflight_sentinel_is_confirmed_before_being_believed() -> None:
+    """A blinking sentinel on the FIRST check must not report up-to-date.
+
+    The pre-flight path returned success on `not update_available` with no
+    corroboration, so round 2's headline false positive survived at the front
+    door: a partially updated device whose first check blinked would be told
+    it needs no update at all.
+    """
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        # First check blinks; the confirming re-check reports the real work.
+        checks=[sentinel, STEP2_PENDING, UP_TO_DATE],
+        firmware_codes=["ccaa-1E1415"] * 4,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0, preflight_confirm_delay=0
+    )
+
+    assert result.success and result.converged
+    assert device.start_calls == 1  # it really did run the update
+    assert device.check_calls >= 3  # blink + confirmation + post-step
+
+
+@pytest.mark.asyncio
+async def test_preflight_sentinel_confirmed_twice_is_up_to_date() -> None:
+    """Two agreeing reads are believed — no update is attempted."""
+    sentinel = _info("", "")
+    device = ScriptedDevice(checks=[sentinel, sentinel])
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, preflight_confirm_delay=0
+    )
+
+    assert result.success and result.converged
+    assert result.steps_run == 0
+    assert device.start_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_preflight_concrete_up_to_date_needs_no_confirmation() -> None:
+    """A concrete version with nothing newer is trusted on one read."""
+    device = ScriptedDevice(checks=[UP_TO_DATE])
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, preflight_confirm_delay=0
+    )
+
+    assert result.success and result.converged
+    assert device.check_calls == 1  # no second call
+
+
+@pytest.mark.asyncio
+async def test_corroboration_read_is_retried_before_giving_up() -> None:
+    """A transient read failure must not turn success into a red error.
+
+    The device reboots after its final component; a single failed runtime read
+    in that window would report a COMPLETED update as unconfirmable.
+    """
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel],
+        # baseline ok, then two failures, then the truth.
+        firmware_codes=["ccaa-1E1415", None, None, "ccaa-1E1515"],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert result.final_version == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_corroboration_validation_error_is_not_raised_at_the_caller() -> None:
+    """fwCode is a required str; a device omitting it mid-reboot raises
+    ValidationError, which would escape into the HA install action."""
+    from pydantic import ValidationError
+
+    class ValidationFailingDevice(ScriptedDevice):
+        async def _read_device_firmware_code(self) -> str | None:
+            # Exercise the production body's except clause.
+            try:
+                raise ValidationError.from_exception_data("InverterRuntime", [])
+            except (LuxpowerAPIError, ValidationError):
+                return None
+
+    device = ValidationFailingDevice(checks=[STEP2_PENDING, _info("", "")])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+    assert not result.success  # indeterminate, but no exception escaped
+    assert "verify the firmware version on the device" in result.message

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -12,9 +12,18 @@ import asyncio
 
 import pytest
 
-from pylxpweb.devices._firmware_update_mixin import FirmwareUpdateMixin
+from pylxpweb.devices._firmware_update_mixin import (
+    _MAX_START_ATTEMPTS_PER_STEP,
+    FirmwareUpdateMixin,
+)
 from pylxpweb.exceptions import LuxpowerAPIError
-from pylxpweb.models import FirmwareUpdateInfo
+from pylxpweb.models import (
+    FirmwareDeviceInfo,
+    FirmwareUpdateInfo,
+    UpdateEligibilityMessage,
+    UpdateEligibilityStatus,
+    UpdateStatus,
+)
 
 
 def _info(
@@ -38,6 +47,33 @@ def _info(
     )
 
 
+def _row(
+    *,
+    start_time: str,
+    in_progress: bool,
+    serial: str = "4413740117",
+) -> FirmwareDeviceInfo:
+    """A ``remoteUpdate/info`` row, in-progress or idle.
+
+    ``startTime`` is the only field that distinguishes one update run from the
+    next, which is what lets the orchestrator tell its own step's activity
+    from a leftover row (the stale-evidence guard).
+    """
+    return FirmwareDeviceInfo(
+        inverterSn=serial,
+        startTime=start_time,
+        stopTime="" if in_progress else "2026-08-01 10:00:00",
+        standardUpdate=True,
+        firmware="ccaa-1E1415",
+        firmwareType="STANDARD",
+        updateStatus=UpdateStatus.UPLOADING if in_progress else UpdateStatus.COMPLETE,
+        isSendStartUpdate=True,
+        isSendEndUpdate=not in_progress,
+        packageIndex=1,
+        updateRate="50% - 280 / 561" if in_progress else "",
+    )
+
+
 class ScriptedDevice(FirmwareUpdateMixin):
     """Mixin host with scripted firmware API responses."""
 
@@ -47,8 +83,9 @@ class ScriptedDevice(FirmwareUpdateMixin):
         checks: list[FirmwareUpdateInfo],
         progresses: list[FirmwareUpdateInfo] | None = None,
         start_results: list[bool | LuxpowerAPIError] | None = None,
-        eligibility: list[bool | LuxpowerAPIError] | None = None,
+        eligibility: list[bool | LuxpowerAPIError | UpdateEligibilityMessage] | None = None,
         failed_statuses: list[bool] | None = None,
+        status_rows: list[FirmwareDeviceInfo | None] | None = None,
     ) -> None:
         self._init_firmware_update_cache()
         # The orchestrator logs against the host's serial (issue #353 chain
@@ -59,6 +96,14 @@ class ScriptedDevice(FirmwareUpdateMixin):
         self._start_results = start_results or []
         self._eligibility = eligibility or []
         self._failed_statuses = failed_statuses or []
+        # When None, status rows are SYNTHESISED to model a well-behaved
+        # server: each accepted start opens a new record (a fresh startTime),
+        # and the row is in-progress whenever the last progress poll was.
+        # Tests that need a misbehaving server (a stale row that never
+        # changes) script the rows explicitly.
+        self._status_rows = status_rows
+        self._run_seq = 0
+        self._last_progress_in_progress = False
         self.start_calls = 0
         self.check_calls = 0
         self.eligibility_calls = 0
@@ -71,9 +116,9 @@ class ScriptedDevice(FirmwareUpdateMixin):
         return self._checks.pop(0)
 
     async def get_firmware_update_progress(self, force: bool = False) -> FirmwareUpdateInfo:
-        if self._progresses:
-            return self._progresses.pop(0)
-        return _info("X-0000", "X-0000")
+        info = self._progresses.pop(0) if self._progresses else _info("X-0000", "X-0000")
+        self._last_progress_in_progress = info.in_progress
+        return info
 
     async def start_firmware_update(self, try_fast_mode: bool = False) -> bool:
         self.start_calls += 1
@@ -81,17 +126,39 @@ class ScriptedDevice(FirmwareUpdateMixin):
             result = self._start_results.pop(0)
             if isinstance(result, LuxpowerAPIError):
                 raise result
+            if result:
+                self._run_seq += 1
             return result
+        self._run_seq += 1
         return True
 
-    async def check_update_eligibility(self) -> bool:
+    async def _update_eligibility_status(self) -> UpdateEligibilityStatus:
         self.eligibility_calls += 1
+        result: bool | LuxpowerAPIError | UpdateEligibilityMessage = True
         if self._eligibility:
             result = self._eligibility.pop(0)
-            if isinstance(result, LuxpowerAPIError):
-                raise result
-            return result
-        return True
+        if isinstance(result, LuxpowerAPIError):
+            raise result
+        if isinstance(result, UpdateEligibilityMessage):
+            return UpdateEligibilityStatus(success=True, msg=result)
+        return UpdateEligibilityStatus(
+            success=True,
+            msg=(
+                UpdateEligibilityMessage.ALLOW_TO_UPDATE
+                if result
+                # Not-allowed defaults to the TRANSIENT code: a permanent
+                # refusal has its own message and its own tests.
+                else UpdateEligibilityMessage.DEVICE_UPDATING
+            ),
+        )
+
+    async def _current_status_row(self) -> FirmwareDeviceInfo | None:
+        if self._status_rows is not None:
+            return self._status_rows.pop(0) if self._status_rows else None
+        return _row(
+            start_time=f"run-{self._run_seq}",
+            in_progress=self._last_progress_in_progress,
+        )
 
     async def _update_step_reported_failed(self) -> bool:
         if self._failed_statuses:
@@ -147,7 +214,10 @@ async def test_start_refused_reports_failure() -> None:
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert not result.success and not result.converged
-    assert result.steps_run == 1
+    # steps_run counts steps the SERVER ACCEPTED. A refused start installed
+    # nothing, so it must not be counted — the docstring and
+    # FirmwareUpdateRunResult both promise that.
+    assert result.steps_run == 0
     assert "refused" in result.message
 
 
@@ -270,14 +340,12 @@ async def test_no_start_write_fires_after_deadline_on_retry() -> None:
     start write may fire past it — the budget is a hard bound on retry writes."""
 
     class SlowRetryEligibilityDevice(ScriptedDevice):
-        elig_calls = 0
-
-        async def check_update_eligibility(self) -> bool:
-            self.elig_calls += 1
-            if self.elig_calls >= 3:
+        async def _update_eligibility_status(self) -> UpdateEligibilityStatus:
+            status = await super()._update_eligibility_status()
+            if self.eligibility_calls >= 3:
                 # the step-2 retry probe runs long, past the tiny budget
                 await asyncio.sleep(0.2)
-            return True
+            return status
 
     device = SlowRetryEligibilityDevice(
         checks=[STEP1_PENDING, STEP2_PENDING],
@@ -499,17 +567,39 @@ def test_scripted_device_is_mixin() -> None:
 
 
 @pytest.mark.asyncio
-async def test_converged_final_version_survives_up_to_date_sentinel() -> None:
-    """When the post-step check answers with the bare 'already latest'
-    sentinel (empty version strings), the result reports the target we
-    converged to, not an empty string (agy review finding)."""
+async def test_up_to_date_sentinel_alone_is_not_convergence() -> None:
+    """An empty 'already latest' sentinel must NOT be reported as success.
+
+    This test previously asserted the opposite: that the remembered target be
+    substituted for the sentinel's empty installed_version. That is precisely
+    how a partially upgraded device could be reported as converged on a
+    version it never reached — the failure this whole change exists to
+    prevent, with the evidence blanked out. "No update available" is
+    necessary but not sufficient; convergence needs a concrete installed
+    version matching the target.
+    """
     sentinel = _info("", "")  # create_up_to_date shape: both fields empty
     device = ScriptedDevice(checks=[STEP2_PENDING, sentinel])
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
-    assert result.success and result.converged
-    assert result.final_version == "ccaa-1E1515"
+    assert not result.success and not result.converged
+    assert result.final_version is None
+    assert "partially upgraded" in result.message
+
+
+@pytest.mark.asyncio
+async def test_convergence_requires_the_target_version() -> None:
+    """A check that reports no update while still on the OLD version is not
+    convergence either — it is the indeterminate case, reported honestly."""
+    stale = _info("ccaa-1E1415", "ccaa-1E1415")  # no update "available", old version
+    device = ScriptedDevice(checks=[STEP2_PENDING, stale])
+
+    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+    assert not result.success and not result.converged
+    assert result.final_version == "ccaa-1E1415"  # what it actually reports
+    assert "ccaa-1E1515" in result.message  # the target it could not confirm
 
 
 @pytest.mark.asyncio
@@ -582,7 +672,7 @@ async def test_no_progress_grace_is_not_unlimited() -> None:
     )
 
     result = await device.run_firmware_update_to_completion(
-        poll_interval=0, start_grace=60, settle_checks=0
+        poll_interval=0, start_grace=60, settle_checks=0, no_progress_grace=1
     )
 
     assert not result.success and not result.converged
@@ -699,14 +789,17 @@ async def test_pre_flight_busy_does_not_wait_out_the_budget() -> None:
         eligibility=[LuxpowerAPIError("deviceBusy")],
     )
 
-    started = asyncio.get_running_loop().time()
     result = await device.run_firmware_update_to_completion(
         poll_interval=30, start_grace=300, busy_grace=900
     )
-    elapsed = asyncio.get_running_loop().time() - started
 
+    # Structural, not wall-clock: the point is that it does not RETRY, and a
+    # timing assertion would both flake under load and pass for the wrong
+    # reason if the retry loop were merely fast.
     assert not result.success
-    assert elapsed < 1.0  # not the 900s budget, and not one 30s backoff
+    assert device.eligibility_calls == 1
+    assert device.start_calls == 0
+    assert result.steps_run == 0
 
 
 def _already_latest() -> LuxpowerAPIError:
@@ -815,3 +908,242 @@ async def test_saw_in_progress_does_not_leak_across_steps() -> None:
     assert result.steps_run == 2
     assert device.start_calls == 2  # no third write
     assert "No firmware version progress after step 2" in result.message
+
+
+# --- Tri-model review round (PR #256) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_config_survives_two_already_current_components() -> None:
+    """The eode case with DEFAULT settings, one component deeper.
+
+    A device can have more than one component already at the target and the
+    server picks the order. With a grace of 1 this fails with the VERBATIM
+    #353 symptom one step later, which is why the default is 2. No explicit
+    no_progress_grace here on purpose: this pins the SHIPPED default.
+    """
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, STEP2_PENDING, STEP2_PENDING, UP_TO_DATE],
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 3,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert result.steps_run == 3
+    assert result.final_version == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_default_grace_still_stops_a_stuck_device() -> None:
+    """The default grace is 2, so a stuck device costs 3 accepted writes and
+    then stops. That coupling (grace + 1) is the blind-reflash bound."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING] * 6,
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 6,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert not result.success
+    assert device.start_calls == 3  # grace(2) + 1, well inside max_steps
+    assert result.steps_run == 3
+
+
+@pytest.mark.asyncio
+async def test_stale_installing_row_does_not_buy_the_grace() -> None:
+    """A leftover in-progress row must not forge the grace's evidence.
+
+    The aggregated progress flag matches ANY in-progress row for the serial.
+    A device whose previous run left an UPLOADING row would look "installing"
+    for a step the server never ran, spending real firmware writes on the
+    strength of someone else's status. Only evidence that appeared or
+    transitioned after our start POST counts.
+    """
+    stale = _row(start_time="run-from-yesterday", in_progress=True)
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING] * 4,
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 4,
+        # Same row, unchanged, before and after our start: stale.
+        status_rows=[stale] * 8,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert not result.success
+    assert device.start_calls == 1  # grace refused, no second blind write
+    assert "No firmware version progress after step 1" in result.message
+
+
+@pytest.mark.asyncio
+async def test_fresh_row_after_our_start_does_buy_the_grace() -> None:
+    """The complement: a row whose startTime changes after our POST is ours."""
+    before_start = _row(start_time="run-1", in_progress=False)
+    ours = _row(start_time="run-2", in_progress=True)
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, STEP2_PENDING, UP_TO_DATE],
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 2,
+        status_rows=[before_start, ours, before_start, ours],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert device.start_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_flapping_check_data_does_not_reset_the_grace() -> None:
+    """Alternating stale snapshots are not progress.
+
+    A check endpoint flapping between two states it has already reported is
+    not the device advancing. Counting each flap as movement reset the grace
+    every time and spent the entire step budget on blind reflashes.
+    """
+    a = _info("ccaa-1E1413", "ccaa-1E1515", app_current=0x14, param_current=0x13)
+    b = _info("ccaa-1E1414", "ccaa-1E1515", app_current=0x14, param_current=0x14)
+    device = ScriptedDevice(
+        checks=[a, b, a, b, a, b, a, b],
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 8,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert not result.success
+    # a->b is genuine novelty once; every later flap revisits a seen state.
+    assert device.start_calls <= 4
+    assert result.steps_run <= 4
+
+
+@pytest.mark.asyncio
+async def test_permanent_eligibility_denial_surfaces_immediately() -> None:
+    """notAllowedInParallel will never clear; do not poll it for 15 minutes."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING, STEP2_PENDING],
+        progresses=[NOOP_INSTALLING, NOOP_DONE],
+        eligibility=[
+            UpdateEligibilityMessage.ALLOW_TO_UPDATE,
+            UpdateEligibilityMessage.NOT_ALLOWED_IN_PARALLEL,
+        ],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, busy_grace=600, settle_checks=0
+    )
+
+    assert not result.success and not result.converged
+    assert device.start_calls == 1  # step 1 only; step 2 never attempted
+    assert device.eligibility_calls == 2  # probed once, not re-polled
+    assert "notAllowedInParallel" in result.message
+    assert "will not clear" in result.message
+
+
+@pytest.mark.asyncio
+async def test_transient_denial_is_still_waited_out() -> None:
+    """The complement: deviceUpdating IS transient and must still be retried."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
+        eligibility=[
+            UpdateEligibilityMessage.ALLOW_TO_UPDATE,
+            UpdateEligibilityMessage.DEVICE_UPDATING,
+            UpdateEligibilityMessage.ALLOW_TO_UPDATE,
+        ],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, busy_grace=60, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert device.start_calls == 2
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Failed updating firmware: invalid checksum",
+        "Error updating firmware image",
+    ],
+)
+@pytest.mark.asyncio
+async def test_permanent_failure_mentioning_updating_is_not_busy(message: str) -> None:
+    """A bare "updating" substring is not a busy signal.
+
+    The loose matcher classified these as transient, so a permanent failure
+    was retried for the whole busy budget and then reported as "device
+    remained busy" — burying the real cause. They must propagate.
+    """
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING],
+        start_results=[True, LuxpowerAPIError(message)],
+    )
+
+    with pytest.raises(LuxpowerAPIError, match="updating"):
+        await device.run_firmware_update_to_completion(
+            poll_interval=0, start_grace=0, busy_grace=60, settle_checks=0
+        )
+
+
+@pytest.mark.asyncio
+async def test_refused_starts_are_capped_per_step() -> None:
+    """The busy budget bounds elapsed time, not request count.
+
+    With a small backoff and a long budget, an always-busy device could hammer
+    the WRITE endpoint indefinitely. Cap the POSTs per step explicitly.
+    """
+
+    class AlwaysBusyAfterFirstStep(ScriptedDevice):
+        async def start_firmware_update(self, try_fast_mode: bool = False) -> bool:
+            self.start_calls += 1
+            if self.start_calls == 1:
+                self._run_seq += 1
+                return True
+            raise LuxpowerAPIError("deviceBusy")
+
+    device = AlwaysBusyAfterFirstStep(checks=[STEP1_PENDING, STEP2_PENDING])
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, busy_grace=600, settle_checks=0
+    )
+
+    assert not result.success
+    # step 1 accepted + the per-step cap on step 2, and no more.
+    assert device.start_calls == 1 + _MAX_START_ATTEMPTS_PER_STEP
+    assert "consecutive attempts" in result.message
+
+
+@pytest.mark.asyncio
+async def test_small_positive_poll_interval_does_not_hot_loop() -> None:
+    """A tiny poll_interval must not slip past the backoff floor.
+
+    The floor used to apply only to exactly 0, so 0.001 hot-looped the API.
+    """
+
+    class BusyMidChain(ScriptedDevice):
+        async def start_firmware_update(self, try_fast_mode: bool = False) -> bool:
+            self.start_calls += 1
+            if self.start_calls == 1:
+                self._run_seq += 1
+                return True
+            raise LuxpowerAPIError("deviceBusy")
+
+    device = BusyMidChain(checks=[STEP1_PENDING, STEP2_PENDING])
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0.001, start_grace=0, busy_grace=0.3, settle_checks=0
+    )
+
+    assert not result.success
+    # At a 0.05s floor, a 0.3s budget allows a handful of attempts — not the
+    # hundreds an unfloored 0.001s interval would have issued.
+    assert device.start_calls <= 1 + _MAX_START_ATTEMPTS_PER_STEP

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -62,10 +62,12 @@ class ScriptedDevice(FirmwareUpdateMixin):
         self.start_calls = 0
         self.check_calls = 0
         self.eligibility_calls = 0
+        self.check_force_flags: list[bool] = []
 
     # Scripted overrides -------------------------------------------------
     async def check_firmware_updates(self, force: bool = False) -> FirmwareUpdateInfo:
         self.check_calls += 1
+        self.check_force_flags.append(force)
         return self._checks.pop(0)
 
     async def get_firmware_update_progress(self, force: bool = False) -> FirmwareUpdateInfo:
@@ -733,6 +735,9 @@ async def test_mid_chain_already_latest_start_error_reports_convergence() -> Non
     assert result.steps_run == 1
     assert device.start_calls == 2  # the refusal really was exercised
     assert result.final_version == "ccaa-1E1515"
+    # The confirming re-check must bypass the 24h check cache, or it would
+    # simply replay the stale pre-step answer it is meant to supersede.
+    assert device.check_force_flags and all(device.check_force_flags)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -51,6 +51,9 @@ class ScriptedDevice(FirmwareUpdateMixin):
         failed_statuses: list[bool] | None = None,
     ) -> None:
         self._init_firmware_update_cache()
+        # The orchestrator logs against the host's serial (issue #353 chain
+        # diagnostics), so the harness must carry one like a real device.
+        self.serial_number = "4413740117"
         self._checks = checks
         self._progresses = progresses or []
         self._start_results = start_results or []
@@ -157,21 +160,24 @@ async def test_not_eligible_reports_failure_without_write() -> None:
 
 @pytest.mark.asyncio
 async def test_transient_device_busy_rechecks_eligibility_and_retries() -> None:
-    """A start race with the previous component must not abort the chain."""
-    installing = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=True)
-    done = _info("ccaa-1E1515", "ccaa-1E1515", in_progress=False)
+    """A start race with the previous component must not abort the chain.
+
+    Mid-chain only: the device is settling a component THIS run started, so
+    the bounded busy-retry applies (before any step, busy fails fast instead).
+    """
     device = ScriptedDevice(
-        checks=[STEP2_PENDING, UP_TO_DATE],
-        progresses=[installing, done],
-        start_results=[LuxpowerAPIError("deviceBusy"), True],
-        eligibility=[True, False, True],
+        checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
+        # step 1 starts cleanly; step 2's start races busy once, then takes.
+        start_results=[True, LuxpowerAPIError("deviceBusy"), True],
     )
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, busy_grace=60
+    )
 
     assert result.success and result.converged
-    assert result.steps_run == 1
-    assert device.start_calls == 2
+    assert result.steps_run == 2
+    assert device.start_calls == 3
 
 
 @pytest.mark.asyncio
@@ -212,20 +218,20 @@ async def test_first_step_not_eligible_still_fails_fast_without_write() -> None:
 @pytest.mark.asyncio
 async def test_busy_error_from_eligibility_is_retried_not_raised() -> None:
     """A busy LuxpowerAPIError raised by the eligibility probe itself must be
-    tolerated (retried within budget), not escape raw and abort the chain."""
-    installing = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=True)
-    done = _info("ccaa-1E1515", "ccaa-1E1515", in_progress=False)
+    tolerated mid-chain (retried within budget), not escape raw and abort."""
     device = ScriptedDevice(
-        checks=[STEP2_PENDING, UP_TO_DATE],
-        progresses=[installing, done],
-        eligibility=[LuxpowerAPIError("deviceBusy"), True],
+        checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
+        # step 1 gate eligible; step 2 gate raises busy once, then eligible.
+        eligibility=[True, LuxpowerAPIError("deviceBusy"), True],
     )
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=60)
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, busy_grace=60
+    )
 
     assert result.success and result.converged
-    assert result.steps_run == 1
-    assert device.start_calls == 1
+    assert result.steps_run == 2
+    assert device.start_calls == 2
     assert not device._eligibility  # the busy eligibility probe was re-polled
 
 
@@ -256,29 +262,33 @@ async def test_non_busy_error_from_start_propagates() -> None:
 
 @pytest.mark.asyncio
 async def test_no_start_write_fires_after_deadline_on_retry() -> None:
-    """If the eligibility probe on a retry straddles the deadline, no start
-    write may fire past it — the budget is a hard bound on retry writes."""
+    """If the eligibility probe on a mid-chain retry straddles the deadline, no
+    start write may fire past it — the budget is a hard bound on retry writes."""
 
     class SlowRetryEligibilityDevice(ScriptedDevice):
         elig_calls = 0
 
         async def check_update_eligibility(self) -> bool:
             self.elig_calls += 1
-            if self.elig_calls >= 2:
-                # second probe (the retry) runs long, past the tiny budget
+            if self.elig_calls >= 3:
+                # the step-2 retry probe runs long, past the tiny budget
                 await asyncio.sleep(0.2)
             return True
 
     device = SlowRetryEligibilityDevice(
-        checks=[STEP1_PENDING],
-        start_results=[LuxpowerAPIError("deviceBusy")],  # first start races busy
+        checks=[STEP1_PENDING, STEP2_PENDING],
+        # step 1 starts cleanly; step 2's start races busy and never recovers.
+        start_results=[True, LuxpowerAPIError("deviceBusy")],
     )
 
-    result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0.1)
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, busy_grace=0.1
+    )
 
     assert not result.success
-    # Only the first (in-budget) start fired; the retry bailed before writing.
-    assert device.start_calls == 1
+    # Step 1 plus step 2's single in-budget attempt; the retry bailed before
+    # writing again.
+    assert device.start_calls == 2
     assert "busy" in result.message.casefold()
 
 
@@ -299,22 +309,28 @@ async def test_no_start_write_fires_after_deadline_on_retry() -> None:
 )
 @pytest.mark.asyncio
 async def test_device_busy_past_start_budget_returns_clean_failure(message: str) -> None:
-    """A persistent busy response exhausts its budget without escaping raw."""
+    """A persistent MID-CHAIN busy response exhausts its budget without
+    escaping raw (before any step, busy fails fast instead — see
+    test_first_start_busy_error_fails_fast)."""
 
-    class PersistentlyBusyDevice(ScriptedDevice):
+    class BusyAfterFirstStepDevice(ScriptedDevice):
         async def start_firmware_update(self, try_fast_mode: bool = False) -> bool:
             self.start_calls += 1
+            if self.start_calls == 1:
+                return True
             raise LuxpowerAPIError(message)
 
-    device = PersistentlyBusyDevice(checks=[STEP1_PENDING])
+    device = BusyAfterFirstStepDevice(checks=[STEP1_PENDING, STEP2_PENDING])
 
     # A budget wide enough for several retries within it, so we verify the loop
     # retries multiple times AND stops cleanly at the deadline (no write past it).
-    result = await device.run_firmware_update_to_completion(poll_interval=0.02, start_grace=0.2)
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0.02, start_grace=0, busy_grace=0.2
+    )
 
     assert not result.success and not result.converged
-    assert result.steps_run == 0
-    assert device.start_calls > 1
+    assert result.steps_run == 1
+    assert device.start_calls > 2
     assert "busy" in result.message.casefold()
 
 
@@ -517,3 +533,210 @@ async def test_every_progress_poll_is_forced() -> None:
 
     assert result.success
     assert forced_flags and all(forced_flags)
+
+
+# --- Partial-upgrade skip (issue #353 round 3) -----------------------------
+#
+# eode's 6000XP sat at ccaa-1E1415 with target ccaa-1E1515. standardUpdate/run
+# takes no component selector, so the server picked the component already at
+# the target: it downloaded and flashed normally (the entity showed 0% -> 100%)
+# but COULD NOT move the version string. Aborting on that first unchanged
+# version meant the component that actually needed 14 -> 15 never ran, and
+# every retry reproduced the same loop.
+
+# A step that visibly installs but leaves the version untouched.
+NOOP_INSTALLING = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=True)
+NOOP_DONE = _info("ccaa-1E1415", "ccaa-1E1515", in_progress=False)
+
+
+@pytest.mark.asyncio
+async def test_no_op_component_does_not_end_the_chain() -> None:
+    """The #353 partial-upgrade case: step 1 re-flashes an already-current
+    component (visible install, no version change), step 2 finishes the job."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, STEP2_PENDING, UP_TO_DATE],
+        progresses=[NOOP_INSTALLING, NOOP_DONE, NOOP_INSTALLING, NOOP_DONE],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert result.steps_run == 2
+    assert device.start_calls == 2
+    assert result.final_version == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_no_progress_grace_is_not_unlimited() -> None:
+    """A genuinely stuck device still stops: the grace excuses ONE consecutive
+    unchanged step, not an open-ended run of firmware writes."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, STEP2_PENDING, STEP2_PENDING],
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 2,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert not result.success and not result.converged
+    assert result.steps_run == 2
+    assert device.start_calls == 2  # no third write
+    assert "No firmware version progress after step 2" in result.message
+
+
+@pytest.mark.asyncio
+async def test_no_progress_grace_zero_restores_immediate_abort() -> None:
+    """no_progress_grace=0 is the pre-#353 behaviour: abort on the first
+    unchanged version, one write only."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, STEP2_PENDING],
+        progresses=[NOOP_INSTALLING, NOOP_DONE],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0, no_progress_grace=0
+    )
+
+    assert not result.success
+    assert result.steps_run == 1
+    assert device.start_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unobserved_step_is_not_excused_by_the_grace() -> None:
+    """The grace requires positive evidence the step ran: a step that never
+    became visible as installing must NOT authorize another firmware write."""
+    device = ScriptedDevice(
+        # start_grace=0 with no in-progress poll => saw_in_progress stays False
+        checks=[STEP2_PENDING, STEP2_PENDING],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
+
+    assert not result.success
+    assert result.steps_run == 1
+    assert device.start_calls == 1  # grace available, but unearned
+    assert "No firmware version progress after step 1" in result.message
+
+
+@pytest.mark.asyncio
+async def test_failed_step_still_aborts_with_grace_available() -> None:
+    """A server-reported FAILED step outranks the no-progress grace."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, STEP2_PENDING],
+        progresses=[NOOP_INSTALLING, NOOP_DONE],
+        failed_statuses=[True],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert not result.success and not result.converged
+    assert result.steps_run == 1
+    assert device.start_calls == 1
+    assert "FAILED" in result.message
+
+
+# --- Pre-flight busy fails fast (issue #353 round 3) -----------------------
+
+
+@pytest.mark.asyncio
+async def test_first_eligibility_busy_error_fails_fast() -> None:
+    """A device already busy when the user asks must be reported immediately,
+    not after the multi-minute mid-chain retry budget."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING],
+        eligibility=[LuxpowerAPIError("deviceBusy")],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, busy_grace=600
+    )
+
+    assert not result.success and not result.converged
+    assert result.steps_run == 0
+    assert device.start_calls == 0
+    assert not device._eligibility  # probed exactly once, no re-poll
+    assert "busy" in result.message.casefold()
+    assert result.final_version == "ccaa-1E1415"
+
+
+@pytest.mark.asyncio
+async def test_first_start_busy_error_fails_fast() -> None:
+    """Eligibility can pass and the start still lose the race to a busy
+    device; before any step that is also an immediate stop, one write only."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING],
+        start_results=[LuxpowerAPIError("deviceBusy")],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, busy_grace=600
+    )
+
+    assert not result.success and not result.converged
+    assert result.steps_run == 0
+    assert device.start_calls == 1  # the one attempt, then stop
+    assert "busy" in result.message.casefold()
+
+
+@pytest.mark.asyncio
+async def test_pre_flight_busy_does_not_wait_out_the_budget() -> None:
+    """Pin the UX complaint itself: the fast-fail must return promptly even
+    when a large busy budget is configured."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING],
+        eligibility=[LuxpowerAPIError("deviceBusy")],
+    )
+
+    started = asyncio.get_running_loop().time()
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=30, start_grace=300, busy_grace=900
+    )
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert not result.success
+    assert elapsed < 1.0  # not the 900s budget, and not one 30s backoff
+
+
+@pytest.mark.asyncio
+async def test_mid_chain_already_latest_start_error_reports_convergence() -> None:
+    """If the check endpoint lags a successful final step, the grace can ask
+    for one step too many; the server's 'already the latest version' refusal
+    is convergence, not an error to surface after a successful update."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING],
+        start_results=[
+            True,
+            LuxpowerAPIError(
+                "API error (HTTP 200): The current machine firmware is already the latest version"
+            ),
+        ],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert result.steps_run == 1
+    assert result.final_version == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_pre_flight_already_latest_start_error_still_propagates() -> None:
+    """Before any step, check-says-update / run-says-latest is a genuine
+    endpoint disagreement about an untouched device and must still surface."""
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING],
+        start_results=[LuxpowerAPIError("already the latest version")],
+    )
+
+    with pytest.raises(LuxpowerAPIError, match="already the latest version"):
+        await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -9,6 +9,8 @@ path.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -268,7 +270,7 @@ async def test_transient_device_busy_rechecks_eligibility_and_retries() -> None:
     device = ScriptedDevice(
         checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
         # step 1 starts cleanly; step 2's start races busy once, then takes.
-        start_results=[True, LuxpowerAPIError("deviceBusy"), True],
+        start_results=[True, LuxpowerAPIError("API error (HTTP 200): deviceBusy"), True],
     )
 
     result = await device.run_firmware_update_to_completion(
@@ -322,7 +324,7 @@ async def test_busy_error_from_eligibility_is_retried_not_raised() -> None:
     device = ScriptedDevice(
         checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
         # step 1 gate eligible; step 2 gate raises busy once, then eligible.
-        eligibility=[True, LuxpowerAPIError("deviceBusy"), True],
+        eligibility=[True, LuxpowerAPIError("API error (HTTP 200): deviceBusy"), True],
     )
 
     result = await device.run_firmware_update_to_completion(
@@ -376,7 +378,7 @@ async def test_no_start_write_fires_after_deadline_on_retry() -> None:
     device = SlowRetryEligibilityDevice(
         checks=[STEP1_PENDING, STEP2_PENDING],
         # step 1 starts cleanly; step 2's start races busy and never recovers.
-        start_results=[True, LuxpowerAPIError("deviceBusy")],
+        start_results=[True, LuxpowerAPIError("API error (HTTP 200): deviceBusy")],
     )
 
     result = await device.run_firmware_update_to_completion(
@@ -393,16 +395,16 @@ async def test_no_start_write_fires_after_deadline_on_retry() -> None:
 @pytest.mark.parametrize(
     "message",
     [
-        "deviceBusy",
-        "device busy",
-        "DEVICE_BUSY",
+        "API error (HTTP 200): deviceBusy",
+        "API error (HTTP 200): device busy",
+        "API error (HTTP 200): DEVICE_BUSY",
         # A start-call TOCTOU race can report the device/parallel-group as
         # already updating; these busy-family codes AND their standardUpdate/run
         # prose variants must also be tolerated, not escape raw (issue #353).
-        "deviceUpdating",
-        "parallelGroupUpdating",
-        "Device is already updating",
-        "Another device in the parallel group is updating",
+        "API error (HTTP 200): deviceUpdating",
+        "API error (HTTP 200): parallelGroupUpdating",
+        "API error (HTTP 200): Device is already updating",
+        "HTTP 500: Another device in the parallel group is updating",
     ],
 )
 @pytest.mark.asyncio
@@ -839,7 +841,7 @@ async def test_first_eligibility_busy_error_fails_fast() -> None:
     not after the multi-minute mid-chain retry budget."""
     device = ScriptedDevice(
         checks=[STEP2_PENDING],
-        eligibility=[LuxpowerAPIError("deviceBusy")],
+        eligibility=[LuxpowerAPIError("API error (HTTP 200): deviceBusy")],
     )
 
     result = await device.run_firmware_update_to_completion(
@@ -860,7 +862,7 @@ async def test_first_start_busy_error_fails_fast() -> None:
     device; before any step that is also an immediate stop, one write only."""
     device = ScriptedDevice(
         checks=[STEP2_PENDING],
-        start_results=[LuxpowerAPIError("deviceBusy")],
+        start_results=[LuxpowerAPIError("API error (HTTP 200): deviceBusy")],
     )
 
     result = await device.run_firmware_update_to_completion(
@@ -879,7 +881,7 @@ async def test_pre_flight_busy_does_not_wait_out_the_budget() -> None:
     when a large busy budget is configured."""
     device = ScriptedDevice(
         checks=[STEP2_PENDING],
-        eligibility=[LuxpowerAPIError("deviceBusy")],
+        eligibility=[LuxpowerAPIError("API error (HTTP 200): deviceBusy")],
     )
 
     result = await device.run_firmware_update_to_completion(
@@ -1201,7 +1203,7 @@ async def test_refused_starts_are_capped_per_step() -> None:
             if self.start_calls == 1:
                 self._run_seq += 1
                 return True
-            raise LuxpowerAPIError("deviceBusy")
+            raise LuxpowerAPIError("API error (HTTP 200): deviceBusy")
 
     device = AlwaysBusyAfterFirstStep(checks=[STEP1_PENDING, STEP2_PENDING])
 
@@ -1228,7 +1230,7 @@ async def test_small_positive_poll_interval_does_not_hot_loop() -> None:
             if self.start_calls == 1:
                 self._run_seq += 1
                 return True
-            raise LuxpowerAPIError("deviceBusy")
+            raise LuxpowerAPIError("API error (HTTP 200): deviceBusy")
 
     device = BusyMidChain(checks=[STEP1_PENDING, STEP2_PENDING])
 
@@ -1294,10 +1296,10 @@ async def test_first_step_attribution_is_still_strict() -> None:
 @pytest.mark.parametrize(
     "message",
     [
-        "systemBusy",
-        "Device is updating, please try again",
-        "SYSTEM_BUSY",
-        "The inverter is busy",
+        "API error (HTTP 200): systemBusy",
+        "API error (HTTP 200): Device is updating, please try again",
+        "HTTP 503: SYSTEM_BUSY",
+        "API error (HTTP 200): The inverter is busy",
     ],
 )
 @pytest.mark.asyncio
@@ -1325,10 +1327,10 @@ async def test_unrecognised_busy_phrasings_are_still_tolerated(message: str) -> 
 @pytest.mark.parametrize(
     "message",
     [
-        "Failed updating firmware: invalid checksum",
-        "Error updating firmware image",
-        "Firmware image corrupt",
-        "Update timed out while updating",
+        "API error (HTTP 200): Failed updating firmware: invalid checksum",
+        "API error (HTTP 200): Error updating firmware image",
+        "API error (HTTP 200): Firmware image corrupt",
+        "API error (HTTP 200): Update timed out while updating",
     ],
 )
 @pytest.mark.asyncio
@@ -1438,14 +1440,21 @@ async def test_no_same_source_baseline_is_indeterminate_not_movement() -> None:
     sentinel = _info("", "")
     device = ScriptedDevice(
         checks=[STEP2_PENDING, sentinel],
-        # Baseline read fails; later reads succeed with some other value.
-        firmware_codes=[None, "ccaa-1E9999", "ccaa-1E9999", "ccaa-1E9999", "ccaa-1E9999"],
+        # The baseline read fails on every attempt INCLUDING its retries (a
+        # single None would now be retried away); the later corroboration
+        # succeeds with some other value.
+        firmware_codes=[None, None, None, None, "ccaa-1E9999"],
     )
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
     assert not result.success and not result.converged
     assert "verify the firmware version on the device" in result.message
+    # The corroborated version IS known here, so the message must say it
+    # rather than claiming the version could not be read.
+    assert "device reports ccaa-1E9999" in result.message
+    assert "no pre-run version to compare" in result.message
+    assert result.final_version == "ccaa-1E9999"
 
 
 # --- Round 4 ---------------------------------------------------------------
@@ -1599,22 +1608,94 @@ async def test_corroboration_read_is_retried_before_giving_up() -> None:
 
 
 @pytest.mark.asyncio
-async def test_corroboration_validation_error_is_not_raised_at_the_caller() -> None:
-    """fwCode is a required str; a device omitting it mid-reboot raises
-    ValidationError, which would escape into the HA install action."""
-    from pydantic import ValidationError
+async def test_pre_run_baseline_read_is_retried() -> None:
+    """The baseline read gets the same retry as the corroboration reads.
 
-    class ValidationFailingDevice(ScriptedDevice):
-        async def _read_device_firmware_code(self) -> str | None:
-            # Exercise the production body's except clause.
-            try:
-                raise ValidationError.from_exception_data("InverterRuntime", [])
-            except (LuxpowerAPIError, ValidationError):
-                return None
-
-    device = ValidationFailingDevice(checks=[STEP2_PENDING, _info("", "")])
+    Run start is itself a transient-failure moment — the reporter's device was
+    literally recovering from an earlier update attempt — and a failed
+    baseline disables the movement test for the WHOLE run, turning a
+    successful update into an indeterminate red error.
+    """
+    sentinel = _info("", "")
+    device = ScriptedDevice(
+        checks=[STEP2_PENDING, sentinel],
+        # Baseline fails once then succeeds; the corroboration then shows the
+        # device on the target. Without the retry the baseline stays None and
+        # the run cannot conclude anything.
+        firmware_codes=[None, "ccaa-1E1415", "ccaa-1E1515"],
+    )
 
     result = await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
 
-    assert not result.success  # indeterminate, but no exception escaped
-    assert "verify the firmware version on the device" in result.message
+    assert result.success and result.converged
+    assert result.final_version == "ccaa-1E1515"
+
+
+# --- Direct coverage of the REAL _read_device_firmware_code body ------------
+#
+# ScriptedDevice overrides this method wholesale, so every orchestration test
+# above exercises the harness, not production. The previous ValidationError
+# test was a tautology: it re-implemented the except clause inside a subclass,
+# so reverting the production catch left it green. These drive the actual body.
+
+
+class _BareHost(FirmwareUpdateMixin):
+    """Mixin host with nothing but what the production body touches."""
+
+    def __init__(self, runtime_result: object) -> None:
+        self._init_firmware_update_cache()
+        self.serial_number = "4413740117"
+        self._runtime_result = runtime_result
+        self._client = self._build_client()
+
+    def _build_client(self) -> MagicMock:
+        async def _get_inverter_runtime(serial: str) -> object:
+            if isinstance(self._runtime_result, Exception):
+                raise self._runtime_result
+            return self._runtime_result
+
+        client = MagicMock()
+        client.api.devices.get_inverter_runtime = _get_inverter_runtime
+        return client
+
+
+@pytest.mark.asyncio
+async def test_read_device_firmware_code_returns_the_code() -> None:
+    host = _BareHost(SimpleNamespace(fwCode="ccaa-1E1515"))
+
+    assert await host._read_device_firmware_code() == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_read_device_firmware_code_treats_empty_as_unknown() -> None:
+    """An empty string is not a version; it must not be reported as one."""
+    host = _BareHost(SimpleNamespace(fwCode=""))
+
+    assert await host._read_device_firmware_code() is None
+
+
+@pytest.mark.asyncio
+async def test_read_device_firmware_code_swallows_api_errors() -> None:
+    host = _BareHost(LuxpowerAPIError("API error (HTTP 500): boom"))
+
+    assert await host._read_device_firmware_code() is None
+
+
+@pytest.mark.asyncio
+async def test_read_device_firmware_code_swallows_validation_errors() -> None:
+    """fwCode is a required str, so a device omitting it mid-reboot raises
+    ValidationError — which would escape into the HA install action."""
+    from pydantic import ValidationError
+
+    host = _BareHost(ValidationError.from_exception_data("InverterRuntime", []))
+
+    assert await host._read_device_firmware_code() is None
+
+
+@pytest.mark.asyncio
+async def test_read_device_firmware_code_does_not_swallow_everything() -> None:
+    """The catch is narrow on purpose: a programming error must still surface."""
+    host = _BareHost(RuntimeError("not an API failure"))
+
+    with pytest.raises(RuntimeError, match="not an API failure"):
+        await host._read_device_firmware_code()

--- a/tests/unit/test_firmware_update_run.py
+++ b/tests/unit/test_firmware_update_run.py
@@ -61,6 +61,7 @@ class ScriptedDevice(FirmwareUpdateMixin):
         self._failed_statuses = failed_statuses or []
         self.start_calls = 0
         self.check_calls = 0
+        self.eligibility_calls = 0
 
     # Scripted overrides -------------------------------------------------
     async def check_firmware_updates(self, force: bool = False) -> FirmwareUpdateInfo:
@@ -82,6 +83,7 @@ class ScriptedDevice(FirmwareUpdateMixin):
         return True
 
     async def check_update_eligibility(self) -> bool:
+        self.eligibility_calls += 1
         if self._eligibility:
             result = self._eligibility.pop(0)
             if isinstance(result, LuxpowerAPIError):
@@ -662,7 +664,7 @@ async def test_first_eligibility_busy_error_fails_fast() -> None:
     assert not result.success and not result.converged
     assert result.steps_run == 0
     assert device.start_calls == 0
-    assert not device._eligibility  # probed exactly once, no re-poll
+    assert device.eligibility_calls == 1  # probed once, no re-poll
     assert "busy" in result.message.casefold()
     assert result.final_version == "ccaa-1E1415"
 
@@ -705,19 +707,22 @@ async def test_pre_flight_busy_does_not_wait_out_the_budget() -> None:
     assert elapsed < 1.0  # not the 900s budget, and not one 30s backoff
 
 
+def _already_latest() -> LuxpowerAPIError:
+    """A fresh instance per use — the harness raises the scripted object."""
+    return LuxpowerAPIError(
+        "API error (HTTP 200): The current machine firmware is already the latest version"
+    )
+
+
 @pytest.mark.asyncio
 async def test_mid_chain_already_latest_start_error_reports_convergence() -> None:
-    """If the check endpoint lags a successful final step, the grace can ask
-    for one step too many; the server's 'already the latest version' refusal
-    is convergence, not an error to surface after a successful update."""
+    """If the check endpoint lags a successful final step, the loop can ask for
+    one step too many. The server's 'already the latest version' refusal is not
+    surfaced as a raw error — but convergence is confirmed by a re-check, never
+    declared on the refusal alone."""
     device = ScriptedDevice(
-        checks=[STEP1_PENDING, STEP2_PENDING],
-        start_results=[
-            True,
-            LuxpowerAPIError(
-                "API error (HTTP 200): The current machine firmware is already the latest version"
-            ),
-        ],
+        checks=[STEP1_PENDING, STEP2_PENDING, UP_TO_DATE],
+        start_results=[True, _already_latest()],
     )
 
     result = await device.run_firmware_update_to_completion(
@@ -726,7 +731,30 @@ async def test_mid_chain_already_latest_start_error_reports_convergence() -> Non
 
     assert result.success and result.converged
     assert result.steps_run == 1
+    assert device.start_calls == 2  # the refusal really was exercised
     assert result.final_version == "ccaa-1E1515"
+
+
+@pytest.mark.asyncio
+async def test_mid_chain_already_latest_without_confirmation_is_not_success() -> None:
+    """The refusal alone must never be reported as success: if the re-check
+    still says an update remains, the endpoints genuinely disagree and the
+    device may be partially upgraded — exactly the failure #353 is about."""
+    device = ScriptedDevice(
+        checks=[STEP1_PENDING, STEP2_PENDING, STEP2_PENDING],
+        start_results=[True, _already_latest()],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
+
+    assert not result.success and not result.converged
+    assert result.steps_run == 1
+    assert device.start_calls == 2
+    assert "partially upgraded" in result.message
+    # The real installed version, not the target we hoped for.
+    assert result.final_version == "ccaa-1E1415"
 
 
 @pytest.mark.asyncio
@@ -740,3 +768,45 @@ async def test_pre_flight_already_latest_start_error_still_propagates() -> None:
 
     with pytest.raises(LuxpowerAPIError, match="already the latest version"):
         await device.run_firmware_update_to_completion(poll_interval=0, start_grace=0)
+
+
+@pytest.mark.asyncio
+async def test_grace_resets_after_a_step_that_moves_the_version() -> None:
+    """The grace is CONSECUTIVE: a no-op, then a real advance, then another
+    no-op must each get their own excuse. Pins the counter reset — without it
+    the second no-op would abort the chain."""
+    mid = _info("ccaa-1E1465", "ccaa-1E1515", app_current=0x14, param_current=0x65)
+    device = ScriptedDevice(
+        # step 1 no-op, step 2 advances, step 3 no-op, step 4 converges
+        checks=[STEP2_PENDING, STEP2_PENDING, mid, mid, UP_TO_DATE],
+        progresses=[NOOP_INSTALLING, NOOP_DONE] * 4,
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=60, settle_checks=0
+    )
+
+    assert result.success and result.converged
+    assert result.steps_run == 4
+    assert device.start_calls == 4
+
+
+@pytest.mark.asyncio
+async def test_saw_in_progress_does_not_leak_across_steps() -> None:
+    """saw_in_progress is per-step evidence. A step that was observed
+    installing must not license the NEXT step's unobserved no-progress step."""
+    device = ScriptedDevice(
+        # step 1 observed installing and advances; step 2 is never observed
+        # installing and does not advance -> must abort, unearned grace.
+        checks=[STEP1_PENDING, STEP2_PENDING, STEP2_PENDING],
+        progresses=[NOOP_INSTALLING, NOOP_DONE],
+    )
+
+    result = await device.run_firmware_update_to_completion(
+        poll_interval=0, start_grace=0, settle_checks=0
+    )
+
+    assert not result.success
+    assert result.steps_run == 2
+    assert device.start_calls == 2  # no third write
+    assert "No firmware version progress after step 2" in result.message


### PR DESCRIPTION
## Root cause

`standardUpdate/run` takes **no component/step selector** (`userId`, `serialNum`, `tryFastMode` only) — the server decides which firmware component a run installs. On a partially upgraded device it can select a component that is **already at the target version**. That run downloads and flashes normally (the HA entity shows 0% → 100%, the device's activity light blinks) but it **cannot move the version string**.

`run_firmware_update_to_completion` treated the first unchanged version after a completed step as a dead chain and aborted. So the component that actually needed upgrading never ran, and every retry reproduced the identical loop.

Reported on a 6000XP (eg4_web_monitor#353) stuck at `ccaa-1E1415` with target `ccaa-1E1515`:

```
Installing (0%) -> Installing (100%) -> "No firmware version progress after step 1;
stopping to avoid repeated update commands (steps run: 1, current version: ccaa-1E1415)"
```

For that device `has_app_update` is True (`v1` 0x14 → `lastV1` 0x15) and `has_parameter_update` is False (`v2` already 0x15) — consistent with the reporter's read that the run flashed the already-current component.

A second defect from the same report: the reporter clicked Install on a device still recovering from an earlier attempt and watched "Installing" for **five minutes** before being told it was busy. The bounded busy-retry added in 3.5.1-beta.1 for *inter-component settling* was also being applied *before the first step*, where there is no chain of ours to protect.

## Fix

**Partial-upgrade skip.** `no_progress_grace` (default **2**) tolerates that many *consecutive* steps that ran without moving the version. A step is only excused with evidence attributable to **its own** start POST, and only if it did not report FAILED.

**Honest residual, stated up front:** convergence holds only while the server does not select more than `no_progress_grace` already-current components in a row. The same number is the blind-reflash exposure on a genuinely stuck device — `no_progress_grace + 1` accepted writes (3). Default 2 rather than 1 because a probe showed a device whose first *two* selections are already-current fails with the verbatim reporter symptom one step later.

Deliberately **not** gated on `needRunStep2..5`: their firmware semantics are unverified and we lack the reporting device's `checkUpdates` response, so requiring an advertised flag risked shipping a fix that never fires. They are logged and included in the abort message instead.

**Pre-flight busy fast-fail.** Busy tolerance applies only once a start has been accepted (`steps_run > 0`). Before that, a busy response from either the eligibility probe or the start call returns immediately. Mid-chain tolerance is unchanged, on its own `busy_grace` budget (900s, bounded by `step_timeout`).

**Convergence requires evidence.** "No update available" is necessary but not sufficient: the up-to-date sentinel returns an EMPTY installed version, and the previous code backfilled the target for it — so a device still on the old firmware could be reported as successfully updated to a version it never reached. Convergence now requires a concrete installed version equal to the target, and the target is pinned from the first check so a later self-contradicting answer cannot redefine the goal.

## Review rounds

Two adversarial rounds. The first (Codex) found a P1 in my own first cut: an unconfirmed "already latest" refusal declared success. The second was a tri-model gate (Fable + Codex high + Gemini 3.1 Pro), all converging FIX-FIRST on seven items — four P1-class. All fixed in `ffb2320`:

| # | Finding | Fix |
|---|---|---|
| 1 | False convergence via empty/stale re-check | Convergence requires installed version == pinned target; both returns share one helper |
| 2 | Stale status row forges the grace's evidence | Pre-POST row snapshot; only evidence that appeared/transitioned/re-opened after our start counts |
| 3 | Flapping snapshots counted as progress (5 blind flashes) | Progress requires a version state not already seen this run |
| 4 | Busy matcher caught permanent failures via "updating" | Matched against known busy codes; `notAllowedInParallel` surfaced immediately |
| 5 | `steps_run` counted refused starts, contradicting its own docstring | Increment moved after the accepted-start check; pinning test corrected |
| 6 | `no_progress_grace` 1 too shallow | Default 2, with the coupling documented |
| 7 | Write-endpoint POSTs unbounded inside the busy budget | Per-step cap on refused starts; backoff floor applies to any `poll_interval`, not just 0 |

Two Gemini findings were **not** actioned, deliberately: the "unprotected re-check exception" (propagation is the documented `Raises` contract) and a settle=0 premature-convergence path (mechanism refuted — a lagging check reports the OLD state, which is update-available, not absence).

## Tests

`tests/unit/test_firmware_update_run.py` — **56 tests** (was 31 on main). The harness gained status-row and eligibility-status seams and models a well-behaved server, so a misbehaving one (a stale row that never changes) can be scripted as the exception it is.

The old `test_converged_final_version_survives_up_to_date_sentinel` asserted the **exact P1 behaviour** — target substituted for an empty installed version — and is inverted.

## Validation

```
uv run pytest tests/ -q          2895 passed, 4 skipped, 80 deselected
uv run ruff check src/ tests/    All checks passed!
uv run ruff format --check       clean
uv run mypy src/pylxpweb/ --strict   Success: no issues found in 94 source files
```

## Residual risk, knowingly accepted

- The grace's evidence is "our own start was seen installing and did not report FAILED", not a positive terminal `SUCCESS`/`COMPLETE`. The poll loop exits as soon as `in_progress` goes false, so the stronger signal is not reliably observable; requiring it risked a fix that never fires. The stale-row attribution closes the part of this that was actually exploitable — the gating row is the INSTALLING one, and it is now attributed to our POST.
- `busy_grace` 900s means a stuck mid-chain device holds the HA install action up to 15 minutes before reporting. Refused-start POSTs inside that window are capped per step.
- The pre-flight fast-fail gives up a transient first-step busy that would previously have self-recovered. That is the reporter's explicit ask.
- Hardware validation on the reporter's 6000XP is still pending.

## Merge order

Touches `constants/registers.py`? No — this branch is confined to the firmware mixin, its tests, and the changelog. It is independent of #258 (#242 register table).

A merge-order dependency on **#254 before #256** was reported, on the grounds of a pre-existing wall-clock flake in `test_device_helpers` failing standalone on this branch. **I could not reproduce it: 4/4 clean standalone runs**, and the full suite passes. Recording it as unconfirmed rather than asserting it — if it does surface in CI, rebasing once #254 lands is the fix.

## Downstream

eg4_web_monitor needs **no code change** — `update.py` calls `run_firmware_update_to_completion()` with defaults and surfaces `result.message`. Only the manifest pin at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 3 (`1c1051b`) — closing the false negatives round 2 opened

A second reviewer's delta review found the previous round over-corrected: closing the false-**positive** convergence paths opened false-**negative** ones that fire on the reporter's exact hardware. Both P1s confirmed against the code.

**P1-1 — the empty sentinel IS the documented converged answer.** `checkUpdates` answers an up-to-date device with `success:false` "already the latest version", which `endpoints/firmware.py` turns into `create_up_to_date()` with `fwCodeBeforeUpload=""` — documented in the repo's own `openapi.yaml`. Round 2 demanded a concrete `installed == target`, so a device that *actually converged* mid-run reported `success=False` and eg4 raised a red error at the moment of success. It was also self-contradictory: the pre-flight path trusts the same sentinel.

Neither trusting nor rejecting the sentinel is right, so it is now **corroborated** against a source that always carries a version — the runtime endpoint's `fwCode`:

| Corroborated version | Verdict |
|---|---|
| On the target | converged |
| Still on the version this run started from | transient answer — continue the chain, do not abort |
| Moved, but not string-equal to the target | converged, reporting the device's own version (the target can be a spliced reconstruction the server never echoes) |
| Unreadable | indeterminate, worded "verify the version on the device" rather than implying failure |

**P1-2 — attribution that may never fire on real hardware.** The stale-row guard demanded a fresh `startTime` for *every* step. If the portal keeps one row per update session and updates it in place, step 2's baseline is already an in-progress row with an unchanged `startTime`, all three freshness clauses fail, the grace is refused, and the reporter's verbatim error returns. The threat is **pre-run leftovers**, so strict attribution now applies only to step 1; from step 2 an in-progress row is this run's own activity.

**P2s.** Busy classification is two-stage — failure prose wins outright, then any busy/updating wording counts as busy — restoring breadth for uncatalogued phrasings (`systemBusy`) while still excluding "invalid checksum". Attribution reuses the row the progress poll already fetched instead of a second `remoteUpdate/info` call that could disagree with it. Target comparison is case-insensitive.

**P3s.** A blank installed version is no longer a novel progress state; `notAllowedInParallel` is worded as a likely parallel-group conflict rather than "will not clear on its own" (our own run can induce it); `_current_status_row` documents the first-match/multi-row risk.

### Worst-case bounds, stated explicitly

Per accepted step: `busy_grace` 900s + `step_timeout` 3600s + settle window (3 × 30s) ≈ 4590s. With `max_steps` 5 that is **≈ 6.4 hours** of held install lock in the pathological case, and at most **5 × 12 = 60** `standardUpdate/run` POSTs. Real installs are 20–40 minutes per step; these are ceilings, not expectations, but the eg4 entity holds its per-serial install lock for the whole chain.

### Tests

56 → **71**. All three new guards are **mutation-verified**: reverting mid-chain attribution, the blank-version novelty guard, or corroboration each fails the specific test written for it.

```
uv run pytest tests/ -q          2910 passed, 4 skipped, 80 deselected
uv run ruff check src/ tests/    All checks passed!
uv run mypy src/pylxpweb/ --strict   Success: no issues found in 94 source files
```

### Still outstanding

Hardware validation. One debug capture of the raw `remoteUpdate/info` rows during a real run would settle the one-row-per-session vs per-component question that P1-2 had to be designed around — that ask is in the draft issue comment.

### Round 3 follow-up (`3e16689`) — one-source version comparison

Round-3 review found one P2 in the verdict table above, silent and one-directional toward false success. The "moved but not string-equal to the target" branch decided convergence by comparing the **runtime** endpoint's `fwCode` against the version the **check** endpoint reported at the start of the run. Those are different endpoints, and this file already documents check-side strings as synthesized reconstructions. If their shapes ever differ by more than case — a prefix one side omits, say — `not _same_version(...)` is *permanently* true, and every sentinel converts to "converged" on its first occurrence without the device having moved at all.

Both offered fixes applied, since they are complementary:

1. The baseline is now read from the **same source** as the corroboration, once before the step loop, so the movement test is `fwCode`-to-`fwCode`.
2. If that baseline is unavailable (the read failed), "did it move?" is not a question this run can answer — it falls to the **indeterminate** verdict rather than counting inequality as movement.

Tests 71 → **73**, both halves mutation-verified: restoring the cross-source comparison fails the new shape-difference test (check side carries a prefix the runtime side omits, runtime never moves → must not converge), and treating a missing baseline as movement fails the new indeterminate test.

```
uv run pytest tests/ -q          2917 passed, 4 skipped, 80 deselected
uv run ruff check src/ tests/    All checks passed!
uv run mypy src/pylxpweb/ --strict   Success: no issues found in 94 source files
```

---

## Round 4 (`d20d604`)

> **Correction to the `3e16689` section above.** That commit landed **only its CHANGELOG hunk** — the same-source baseline fix and its two tests never reached the branch, despite being validated locally and reported as pushed. Caught by a test-count discrepancy while starting this round. Both are re-applied here and mutation-verified again. Treat the `3e16689` section as describing work that is live **as of `d20d604`**, not before it.

**P1 — the busy classifier never fired in production.** `LuxpowerClient` wraps every failure before it reaches the orchestrator, and two of its three wrappers contain the word "error": `API error (HTTP 200): deviceBusy` and `Unexpected error: …`. Since "error" is in the permanent-failure prose, stage 1 matched the **wrapper**, ruled every busy response permanent, and left the entire mid-chain busy tolerance dead. The unit tests passed only because they injected a bare `deviceBusy` — a shape the client never emits. Classification now strips the known wrappers with anchored patterns and runs on the server's own message; the already-latest matcher gets the same treatment; tests inject the real production strings.

**P1 — the pre-flight path still trusted the raw sentinel.** It returned success on `not update_available` with no corroboration, so round 2's headline false positive survived at the front door. An empty-version answer now gets **one confirming re-check** after `preflight_confirm_delay`; both agreeing reports up-to-date, disagreement proceeds into the chain. A concrete version with nothing newer is still trusted on one read. **Residual: two consecutive blinks would still slip through** — this is a confirmation, not a proof.

**P1 — `ValidationError` was reachable from the install action.** `fwCode` is a required `str`, so a device omitting it mid-reboot raised straight out of `_read_device_firmware_code`. Now caught alongside `LuxpowerError`.

**P1 — a transient read-back failure reported success as failure.** The most likely moment for the runtime read to fail is while the device reboots after its final component — exactly when the update has succeeded. The read is retried a bounded number of times before settling on indeterminate. Indeterminate still never fabricates success; the retries only make it rare.

### Decisions, not artifacts

**Verdict 3 — "no further updates + device moved off its start version" stays converged.** The target string can be a splice reconstruction the server never echoes, so demanding equality would fail real convergences. The trade is that we report success without having verified target equality — so the message now says exactly that: it reports the server found no further updates, gives the device's **actual** version, and states the target was not echoed back for comparison. `final_version` is the device's own version, never the target. A test pins that wording.

**Steps ≥2 accept any in-progress row as attribution.** Deliberate. The stale-row threat is *pre-run* leftovers, which only step 1 is exposed to; demanding a fresh `startTime` on later steps breaks on a portal that keeps one row per session and updates it in place, reintroducing the exact reported failure. The grace and `max_steps` bound it either way. **This rests on an unverified question** — one row per session vs one per component — and a single debug capture of the raw `remoteUpdate/info` rows during a real run would settle it. That ask is in the issue comment draft.

### Tests

71 → **87**. Mutation-verified: reverting the wrapper stripping, the pre-flight confirmation, the corroboration retry, or the same-source baseline each fails the test written for it.

```
uv run pytest tests/ -q          2931 passed, 4 skipped, 80 deselected
uv run ruff check src/ tests/    All checks passed!
uv run mypy src/pylxpweb/ --strict   Success: no issues found in 94 source files
```

---

## Final round (`79b184c`)

**Behaviour — one change.** The pre-run baseline firmware read now gets the same bounded retry as the corroboration reads, through a shared helper. Run start is itself a transient-failure moment — the reporting device was literally recovering from an earlier update attempt — and a failed baseline disables the movement check for the *whole* run, turning a successful update into an indeterminate red error.

**Coverage.** `_read_device_firmware_code`'s production body had none: the harness overrides it wholesale, and the previous `ValidationError` test was a **tautology** that re-implemented the except clause inside a subclass, so reverting the production catch left the suite green. Deleted and replaced with direct tests of the real body against a minimal host — code returned, empty string treated as unknown, `LuxpowerError` swallowed, `ValidationError` swallowed, and an unrelated exception still propagating (the catch is narrow on purpose).

**Test shape.** The 8 legacy busy injections are migrated off the bare `deviceBusy` string onto the wrapper shapes the client actually emits. That unreal shape is exactly what hid the classifier P1 for three rounds; leaving it in the suite invites the same blind spot back. Zero bare occurrences remain.

**Message honesty.** When there is no same-source baseline but the device's version *is* known, the result no longer claims the version "could not be read" — it reports the version, says there is no pre-run value to compare against, and `final_version` carries the known value instead of `None`.

### Accepted cost

Pressing Install on an already-up-to-date device that answers with the sentinel now waits `preflight_confirm_delay` (10s) for a confirming re-check before reporting up-to-date. That is the price of never trusting a lone sentinel, and it is judged worth it: the entity shows in-progress during the wait, and the reporter's fast-fail request concerned a **busy** device, which still fails fast on the first probe. A concrete version with nothing newer is still trusted on a single read and returns immediately.

### Mutation results — including one that failed

Each item was mutation-tested. Worth recording rather than hiding: **the baseline retry initially had no failing mutant** — removing it left all 91 tests green — so a test was written specifically for it and re-verified. That is the same gap class this round set out to close, found in this round's own work.

### Suite counts (corrected)

```
uv run pytest tests/unit -q            2898 passed
uv run pytest tests/ -q                2936 passed, 4 skipped, 80 deselected
uv run pytest tests/ --collect-only    2940/3020 collected (80 deselected)
uv run ruff check src/ tests/          All checks passed!
uv run mypy src/pylxpweb/ --strict     Success: no issues found in 94 source files
```

Orchestrator tests: **92** (`tests/unit/test_firmware_update_run.py`).