### PR TITLE
Add inverter smart load cloud controls

### DIFF
--- a/src/pylxpweb/endpoints/control.py
+++ b/src/pylxpweb/endpoints/control.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+import math
+from typing import Any, cast
 
 from pylxpweb.constants import SCHEDULE_CONFIGS, ScheduleType
 from pylxpweb.endpoints.base import BaseEndpoint
@@ -32,6 +33,48 @@ _SCHEDULE_REGISTER_ADDRESSES: frozenset[int] = frozenset(
     for config in SCHEDULE_CONFIGS.values()
     for address in range(config.base_register, config.base_register + 2 * config.periods)
 )
+
+
+def _parse_int_parameter(raw: object) -> int | None:
+    """Parse a named cloud parameter as an integer when possible."""
+    if raw is None:
+        return None
+    try:
+        parsed: int = int(cast(Any, raw))
+    except (TypeError, ValueError):
+        return None
+    return parsed
+
+
+def _parse_float_parameter(raw: object) -> float | None:
+    """Parse a named cloud parameter as a float when possible."""
+    if raw is None:
+        return None
+    try:
+        parsed: float = float(cast(Any, raw))
+    except (TypeError, ValueError):
+        return None
+    return parsed
+
+
+def _parse_enabled_parameter(raw: object) -> bool | None:
+    """Parse a named cloud function parameter without inventing False."""
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        lowered = raw.strip().lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+    return None
+
+
+def _validate_tenth_resolution(value: float, name: str) -> None:
+    """Require a value to align with the cloud parameter's 0.1 step."""
+    scaled = value * 10
+    if not math.isclose(scaled, round(scaled), rel_tol=0.0, abs_tol=1e-9):
+        raise ValueError(f"{name} must be a multiple of 0.1, got {value}")
 
 
 class ControlEndpoints(BaseEndpoint):
@@ -2547,30 +2590,311 @@ class ControlEndpoints(BaseEndpoint):
         """
         params = await self.read_device_parameters_ranges(inverter_sn)
 
-        def _parse(key: str) -> int | None:
-            raw = params.get(key)
-            if raw is None:
-                return None
-            try:
-                return int(raw)
-            except (TypeError, ValueError):
-                return None
+        return {
+            "start_soc": _parse_int_parameter(params.get("_12K_HOLD_AC_COUPLE_START_SOC")),
+            "end_soc": _parse_int_parameter(params.get("_12K_HOLD_AC_COUPLE_END_SOC")),
+            "enabled": _parse_enabled_parameter(params.get("FUNC_AC_COUPLING_FUNCTION")),
+        }
 
-        def _parse_enabled(raw: object) -> bool | None:
-            if isinstance(raw, bool):
-                return raw
-            if isinstance(raw, str):
-                lowered = raw.strip().lower()
-                if lowered == "true":
-                    return True
-                if lowered == "false":
-                    return False
-            return None
+    # ============================================================================
+    # Inverter Smart Load Threshold Controls (Cloud API)
+    # ============================================================================
+    #
+    # INVERTER-LEVEL smart-load settings from the portal's Smart Load tab,
+    # distinct from the GridBOSS/MID per-port smart-load controls elsewhere in
+    # this module. The five ``_12K_HOLD_*`` values were observed on both an
+    # 18kPV and a FlexBOSS21, while a GridBOSS exposed only the function key and
+    # none of these inverter threshold keys. Their absence is therefore kept as
+    # ``None`` by the getter rather than replaced with a plausible-looking zero.
+    #
+    # CLOUD-ONLY: no local Modbus registers are pinned for these named params.
+    # Reads have been observed on live hardware, but the write path has not been
+    # verified on hardware and must remain routed through the named cloud API.
+
+    async def set_inverter_smart_load_start_soc(
+        self,
+        inverter_sn: str,
+        percent: int,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Set the inverter smart-load START SOC threshold via cloud API.
+
+        This configures the SOC threshold used to start the inverter-level
+        smart load when the firmware is operating in SOC mode.
+
+        Warning:
+            The named cloud write path is unverified on hardware. No local
+            Modbus register is pinned for this parameter.
+
+        Args:
+            inverter_sn: Inverter serial number
+            percent: Battery SOC (%) to start the smart load (0-100)
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Raises:
+            ValueError: If percent is out of range
+
+        Example:
+            >>> await client.control.set_inverter_smart_load_start_soc(
+            ...     "1234567890", 69
+            ... )
+        """
+        if not 0 <= percent <= 100:
+            raise ValueError(f"percent must be 0-100, got {percent}")
+
+        return await self.write_parameter(
+            inverter_sn,
+            "_12K_HOLD_SMART_LOAD_START_SOC",
+            str(percent),
+            client_type=client_type,
+        )
+
+    async def set_inverter_smart_load_end_soc(
+        self,
+        inverter_sn: str,
+        percent: int,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Set the inverter smart-load END SOC threshold via cloud API.
+
+        This configures the SOC threshold used to stop the inverter-level
+        smart load when the firmware is operating in SOC mode.
+
+        Warning:
+            The named cloud write path is unverified on hardware. Unlike the
+            AC-couple END SOC, no 255 sentinel has been observed here.
+
+        Args:
+            inverter_sn: Inverter serial number
+            percent: Battery SOC (%) to stop the smart load (0-100)
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Raises:
+            ValueError: If percent is out of range
+
+        Example:
+            >>> await client.control.set_inverter_smart_load_end_soc(
+            ...     "1234567890", 60
+            ... )
+        """
+        if not 0 <= percent <= 100:
+            raise ValueError(f"percent must be 0-100, got {percent}")
+
+        return await self.write_parameter(
+            inverter_sn,
+            "_12K_HOLD_SMART_LOAD_END_SOC",
+            str(percent),
+            client_type=client_type,
+        )
+
+    async def set_inverter_smart_load_start_pv_power(
+        self,
+        inverter_sn: str,
+        kilowatts: float,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Set the inverter smart-load START PV power threshold via cloud API.
+
+        The named cloud parameter carries human-readable kilowatts with 0.1 kW
+        resolution. The 100 kW upper bound is a defensive sanity ceiling, not
+        a firmware-confirmed maximum.
+
+        Warning:
+            The named cloud write path is unverified on hardware. No local
+            Modbus register is pinned for this parameter.
+
+        Args:
+            inverter_sn: Inverter serial number
+            kilowatts: PV power (kW) required to start the smart load (0-100)
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Raises:
+            ValueError: If kilowatts is out of range or not a multiple of 0.1
+
+        Example:
+            >>> await client.control.set_inverter_smart_load_start_pv_power(
+            ...     "1234567890", 0.5
+            ... )
+        """
+        if not 0 <= kilowatts <= 100:
+            raise ValueError(f"kilowatts must be 0-100, got {kilowatts}")
+        _validate_tenth_resolution(kilowatts, "kilowatts")
+
+        return await self.write_parameter(
+            inverter_sn,
+            "_12K_HOLD_START_PV_POWER",
+            f"{kilowatts:g}",
+            client_type=client_type,
+        )
+
+    async def set_inverter_smart_load_start_volt(
+        self,
+        inverter_sn: str,
+        volts: float,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Set the inverter smart-load START voltage threshold via cloud API.
+
+        The named cloud parameter carries volts, not decivolts, with 0.1 V
+        resolution. The 100 V upper bound is a defensive sanity ceiling for
+        48 V-class battery banks, not a firmware-confirmed maximum.
+
+        Warning:
+            The named cloud write path is unverified on hardware. No local
+            Modbus register is pinned for this parameter.
+
+        Args:
+            inverter_sn: Inverter serial number
+            volts: Battery voltage (V) to start the smart load (0-100)
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Raises:
+            ValueError: If volts is out of range or not a multiple of 0.1
+
+        Example:
+            >>> await client.control.set_inverter_smart_load_start_volt(
+            ...     "1234567890", 54.0
+            ... )
+        """
+        if not 0 <= volts <= 100:
+            raise ValueError(f"volts must be 0-100, got {volts}")
+        _validate_tenth_resolution(volts, "volts")
+
+        return await self.write_parameter(
+            inverter_sn,
+            "_12K_HOLD_SMART_LOAD_START_VOLT",
+            f"{volts:g}",
+            client_type=client_type,
+        )
+
+    async def set_inverter_smart_load_end_volt(
+        self,
+        inverter_sn: str,
+        volts: float,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Set the inverter smart-load END voltage threshold via cloud API.
+
+        The named cloud parameter carries volts, not decivolts, with 0.1 V
+        resolution. The 100 V upper bound is a defensive sanity ceiling for
+        48 V-class battery banks, not a firmware-confirmed maximum.
+
+        Warning:
+            The named cloud write path is unverified on hardware. No local
+            Modbus register is pinned for this parameter.
+
+        Args:
+            inverter_sn: Inverter serial number
+            volts: Battery voltage (V) to stop the smart load (0-100)
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Raises:
+            ValueError: If volts is out of range or not a multiple of 0.1
+
+        Example:
+            >>> await client.control.set_inverter_smart_load_end_volt(
+            ...     "1234567890", 48.0
+            ... )
+        """
+        if not 0 <= volts <= 100:
+            raise ValueError(f"volts must be 0-100, got {volts}")
+        _validate_tenth_resolution(volts, "volts")
+
+        return await self.write_parameter(
+            inverter_sn,
+            "_12K_HOLD_SMART_LOAD_END_VOLT",
+            f"{volts:g}",
+            client_type=client_type,
+        )
+
+    async def set_inverter_smart_load_enabled(
+        self,
+        inverter_sn: str,
+        enabled: bool,
+        client_type: str = "WEB",
+    ) -> SuccessResponse:
+        """Enable or disable the inverter's smart-load function via cloud API.
+
+        Toggles ``FUNC_SMART_LOAD_ENABLE`` — the inverter-level Smart Load tab
+        function, distinct from the GridBOSS/MID per-port
+        ``FUNC_SMART_LOAD_EN_{n}`` functions (``enable_smart_load`` /
+        ``disable_smart_load``). These controls target different hardware and
+        must not be confused.
+
+        Cloud-routed: no local Modbus register is pinned for this function, and
+        the named cloud write path remains unverified on hardware.
+
+        Args:
+            inverter_sn: Inverter serial number
+            enabled: Enable or disable the inverter smart-load function
+            client_type: Client type (WEB/APP)
+
+        Returns:
+            SuccessResponse: Operation result
+
+        Example:
+            >>> await client.control.set_inverter_smart_load_enabled(
+            ...     "1234567890", True
+            ... )
+        """
+        return await self.control_function(
+            inverter_sn,
+            "FUNC_SMART_LOAD_ENABLE",
+            enabled,
+            client_type=client_type,
+        )
+
+    async def get_inverter_smart_load_limits(
+        self, inverter_sn: str
+    ) -> dict[str, int | float | bool | None]:
+        """Get inverter smart-load thresholds and enable state via cloud API.
+
+        Returns:
+            Dictionary with ``start_soc``, ``end_soc``, ``start_pv_power``,
+            ``start_volt``, ``end_volt`` and ``enabled``. SOC values are whole
+            percentages; PV power is in kilowatts; voltage values are in volts.
+            Any absent, non-numeric or otherwise unparseable field is ``None``.
+            This preserves the distinction from legal numeric zeroes and from
+            a real disabled (``False``) function state. Function params arrive
+            as JSON booleans; string ``"true"``/``"false"`` is also accepted
+            defensively.
+
+        Example:
+            >>> # Illustrative only — shape of the return value. The exact
+            >>> # numbers depend on the device; a set→get round-trip through
+            >>> # this cloud getter is unverified pending a live call on
+            >>> # smart-load-capable hardware.
+            >>> limits = await client.control.get_inverter_smart_load_limits(
+            ...     "1234567890"
+            ... )
+            >>> limits  # doctest: +SKIP
+            {'start_soc': 90, 'end_soc': 60, 'start_pv_power': 0.5,
+             'start_volt': 54.0, 'end_volt': 48.0, 'enabled': False}
+        """
+        params = await self.read_device_parameters_ranges(inverter_sn)
 
         return {
-            "start_soc": _parse("_12K_HOLD_AC_COUPLE_START_SOC"),
-            "end_soc": _parse("_12K_HOLD_AC_COUPLE_END_SOC"),
-            "enabled": _parse_enabled(params.get("FUNC_AC_COUPLING_FUNCTION")),
+            "start_soc": _parse_int_parameter(params.get("_12K_HOLD_SMART_LOAD_START_SOC")),
+            "end_soc": _parse_int_parameter(params.get("_12K_HOLD_SMART_LOAD_END_SOC")),
+            "start_pv_power": _parse_float_parameter(params.get("_12K_HOLD_START_PV_POWER")),
+            "start_volt": _parse_float_parameter(params.get("_12K_HOLD_SMART_LOAD_START_VOLT")),
+            "end_volt": _parse_float_parameter(params.get("_12K_HOLD_SMART_LOAD_END_VOLT")),
+            "enabled": _parse_enabled_parameter(params.get("FUNC_SMART_LOAD_ENABLE")),
         }
 
     # ============================================================================

--- a/tests/unit/endpoints/test_control_helpers.py
+++ b/tests/unit/endpoints/test_control_helpers.py
@@ -997,6 +997,318 @@ class TestInverterACCoupleSocLimitsCloud:
         assert limits["enabled"] is False
 
 
+class TestInverterSmartLoadLimitsCloud:
+    """Inverter-level smart-load cloud API methods (eg4_web_monitor#499)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "value", "hold_param", "value_text"),
+        [
+            (
+                "set_inverter_smart_load_start_soc",
+                69,
+                "_12K_HOLD_SMART_LOAD_START_SOC",
+                "69",
+            ),
+            (
+                "set_inverter_smart_load_end_soc",
+                60,
+                "_12K_HOLD_SMART_LOAD_END_SOC",
+                "60",
+            ),
+            (
+                "set_inverter_smart_load_start_pv_power",
+                0.5,
+                "_12K_HOLD_START_PV_POWER",
+                "0.5",
+            ),
+            (
+                "set_inverter_smart_load_start_volt",
+                54.0,
+                "_12K_HOLD_SMART_LOAD_START_VOLT",
+                "54",
+            ),
+            (
+                "set_inverter_smart_load_end_volt",
+                48.5,
+                "_12K_HOLD_SMART_LOAD_END_VOLT",
+                "48.5",
+            ),
+        ],
+    )
+    async def test_set_inverter_smart_load_parameter_wire_values(
+        self,
+        control: ControlEndpoints,
+        method_name: str,
+        value: int | float,
+        hold_param: str,
+        value_text: str,
+    ) -> None:
+        """Each setter sends the observed named param in portal units."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        result = await getattr(control, method_name)(SERIAL, value)
+
+        assert result.success is True
+        control.write_parameter.assert_called_once_with(
+            SERIAL, hold_param, value_text, client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "set_inverter_smart_load_start_soc",
+            "set_inverter_smart_load_end_soc",
+        ],
+    )
+    async def test_set_inverter_smart_load_soc_boundaries(
+        self, control: ControlEndpoints, method_name: str
+    ) -> None:
+        """Both SOC endpoints accept the documented 0 and 100 boundaries."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        assert (await getattr(control, method_name)(SERIAL, 0)).success is True
+        assert (await getattr(control, method_name)(SERIAL, 100)).success is True
+        assert [call.args[2] for call in control.write_parameter.await_args_list] == [
+            "0",
+            "100",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "set_inverter_smart_load_start_soc",
+            "set_inverter_smart_load_end_soc",
+        ],
+    )
+    @pytest.mark.parametrize("bad", [-1, 101, 255])
+    async def test_set_inverter_smart_load_soc_rejects_out_of_range(
+        self, control: ControlEndpoints, method_name: str, bad: int
+    ) -> None:
+        """Smart-load SOC has no 255 sentinel and rejects outside 0-100."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        with pytest.raises(ValueError, match="percent must be 0-100"):
+            await getattr(control, method_name)(SERIAL, bad)
+
+        control.write_parameter.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "set_inverter_smart_load_start_pv_power",
+            "set_inverter_smart_load_start_volt",
+            "set_inverter_smart_load_end_volt",
+        ],
+    )
+    async def test_set_inverter_smart_load_float_boundaries(
+        self, control: ControlEndpoints, method_name: str
+    ) -> None:
+        """PV power and voltage setters accept and compactly format 0 and 100."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        assert (await getattr(control, method_name)(SERIAL, 0.0)).success is True
+        assert (await getattr(control, method_name)(SERIAL, 100.0)).success is True
+        assert [call.args[2] for call in control.write_parameter.await_args_list] == [
+            "0",
+            "100",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "set_inverter_smart_load_start_pv_power",
+            "set_inverter_smart_load_start_volt",
+            "set_inverter_smart_load_end_volt",
+        ],
+    )
+    @pytest.mark.parametrize("bad", [-0.1, 100.1])
+    async def test_set_inverter_smart_load_float_rejects_out_of_range(
+        self, control: ControlEndpoints, method_name: str, bad: float
+    ) -> None:
+        """PV power and voltage writes reject values outside 0-100."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        with pytest.raises(ValueError, match="must be 0-100"):
+            await getattr(control, method_name)(SERIAL, bad)
+
+        control.write_parameter.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "set_inverter_smart_load_start_pv_power",
+            "set_inverter_smart_load_start_volt",
+            "set_inverter_smart_load_end_volt",
+        ],
+    )
+    async def test_set_inverter_smart_load_float_rejects_sub_tenth_step(
+        self, control: ControlEndpoints, method_name: str
+    ) -> None:
+        """The observed 0.1 resolution rejects a value between valid steps."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        with pytest.raises(ValueError, match="multiple of 0.1"):
+            await getattr(control, method_name)(SERIAL, 54.25)
+
+        control.write_parameter.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "set_inverter_smart_load_start_pv_power",
+            "set_inverter_smart_load_start_volt",
+            "set_inverter_smart_load_end_volt",
+        ],
+    )
+    async def test_set_inverter_smart_load_float_accepts_roundoff(
+        self, control: ControlEndpoints, method_name: str
+    ) -> None:
+        """Normal binary float noise around a tenth does not reject a write."""
+        control.write_parameter = AsyncMock(return_value=SuccessResponse(success=True))
+
+        result = await getattr(control, method_name)(SERIAL, 0.1 + 0.2)
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_set_inverter_smart_load_enabled(self, control: ControlEndpoints) -> None:
+        """Enable state uses the inverter-level FUNC_SMART_LOAD_ENABLE param."""
+        control.control_function = AsyncMock(return_value=SuccessResponse(success=True))
+
+        assert (await control.set_inverter_smart_load_enabled(SERIAL, True)).success is True
+        control.control_function.assert_called_with(
+            SERIAL, "FUNC_SMART_LOAD_ENABLE", True, client_type="WEB"
+        )
+
+        assert (await control.set_inverter_smart_load_enabled(SERIAL, False)).success is True
+        control.control_function.assert_called_with(
+            SERIAL, "FUNC_SMART_LOAD_ENABLE", False, client_type="WEB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_smart_load_limits_observed_payload(
+        self, control: ControlEndpoints
+    ) -> None:
+        """The getter parses the six values observed on two inverter families."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "FUNC_SMART_LOAD_ENABLE": False,
+                "_12K_HOLD_SMART_LOAD_START_SOC": "90",
+                "_12K_HOLD_SMART_LOAD_END_SOC": "60",
+                "_12K_HOLD_START_PV_POWER": "0.5",
+                "_12K_HOLD_SMART_LOAD_START_VOLT": "54",
+                "_12K_HOLD_SMART_LOAD_END_VOLT": "48",
+            }
+        )
+
+        limits = await control.get_inverter_smart_load_limits(SERIAL)
+
+        assert limits == {
+            "start_soc": 90,
+            "end_soc": 60,
+            "start_pv_power": 0.5,
+            "start_volt": 54.0,
+            "end_volt": 48.0,
+            "enabled": False,
+        }
+        control.read_device_parameters_ranges.assert_called_once_with(SERIAL)
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_smart_load_limits_gridboss_shape(
+        self, control: ControlEndpoints
+    ) -> None:
+        """GridBOSS has the function key but none of the inverter HOLD keys."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={"FUNC_SMART_LOAD_ENABLE": True}
+        )
+
+        limits = await control.get_inverter_smart_load_limits(SERIAL)
+
+        assert limits == {
+            "start_soc": None,
+            "end_soc": None,
+            "start_pv_power": None,
+            "start_volt": None,
+            "end_volt": None,
+            "enabled": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_smart_load_limits_non_numeric(
+        self, control: ControlEndpoints
+    ) -> None:
+        """Every unparseable value becomes None rather than a fake zero/off."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "FUNC_SMART_LOAD_ENABLE": "unknown",
+                "_12K_HOLD_SMART_LOAD_START_SOC": "n/a",
+                "_12K_HOLD_SMART_LOAD_END_SOC": object(),
+                "_12K_HOLD_START_PV_POWER": "not-a-number",
+                "_12K_HOLD_SMART_LOAD_START_VOLT": object(),
+                "_12K_HOLD_SMART_LOAD_END_VOLT": None,
+            }
+        )
+
+        limits = await control.get_inverter_smart_load_limits(SERIAL)
+
+        assert limits == {
+            "start_soc": None,
+            "end_soc": None,
+            "start_pv_power": None,
+            "start_volt": None,
+            "end_volt": None,
+            "enabled": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_inverter_smart_load_limits_preserves_zero_values(
+        self, control: ControlEndpoints
+    ) -> None:
+        """Legal zero thresholds and a real False remain distinct from absence."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={
+                "FUNC_SMART_LOAD_ENABLE": False,
+                "_12K_HOLD_SMART_LOAD_START_SOC": "0",
+                "_12K_HOLD_SMART_LOAD_END_SOC": "0",
+                "_12K_HOLD_START_PV_POWER": "0",
+                "_12K_HOLD_SMART_LOAD_START_VOLT": "0",
+                "_12K_HOLD_SMART_LOAD_END_VOLT": "0",
+            }
+        )
+
+        limits = await control.get_inverter_smart_load_limits(SERIAL)
+
+        assert limits == {
+            "start_soc": 0,
+            "end_soc": 0,
+            "start_pv_power": 0.0,
+            "start_volt": 0.0,
+            "end_volt": 0.0,
+            "enabled": False,
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("raw", "expected"), [("TRUE", True), ("false", False)])
+    async def test_get_inverter_smart_load_limits_enabled_string(
+        self, control: ControlEndpoints, raw: str, expected: bool
+    ) -> None:
+        """Defensive parsing accepts case-insensitive boolean strings."""
+        control.read_device_parameters_ranges = AsyncMock(
+            return_value={"FUNC_SMART_LOAD_ENABLE": raw}
+        )
+
+        limits = await control.get_inverter_smart_load_limits(SERIAL)
+
+        assert limits["enabled"] is expected
+
+
 class TestACChargeVoltageLimitsCloud:
     """Test AC charge voltage limit cloud API methods."""
 


### PR DESCRIPTION
## Summary

- Add inverter-level smart-load cloud setters for enable state, SOC thresholds, PV start power, and voltage-mode thresholds.
- Add a tolerant cloud getter that preserves absent/unparseable fields as `None`, including the GridBOSS capability-gating shape.
- Share integer and enable-state parsing with the existing inverter AC-couple getter without changing its observable behavior.

## Named cloud parameters

- `FUNC_SMART_LOAD_ENABLE`
- `_12K_HOLD_SMART_LOAD_START_SOC`
- `_12K_HOLD_SMART_LOAD_END_SOC`
- `_12K_HOLD_START_PV_POWER`
- `_12K_HOLD_SMART_LOAD_START_VOLT`
- `_12K_HOLD_SMART_LOAD_END_VOLT`

## Evidence and safety

Read-only parameter-range probes found all six keys on both an 18kPV and a FlexBOSS21 in the 127+127 range. The GridBOSS exposed `FUNC_SMART_LOAD_ENABLE` but omitted all five inverter threshold keys, so the getter returns `None` for those missing values rather than fabricated zeroes.

The named cloud write path is unverified on hardware. No device writes were performed while implementing or validating this change, and no local Modbus/raw-register mappings were added.

## Validation

- `uv sync --extra dev`
- `uv run pytest -x -q` — 2905 passed, 4 skipped
- `uv run ruff check --fix . && uv run ruff format .`
- `uv run mypy --strict src/` — 94 source files clean

This unblocks `eg4_web_monitor#499` by providing the named cloud controls consumed by the integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
