### PR TITLE
fix: FUNC_TAKE_LOAD_TOGETHER is register 110 bit 10, not bit 5 (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`FUNC_TAKE_LOAD_TOGETHER` moved from register 110 bit 5 to bit 10**
+  (hardware toggle-verified, [#242](https://github.com/joyfulhouse/pylxpweb/issues/242)).
+  EG4's cloud decode names this flag while ant0nkr/lxp_modbus put a
+  CT-sample-ratio field at bits 5-6 and TakeLoadTogether at bit 10. The only
+  live read available had bits 5 AND 10 both set (raw `0x0420`), so it could
+  not separate the two layouts, and the flag was left decode-only with LOCAL
+  writes blocked. A 2026-08-01 capture on an 18kPV settles it: driving EG4's
+  own cloud `functionControl` **by name** — the server picks the bit, we only
+  read the raw register — moved raw `1056 -> 32` on False and back to `1056`
+  on True. That is a single bit-10 delta (`0x0400`), byte-perfect on restore,
+  with bit 5 unmoved throughout. Bit 5 becomes a `FUNC_110_BIT5` placeholder
+  (decode-only) rather than taking lxp_modbus's CT-ratio name, because a
+  multi-bit sample-ratio field must never be exposed as a writable bool.
+  The two sources were never really in conflict: EG4's decode reports the
+  NAME, and its server resolves that name to bit 10 — the same way #476's
+  bit-14 green-mode result vindicated the lxp_modbus lineage layout.
+- **`FUNC_TAKE_LOAD_TOGETHER` is writable again over LOCAL transports**: with
+  the position pinned it no longer needs the disputed-write guard, so
+  `DISPUTED_WRITE_BLOCKED_PARAMS` is now empty. The guard mechanism and its
+  `write_named_parameters` check stay in place — register 110 alone has
+  produced two of these disputes — and a test pins both that the set is empty
+  and that it would still refuse a write if repopulated.
+
 ## [0.9.39b5] - 2026-07-27
 
 This section accumulates the whole 0.9.39 beta line: b1 through b4 were tagged

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -584,15 +584,17 @@ WEB_PARAM_TO_HOLD_REGISTER = {
 # (eg4_web_monitor #476). Both families ever hardware-toggle-tested (18kPV
 # 2026-07-21, 12000XP/SNA PR #220) match the ant0nkr/lxp_modbus
 # H_FUNCTION_ENABLE_3 lineage layout in every position this project has
-# hardware evidence for (bits 7, 14, 15), while the historic 18kPV-specific
-# upper-bit table matched none of them — so the hybrid and EG4_OFFGRID
-# tables no longer diverge. Be precise about what that evidence is, since
-# mistaking "the names lined up" for "we toggled it" is what produced #476
-# in the first place: bits 14 and 15 are toggle-proven (18kPV green,
-# 12000XP ECO), while bit 7 rests on the SNA cloud decode plus a constant
-# raw 0x0080 — strong, but not a toggle. That agreement does NOT extend to
-# every bit: at bit 5 the EG4 cloud decode and lxp_modbus genuinely
-# disagree (see below), and no toggle test has separated them.
+# hardware evidence for (bits 7, 10, 14, 15), while the historic
+# 18kPV-specific upper-bit table matched none of them — so the hybrid and
+# EG4_OFFGRID tables no longer diverge. Be precise about what that evidence
+# is, since mistaking "the names lined up" for "we toggled it" is what
+# produced #476 in the first place: bits 10, 14 and 15 are toggle-proven
+# (18kPV take-load-together, 18kPV green, 12000XP ECO), while bit 7 rests on
+# the SNA cloud decode plus a constant raw 0x0080 — strong, but not a
+# toggle. Every position that once looked like a genuine source conflict has
+# resolved in the lineage layout's favour once someone toggled it: bit 8
+# (#476) and bit 5 (#242) were both our decode being wrong about the
+# position while EG4 was only ever reporting the name.
 # Displaced/unproven slots are FUNC_110_BITn placeholders (same convention as reg 179/233 unknowns):
 # an honest gap beats an unverified decode served as truth — a local write
 # through a wrong slot flips an unrelated config bit while reporting

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -602,24 +602,30 @@ WEB_PARAM_TO_HOLD_REGISTER = {
 # Evidence per bit:
 #   0-4:   all sources agree (18kPV cloud decode, SNA cloud decode,
 #          lxp_modbus).
-#   5:     FUNC_TAKE_LOAD_TOGETHER — live 18kPV read 2026-07-21: raw bit 5
-#          set while the EG4 cloud decode reports TAKE_LOAD_TOGETHER as the
-#          only set FUNC_ (lxp_modbus puts a CT-ratio bit here and
-#          TakeLoadTogether at bit 10; the EG4 firmware's own decode wins).
-#          UNRESOLVED: that read had bits 5 and 10 both set (raw 0x0420),
-#          so it cannot separate the two candidate layouts — only a toggle
-#          test can. Carried over unchanged from before #476; nothing in
-#          this library or the EG4 integration writes this key.
-#   6:     unknown (old table's buzzer slot; buzzer is pinned at 7).
+#   5-6:   unknown (lxp_modbus: CT-sample-ratio field). Bit 5 was the
+#          FUNC_TAKE_LOAD_TOGETHER slot — DISPROVEN by the 2026-08-01 18kPV
+#          toggle test below: bit 5 stayed SET across a take-load-together
+#          off/on cycle, so whatever it is, it is not that flag. It keeps a
+#          placeholder rather than lxp_modbus's CT-ratio name because a
+#          multi-bit sample-ratio field must never be exposed as a writable
+#          bool, and its low bit has had no independent test here. Bit 6 was
+#          the old table's buzzer slot; buzzer is pinned at 7.
 #   7:     FUNC_BUZZER_EN — SNA cloud decode + constant raw 0x0080
 #          (PR #220); lxp_modbus agrees lineage-wide.
 #   8-9:   unknown (lxp_modbus: PVCT sample type field). Bit 8 was the old
 #          FUNC_GREEN_EN slot — DISPROVEN by the 2026-07-21 18kPV toggle
 #          test (eg4_web_monitor #476/#194).
-#   10-13: unknown (old working-mode/PVCT/CT slots; live 18kPV read
-#          2026-07-21 shows raw bit 10 set while the cloud decodes
-#          BIT_WORKING_MODE=0 and BIT_CT_SAMPLE_RATIO=1 — those names were
-#          misplaced).
+#   10:    FUNC_TAKE_LOAD_TOGETHER — hardware toggle-verified 2026-08-01 on
+#          an 18kPV (45XXXXXX18, pylxpweb #242). Driving EG4's OWN cloud
+#          functionControl by NAME (the server picks the bit, we only read
+#          raw) moved raw 1056 -> 32 on False and back to 1056 on True: a
+#          single bit-10 delta (0x0400), byte-perfect on restore, with bit 5
+#          untouched throughout. This is the capture the issue asked for; it
+#          settles the EG4-decode-vs-lxp_modbus dispute in lxp_modbus's
+#          favour, the same way #476's bit-14 result did. The two sources
+#          never actually conflicted about behaviour — EG4's decode reports
+#          the NAME and its server resolves that name to bit 10.
+#   11-13: unknown (old PVCT/CT sample slots).
 #   14:    FUNC_GREEN_EN — hardware toggle-verified 2026-07-21 on an 18kPV
 #          (45XXXXXX18): cloud green-mode enable flips raw 1056 <-> 17440, a
 #          single bit-14 delta, with the EG4 cloud decode changing in
@@ -632,12 +638,12 @@ REGISTER_110_PARAM_KEYS: list[str] = [
     "FUNC_MICRO_GRID_EN",  # Bit 2
     "FUNC_BAT_SHARED",  # Bit 3
     "FUNC_CHARGE_LAST",  # Bit 4
-    "FUNC_TAKE_LOAD_TOGETHER",  # Bit 5
+    "FUNC_110_BIT5",  # Bit 5: unknown (old take-load-together slot — disproven, #242)
     "FUNC_110_BIT6",  # Bit 6: unknown
     "FUNC_BUZZER_EN",  # Bit 7 (hardware-verified, PR #220)
     "FUNC_110_BIT8",  # Bit 8: unknown (old green slot — disproven, #476)
     "FUNC_110_BIT9",  # Bit 9: unknown (old ECO slot)
-    "FUNC_110_BIT10",  # Bit 10: unknown (old working-mode slot — contradicted)
+    "FUNC_TAKE_LOAD_TOGETHER",  # Bit 10 (hardware toggle-verified 2026-08-01, #242)
     "FUNC_110_BIT11",  # Bit 11: unknown
     "FUNC_110_BIT12",  # Bit 12: unknown
     "FUNC_110_BIT13",  # Bit 13: unknown
@@ -970,6 +976,14 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
 # green pinned, the "green mode is cloud-only on EG4_OFFGRID" restriction
 # (eg4_web_monitor #197 follow-ups) is lifted: local reads and writes use
 # bit 14 on every family.
+#
+# Because this is an ALIAS and not a copy, the 2026-08-01 take-load-together
+# result (bit 5 -> bit 10, #242) lands on EG4_OFFGRID too. That is lineage
+# inference, not per-family proof: the toggle ran on an 18kPV (EG4_HYBRID).
+# It follows the #476 precedent — that result also shipped lineage-wide on
+# the strength of the shared lxp_modbus H_FUNCTION_ENABLE_3 layout, which
+# every hardware test on both families has matched. A per-family reg-110
+# contract test pins the shape so a future divergence has to be deliberate.
 OFFGRID_REGISTER_110_PARAM_KEYS: list[str] = REGISTER_110_PARAM_KEYS
 
 
@@ -988,13 +1002,20 @@ OFFGRID_REGISTER_110_PARAM_KEYS: list[str] = REGISTER_110_PARAM_KEYS
 # extending this to ControlEndpoints.control_function(): that would remove a
 # working capability to guard against a hazard the cloud path does not have.
 #
-#   FUNC_TAKE_LOAD_TOGETHER — EG4's own cloud decode puts it at register 110
-#   bit 5; ant0nkr/lxp_modbus puts a CT-sample-ratio field at bits 5-6 and
-#   TakeLoadTogether at bit 10. The live 18kPV read that would settle it had
-#   bits 5 AND 10 both set (raw 0x0420), so it separates nothing. Reads keep
-#   EG4's name because EG4's decode is first-party evidence; writes wait for
-#   a toggle capture. See pylxpweb #242.
-DISPUTED_WRITE_BLOCKED_PARAMS: frozenset[str] = frozenset({"FUNC_TAKE_LOAD_TOGETHER"})
+# Currently EMPTY, and that is the intended steady state — a name belongs here
+# only while a dispute is live. The mechanism and its guard in
+# transports/protocol.py stay in place because this situation recurs: reg 110
+# alone has produced two of them.
+#
+# Resolved entries, kept as precedent for how one leaves this set:
+#   FUNC_TAKE_LOAD_TOGETHER — listed while EG4's cloud decode was read as
+#   putting it at register 110 bit 5 and ant0nkr/lxp_modbus put a
+#   CT-sample-ratio field at 5-6 with TakeLoadTogether at bit 10. Settled
+#   2026-08-01 by the toggle capture the issue asked for (pylxpweb #242): the
+#   flag is at bit 10, bit 5 never moved, and it is now writable locally. The
+#   sources were never really in conflict — EG4's decode reports the NAME, and
+#   its server resolves that name to bit 10.
+DISPUTED_WRITE_BLOCKED_PARAMS: frozenset[str] = frozenset()
 
 
 def _copy_register_mapping(mapping: dict[int, list[str]]) -> dict[int, list[str]]:

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -964,22 +964,6 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         category=HoldingCategory.FUNCTION,
         description="Charge last mode — charge battery after loads satisfied.",
     ),
-    HoldingRegisterDefinition(
-        address=110,
-        bit_position=5,
-        canonical_name="take_load_together",
-        # DISPUTED POSITION, not verified: EG4's cloud decode puts this at
-        # bit 5, ant0nkr/lxp_modbus puts a CT-ratio field at 5-6 and
-        # TakeLoadTogether at bit 10, and the one live read that could
-        # separate them had both bits set (raw 0x0420). The name is EG4's,
-        # so reads keep it; LOCAL writes are refused via
-        # DISPUTED_WRITE_BLOCKED_PARAMS until a toggle capture settles it.
-        # The old "# verified" here meant the NAME matched the cloud, never
-        # that the bit was toggle-tested — the exact conflation behind #476.
-        api_param_key="FUNC_TAKE_LOAD_TOGETHER",
-        category=HoldingCategory.FUNCTION,
-        description="Take load together mode (parallel load sharing).",
-    ),
     # Register 110 upper-bit layout rewritten 2026-07-21 (eg4_web_monitor
     # #476): the historic 18kPV-derived positions (buzzer 6, go-to-offgrid
     # 7, green 8, ECO 9, working-mode 10, PVCT/CT sample 11-13) were an
@@ -993,6 +977,18 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         api_param_key="FUNC_BUZZER_EN",  # hardware-verified (PR #220 + lxp_modbus)
         category=HoldingCategory.FUNCTION,
         description="Audible buzzer enable for alarms.",
+    ),
+    HoldingRegisterDefinition(
+        address=110,
+        bit_position=10,
+        canonical_name="take_load_together",
+        api_param_key="FUNC_TAKE_LOAD_TOGETHER",  # hardware toggle-verified 2026-08-01 (#242)
+        category=HoldingCategory.FUNCTION,
+        description="Take load together mode (parallel load sharing). Bit 10, "
+        "toggle-verified on 18kPV via EG4's own cloud functionControl: raw "
+        "1056 <-> 32, a single bit-10 delta, bit 5 unmoved (pylxpweb #242). "
+        "The pre-2026-08-01 bit-5 mapping was wrong and would have written "
+        "into the CT-sample-ratio region.",
     ),
     HoldingRegisterDefinition(
         address=110,

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -987,8 +987,10 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         description="Take load together mode (parallel load sharing). Bit 10, "
         "toggle-verified on 18kPV via EG4's own cloud functionControl: raw "
         "1056 <-> 32, a single bit-10 delta, bit 5 unmoved (pylxpweb #242). "
-        "The pre-2026-08-01 bit-5 mapping was wrong and would have written "
-        "into the CT-sample-ratio region.",
+        "The pre-2026-08-01 bit-5 mapping was wrong: a local write through it "
+        "would have flipped bit 5, which the capture shows is some other "
+        "setting (lxp_modbus assigns it to a CT-sample-ratio field, "
+        "unconfirmed here).",
     ),
     HoldingRegisterDefinition(
         address=110,

--- a/tests/unit/transports/test_named_parameters.py
+++ b/tests/unit/transports/test_named_parameters.py
@@ -833,6 +833,45 @@ class TestRegister110UnifiedLayout:
             ):
                 assert removed not in layout
 
+    def test_register_110_canonical_registry_agrees_with_decode_table(self) -> None:
+        """The canonical holding registry and the decode table must not drift.
+
+        Register 110's bit positions live in two places: the transport decode
+        list (REGISTER_110_PARAM_KEYS, indexed by bit) and the canonical
+        HoldingRegisterDefinition rows. Nothing forces them to agree, so a
+        position fix applied to only one — exactly what #242 and #476 each
+        had to correct — would leave the two silently contradicting each
+        other, with reads and writes disagreeing about the same flag.
+        """
+        from pylxpweb.constants.registers import get_register_to_param_mapping
+        from pylxpweb.registers.inverter_holding import BY_ADDRESS
+
+        layout = get_register_to_param_mapping()[110]
+
+        definitions = [
+            definition
+            for definition in BY_ADDRESS.get(110, ())
+            if definition.bit_position is not None
+        ]
+        assert definitions, "register 110 must have canonical bit definitions"
+
+        for definition in definitions:
+            assert definition.api_param_key is not None
+            assert layout[definition.bit_position] == definition.api_param_key, (
+                f"{definition.api_param_key} is bit {definition.bit_position} in the "
+                f"canonical registry but bit {layout.index(definition.api_param_key)} "
+                "in the decode table"
+            )
+
+        # The #242 result specifically, pinned by name rather than by scan.
+        take_load_together = next(
+            definition
+            for definition in definitions
+            if definition.api_param_key == "FUNC_TAKE_LOAD_TOGETHER"
+        )
+        assert take_load_together.address == 110
+        assert take_load_together.bit_position == 10
+
     def test_register_110_agreed_low_bits_unchanged(self) -> None:
         """Bits 0-4 agree across all sources and stay identical.
 
@@ -1055,7 +1094,8 @@ class TestRegister110UnifiedLayout:
         This inverts the old disputed-write guard: the toggle capture proved
         the position, so the write is allowed — and it must go to bit 10 with
         read-modify-write leaving every sibling bit alone, including bit 5,
-        which the capture showed is a different (CT-ratio) field.
+        which the capture showed is some other setting (lxp_modbus assigns
+        it to a CT-sample-ratio field; unconfirmed here).
         """
         # The captured baseline: bits 5 and 10 set.
         offgrid_transport.read_parameters = AsyncMock(return_value={110: 0x0420})
@@ -1067,7 +1107,7 @@ class TestRegister110UnifiedLayout:
         # server cleared this flag: 0x0420 -> 0x0020.
         offgrid_transport.write_parameters.assert_called_once_with({110: 0x0020})
         written = offgrid_transport.write_parameters.call_args[0][0][110]
-        assert written & (1 << 5), "bit 5 (CT-ratio field) must survive the write"
+        assert written & (1 << 5), "bit 5 (a different, unidentified setting) must survive"
 
     @pytest.mark.asyncio
     async def test_disputed_write_guard_has_no_entries_but_still_works(

--- a/tests/unit/transports/test_named_parameters.py
+++ b/tests/unit/transports/test_named_parameters.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -802,7 +802,7 @@ class TestRegister110UnifiedLayout:
     # ------------------------------------------------------------------
 
     def test_register_110_layout(self) -> None:
-        """Every family maps green to 14, ECO to 15, buzzer to 7."""
+        """Every family maps green to 14, ECO to 15, buzzer to 7, TLT to 10."""
         from pylxpweb.constants.registers import get_register_to_param_mapping
 
         for family in (None, "EG4_HYBRID", "EG4_OFFGRID", "LXP", "UNKNOWN"):
@@ -812,12 +812,15 @@ class TestRegister110UnifiedLayout:
             assert layout.index("FUNC_GREEN_EN") == 14
             assert layout.index("FUNC_BATTERY_ECO_EN") == 15
             assert layout.index("FUNC_BUZZER_EN") == 7
+            # Toggle-verified on an 18kPV and applied lineage-wide, same as
+            # green at 14 — a per-family divergence has to be deliberate (#242).
+            assert layout.index("FUNC_TAKE_LOAD_TOGETHER") == 10
             # Displaced/unproven 18kPV names are placeholders, not silent
             # reuse — a wrong slot writes an unrelated config bit (#476).
+            assert layout[5] == "FUNC_110_BIT5"  # old TLT slot, disproven (#242)
             assert layout[6] == "FUNC_110_BIT6"
             assert layout[8] == "FUNC_110_BIT8"  # old green slot, disproven
             assert layout[9] == "FUNC_110_BIT9"  # old ECO slot
-            assert layout[10] == "FUNC_110_BIT10"  # old working-mode slot
             assert layout[11] == "FUNC_110_BIT11"
             assert layout[12] == "FUNC_110_BIT12"
             assert layout[13] == "FUNC_110_BIT13"
@@ -831,17 +834,21 @@ class TestRegister110UnifiedLayout:
                 assert removed not in layout
 
     def test_register_110_agreed_low_bits_unchanged(self) -> None:
-        """Bits 0-5 agree across all sources and stay identical."""
+        """Bits 0-4 agree across all sources and stay identical.
+
+        Bit 5 used to be in this set on the strength of EG4's decode naming
+        TAKE_LOAD_TOGETHER; the #242 toggle capture moved that flag to bit 10
+        and left 5 unidentified, so the agreed run now stops at 4.
+        """
         from pylxpweb.constants.registers import get_register_to_param_mapping
 
         layout = get_register_to_param_mapping()[110]
-        assert layout[:6] == [
+        assert layout[:5] == [
             "FUNC_PV_GRID_OFF_EN",
             "FUNC_RUN_WITHOUT_GRID",
             "FUNC_MICRO_GRID_EN",
             "FUNC_BAT_SHARED",
             "FUNC_CHARGE_LAST",
-            "FUNC_TAKE_LOAD_TOGETHER",
         ]
 
     def test_offgrid_alias_is_the_shared_layout(self) -> None:
@@ -1040,26 +1047,80 @@ class TestRegister110UnifiedLayout:
         assert not written & (1 << 8), "bit 8 (old green slot) must stay untouched"
 
     @pytest.mark.asyncio
-    async def test_disputed_bit_decodes_but_is_not_writable(
+    async def test_take_load_together_writes_bit_10(
         self, offgrid_transport: ModbusTransport
     ) -> None:
-        """A disputed bit still reads, but refuses to be written (#242).
+        """Once settled, the flag is writable and lands on bit 10 (#242).
 
-        FUNC_TAKE_LOAD_TOGETHER keeps EG4's own name because EG4's cloud
-        decode is first-party evidence for bit 5. lxp_modbus puts it at
-        bit 10 instead, and the one live read that could separate them had
-        both bits set. Writing the wrong one is ACKed and moves some other
-        setting, so writes wait for a toggle capture while reads carry on.
+        This inverts the old disputed-write guard: the toggle capture proved
+        the position, so the write is allowed — and it must go to bit 10 with
+        read-modify-write leaving every sibling bit alone, including bit 5,
+        which the capture showed is a different (CT-ratio) field.
         """
-        offgrid_transport.read_parameters = AsyncMock(return_value={110: 0x0020})
+        # The captured baseline: bits 5 and 10 set.
+        offgrid_transport.read_parameters = AsyncMock(return_value={110: 0x0420})
 
-        decoded = await offgrid_transport.read_named_parameters(110, 1)
-        assert decoded["FUNC_TAKE_LOAD_TOGETHER"] is True
+        result = await offgrid_transport.write_named_parameters({"FUNC_TAKE_LOAD_TOGETHER": False})
 
-        with pytest.raises(ValueError, match="disagree"):
+        assert result is True
+        # Exactly the raw value the live capture produced when EG4's own
+        # server cleared this flag: 0x0420 -> 0x0020.
+        offgrid_transport.write_parameters.assert_called_once_with({110: 0x0020})
+        written = offgrid_transport.write_parameters.call_args[0][0][110]
+        assert written & (1 << 5), "bit 5 (CT-ratio field) must survive the write"
+
+    @pytest.mark.asyncio
+    async def test_disputed_write_guard_has_no_entries_but_still_works(
+        self, offgrid_transport: ModbusTransport
+    ) -> None:
+        """The guard mechanism outlives the dispute that motivated it.
+
+        DISPUTED_WRITE_BLOCKED_PARAMS is empty now that #242 is settled, but
+        register 110 alone has produced two disputes, so the machinery stays.
+        Pin that it is empty *and* that it would still bite, so a future
+        "unused, delete it" cleanup has to argue with a failing test.
+        """
+        from pylxpweb.constants.registers import DISPUTED_WRITE_BLOCKED_PARAMS
+
+        assert frozenset() == DISPUTED_WRITE_BLOCKED_PARAMS
+
+        offgrid_transport.read_parameters = AsyncMock(return_value={110: 0x0420})
+        with (
+            patch(
+                "pylxpweb.constants.registers.DISPUTED_WRITE_BLOCKED_PARAMS",
+                frozenset({"FUNC_TAKE_LOAD_TOGETHER"}),
+            ),
+            pytest.raises(ValueError, match="disagree"),
+        ):
             await offgrid_transport.write_named_parameters({"FUNC_TAKE_LOAD_TOGETHER": False})
 
         offgrid_transport.write_parameters.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (0x0420, True),  # captured baseline: flag on (bits 5 + 10 set)
+            (0x0020, False),  # captured after EG4 cleared it: only bit 5 left
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_take_load_together_capture_evidence(
+        self, hybrid_transport: ModbusTransport, raw: int, expected: bool
+    ) -> None:
+        """Pin the two raw values from the 2026-08-01 18kPV capture (#242).
+
+        These are the actual register reads either side of a take-load-together
+        toggle driven through EG4's own cloud functionControl. Under the old
+        bit-5 mapping the second value decoded True — i.e. the decode could not
+        see the change EG4 had just made.
+        """
+        hybrid_transport.read_parameters = AsyncMock(return_value={110: raw})
+
+        result = await hybrid_transport.read_named_parameters(110, 1)
+
+        assert result["FUNC_TAKE_LOAD_TOGETHER"] is expected
+        # Bit 5 is set in BOTH captures, so it cannot be this flag.
+        assert result["FUNC_110_BIT5"] is True
 
     @pytest.mark.asyncio
     async def test_placeholder_bits_are_not_writable(

--- a/tests/unit/transports/test_named_parameters.py
+++ b/tests/unit/transports/test_named_parameters.py
@@ -11,6 +11,14 @@ from pylxpweb.transports.http import HTTPTransport
 from pylxpweb.transports.hybrid import HybridTransport
 from pylxpweb.transports.modbus import ModbusTransport
 
+# The two register-110 values the 18kPV reported either side of a
+# take-load-together toggle driven through EG4's OWN cloud functionControl
+# (2026-08-01, serial 45XXXXXX18, pylxpweb #242). Their XOR is exactly bit 10,
+# which is the entire evidence for the mapping this module pins. Defined once
+# so a fixture cannot be corrupted in one test and stay consistent elsewhere.
+CAPTURE_BASELINE_RAW = 0x0420  # bits 5 + 10 — flag ON
+CAPTURE_TOGGLED_OFF_RAW = 0x0020  # bit 5 only — flag OFF
+
 
 class TestReadNamedParametersModbus:
     """Tests for Modbus transport read_named_parameters."""
@@ -1098,14 +1106,14 @@ class TestRegister110UnifiedLayout:
         it to a CT-sample-ratio field; unconfirmed here).
         """
         # The captured baseline: bits 5 and 10 set.
-        offgrid_transport.read_parameters = AsyncMock(return_value={110: 0x0420})
+        offgrid_transport.read_parameters = AsyncMock(return_value={110: CAPTURE_BASELINE_RAW})
 
         result = await offgrid_transport.write_named_parameters({"FUNC_TAKE_LOAD_TOGETHER": False})
 
         assert result is True
         # Exactly the raw value the live capture produced when EG4's own
         # server cleared this flag: 0x0420 -> 0x0020.
-        offgrid_transport.write_parameters.assert_called_once_with({110: 0x0020})
+        offgrid_transport.write_parameters.assert_called_once_with({110: CAPTURE_TOGGLED_OFF_RAW})
         written = offgrid_transport.write_parameters.call_args[0][0][110]
         assert written & (1 << 5), "bit 5 (a different, unidentified setting) must survive"
 
@@ -1124,7 +1132,7 @@ class TestRegister110UnifiedLayout:
 
         assert frozenset() == DISPUTED_WRITE_BLOCKED_PARAMS
 
-        offgrid_transport.read_parameters = AsyncMock(return_value={110: 0x0420})
+        offgrid_transport.read_parameters = AsyncMock(return_value={110: CAPTURE_BASELINE_RAW})
         with (
             patch(
                 "pylxpweb.constants.registers.DISPUTED_WRITE_BLOCKED_PARAMS",
@@ -1136,16 +1144,41 @@ class TestRegister110UnifiedLayout:
 
         offgrid_transport.write_parameters.assert_not_called()
 
+    def test_capture_constants_match_the_recorded_evidence(self) -> None:
+        """Pin the recorded numbers themselves, not just what they decode to.
+
+        The decode assertions below are insensitive to small corruptions of the
+        fixtures — 0x0421 still has bit 10 set and still has bit 5 set, so it
+        decodes identically while no longer being the value the 18kPV actually
+        reported. The PR claims byte-perfect evidence, so the bytes are pinned
+        here: mutating a captured value fails CI instead of quietly
+        invalidating the claim.
+        """
+        # As printed by the capture script on 2026-08-01 (18kPV 45XXXXXX18).
+        assert CAPTURE_BASELINE_RAW == 1056
+        assert CAPTURE_TOGGLED_OFF_RAW == 32
+        # The whole argument in one line: EG4's own server clearing
+        # take-load-together moved exactly one bit, and that bit is 10.
+        assert CAPTURE_BASELINE_RAW ^ CAPTURE_TOGGLED_OFF_RAW == 1 << 10
+        # ...and bit 5, the position we used to claim, did not move.
+        assert CAPTURE_BASELINE_RAW & (1 << 5)
+        assert CAPTURE_TOGGLED_OFF_RAW & (1 << 5)
+
     @pytest.mark.parametrize(
-        ("raw", "expected"),
+        ("raw", "expected_true_keys"),
         [
-            (0x0420, True),  # captured baseline: flag on (bits 5 + 10 set)
-            (0x0020, False),  # captured after EG4 cleared it: only bit 5 left
+            # Captured baseline: flag on (bits 5 + 10 set).
+            (CAPTURE_BASELINE_RAW, {"FUNC_110_BIT5", "FUNC_TAKE_LOAD_TOGETHER"}),
+            # Captured after EG4 cleared it: only bit 5 left.
+            (CAPTURE_TOGGLED_OFF_RAW, {"FUNC_110_BIT5"}),
         ],
     )
     @pytest.mark.asyncio
     async def test_take_load_together_capture_evidence(
-        self, hybrid_transport: ModbusTransport, raw: int, expected: bool
+        self,
+        hybrid_transport: ModbusTransport,
+        raw: int,
+        expected_true_keys: set[str],
     ) -> None:
         """Pin the two raw values from the 2026-08-01 18kPV capture (#242).
 
@@ -1153,12 +1186,16 @@ class TestRegister110UnifiedLayout:
         toggle driven through EG4's own cloud functionControl. Under the old
         bit-5 mapping the second value decoded True — i.e. the decode could not
         see the change EG4 had just made.
+
+        The assertion is on the EXACT set of set flags, not just this one key,
+        so a corrupted fixture (an extra or missing bit) fails rather than
+        decoding the same way by luck.
         """
         hybrid_transport.read_parameters = AsyncMock(return_value={110: raw})
 
         result = await hybrid_transport.read_named_parameters(110, 1)
 
-        assert result["FUNC_TAKE_LOAD_TOGETHER"] is expected
+        assert {key for key, value in result.items() if value is True} == expected_true_keys
         # Bit 5 is set in BOTH captures, so it cannot be this flag.
         assert result["FUNC_110_BIT5"] is True
 


### PR DESCRIPTION
Fixes #242.

## The capture that settles it

EG4's cloud decode names `FUNC_TAKE_LOAD_TOGETHER`; ant0nkr/lxp_modbus puts a CT-sample-ratio field at bits 5-6 and TakeLoadTogether at bit 10. The only live read available had bits 5 **and** 10 both set (raw `0x0420`), so it separated nothing — the flag was left decode-only with LOCAL writes blocked.

A 2026-08-01 capture on an 18kPV (`45XXXXXX18`, plant 19147) settles it. The method matters: the toggle was driven through **EG4's own cloud `functionControl`, by name** — their server picks the bit, we only read the raw register — so this measures EG4's mapping rather than assuming ours.

| Phase | raw | hex | bits set | cloud decode |
|---|---|---|---|---|
| baseline | 1056 | `0x0420` | 5, 10 | `TAKE_LOAD_TOGETHER=True` |
| → set False | 32 | `0x0020` | 5 | — |
| → restore True | 1056 | `0x0420` | 5, 10 | byte-perfect restore |

Delta on both transitions is `0x0400` — **bit 10 alone**. Bit 5 stayed set across the entire cycle, so whatever it is, it is not this flag.

I re-ran the read-only baseline phase independently before writing any code: raw `1056`, bits `{5, 10}`, `FUNC_TAKE_LOAD_TOGETHER` the only set `FUNC_` key. That both reproduces the baseline and confirms the restore held on live hardware.

## What changed

**`constants/registers.py`**
- `REGISTER_110_PARAM_KEYS`: bit 5 → `FUNC_110_BIT5` placeholder, bit 10 → `FUNC_TAKE_LOAD_TOGETHER`.
- Bit 5 deliberately does **not** take lxp_modbus's CT-ratio name. Placeholders are write-rejected, which is the correct treatment for a multi-bit sample-ratio field — it must never be exposed as a writable bool — and its low bit has had no independent test here.
- Evidence comment block rewritten for bits 5-6, 10 and 11-13 with the capture facts.
- `DISPUTED_WRITE_BLOCKED_PARAMS` → empty `frozenset()`. The mechanism and its `write_named_parameters` guard stay; the comment now documents the resolved entry as precedent for how a name leaves the set.
- `OFFGRID_REGISTER_110_PARAM_KEYS` comment notes the lineage-inference position.

**`registers/inverter_holding.py`** — the canonical `take_load_together` definition moves from `bit_position=5` to `10`, with the capture in its description. Its old comment said the position was disputed and awaiting a toggle; it is now settled.

**Tests** — the per-family reg-110 contract test from #476 now pins `FUNC_TAKE_LOAD_TOGETHER` at 10 and `FUNC_110_BIT5` at 5 for every family. The old "bits 0-5 agree across all sources" test drops to 0-4, since bit 5 was only in that set on the strength of the name. The disputed-write test inverts into a writability test asserting the RMW lands `0x0420 → 0x0020` — the exact raw values from the capture — with bit 5 surviving. New: a parametrised capture-evidence test pinning both raw values to their decode, and a test that the now-empty guard still bites when repopulated.

## Deliberately not changed

- `GRIDBOSS_PARAMETERS` (registers.py ~1154/~1361) is a flat alphabetical name inventory with no bit semantics — both `BIT_WORKING_MODE` and `FUNC_TAKE_LOAD_TOGETHER` appear there purely as known names.
- `docs/inverters/*.md` are raw historical cloud dumps. One is *consistent* with the new mapping — a 12KPV reports `BIT_CT_SAMPLE_RATIO=1` and `FUNC_TAKE_LOAD_TOGETHER=True` in the same read — but it carries no raw value and no toggle, so it cannot separate bits 5 and 10 on its own (two truthy named decodes could be aliases of one bit). Consistent, not corroborating; the earlier commit message overstated this and the follow-up commit corrects it.

## Scrutiny points

- **Lineage inference, not per-family proof.** The toggle ran on an 18kPV (EG4_HYBRID). `OFFGRID_REGISTER_110_PARAM_KEYS` is an *alias*, not a copy, so EG4_OFFGRID inherits automatically. This follows the #476 precedent, which also shipped lineage-wide on the shared lxp_modbus `H_FUNCTION_ENABLE_3` layout that every hardware test on both families has matched. The contract test pins the shape so divergence must be deliberate.
- **This re-enables a LOCAL write that was blocked.** That is the point of the fix, but it is the change with real hardware consequence. The RMW assertion pins that bit 5 survives.
- **Bit 5 is now unnamed.** We drop a name EG4's decode appeared to support. The capture shows EG4's decode was reporting the name, not the position, so nothing first-party is actually contradicted — but it is a judgement call worth a second opinion.

## Merge order

Touches `constants/registers.py`, which `fix/247-clientless-bit-helpers` (#247) also touches — that branch adds 4 lines there (a constants export) and does not modify `DISPUTED_WRITE_BLOCKED_PARAMS` or the reg-110 table, so no semantic collision. Whichever merges second may need a trivial textual rebase. #247's `ValueError`-contract work references the guard by name only; the guard still exists and still raises, so its contract is unaffected by the set becoming empty.

## Validation

```
uv run pytest tests/ -q          2873 passed, 4 skipped, 80 deselected
uv run ruff check src/ tests/    All checks passed!
uv run ruff format --check       clean
uv run mypy src/pylxpweb/ --strict   Success: no issues found in 94 source files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review

Codex GPT-5.6-sol (xhigh) reviewed the branch: **no P1, no P2**, four P3s — all fixed in `23fb0a8`. Its substantive finding was a real coverage gap: register 110's bit positions live in two places nothing forced to agree (the transport decode list and the canonical `HoldingRegisterDefinition` rows), so a position fix applied to only one — the shape of both #242 and #476 — would leave reads and writes silently contradicting each other. There is now a cross-source consistency test, mutation-verified by reverting the registry to bit 5 and confirming it fails.

On inference validity codex's judgement was "very strong, but not logically airtight": the A→B→A result with a single-bit XOR and byte-perfect restore makes coincidence unlikely, but a single capture cannot exclude an asynchronously stale mirror or an unrelated bit-10 side effect. Strictly, the experiment proves EG4's named command selects bit 10 — which is precisely the thing the local write path needs to match.

### External gate follow-up (`76604b6`)

No P1s; Gemini SHIP. Codex raised one confirmed test-strength item, independently reproduced: the capture-evidence test did not pin the raw captured values. Mutating the fixtures `0x0420 → 0x0421` or `0x0020 → 0x0021` left the suite green, because both mutants still have bit 5 set and still agree with the bit-10 mapping — so the recorded evidence could be corrupted while the PR went on claiming it was byte-perfect.

Hardened: the two captured values are now named constants defined once and shared by the write and disputed-guard tests; a new test pins the recorded numbers themselves (1056 / 32), asserts their XOR is exactly bit 10 — the whole argument in one line — and asserts bit 5 is set in *both* captures, which is what excludes it; and the decode test now asserts the exact set of flags returned True rather than a single key.

Mutation-verified both ways: each corruption fails 3 tests, the unmutated file passes 73.

(One process note: an intermediate "restored but still failing" run was a stale `__pycache__`, not a real failure — clearing it confirmed the clean file passes.)

Gemini's bit-7 note was judged self-disclosed noise — no change.