### PR TITLE
Make Quick Charge bitfield updates atomic

### DIFF
--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -1950,7 +1950,17 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             value: True to set bit, False to clear bit
 
         Returns:
-            True if successful
+            True if successful, False if the write failed at the transport
+            layer (link down, device rejected the frame)
+
+        Raises:
+            LuxpowerDeviceError: If ``register`` is not a mapped bit-field
+                register — a single-value register (e.g. holding 67) would be
+                blind-overwritten with 0/1 rather than bit-modified, and a
+                placeholder or disputed bit name is refused by the named
+                write path because its function is not hardware-verified.
+                These are caller errors, distinct from a runtime write
+                failure, and are raised rather than reported as False.
 
         Example:
             >>> # Enable AC charge (register 21, bit 7)
@@ -1962,6 +1972,8 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             Only available in transport mode (Modbus/Dongle).
             For HTTP mode, use the specific control methods like enable_ac_charge().
         """
+        from pylxpweb.constants.registers import REGISTER_TO_PARAM_KEYS
+
         if self._transport is None:
             _LOGGER.warning(
                 "write_transport_bit() only available in transport mode for %s",
@@ -1969,8 +1981,22 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             )
             return False
 
+        # A single-key entry names a VALUE register: the named write path
+        # would classify it as a plain value and overwrite the whole 16-bit
+        # setpoint with int(True/False). Refuse rather than corrupt (a
+        # pre-#260 caller got a raw bit RMW here, never a blind overwrite).
+        keys = REGISTER_TO_PARAM_KEYS.get(register)
+        if keys is not None and not (
+            len(keys) > 1 and all(k.startswith(("FUNC_", "BIT_")) for k in keys)
+        ):
+            raise LuxpowerDeviceError(
+                f"Register {register} is not a bit-field register; "
+                "write_transport_bit() would overwrite its value — use "
+                "write_transport_register() instead"
+            )
+
+        param_key = self._cloud_param_key(register, bit)
         try:
-            param_key = self._cloud_param_key(register, bit)
             success = await self._transport.write_named_parameters({param_key: value})
             if success:
                 _LOGGER.debug(
@@ -1984,6 +2010,13 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                 self._invalidate_parameters_cache()
             return success
 
+        except ValueError as err:
+            # Named-path refusal (placeholder bit with unverified function,
+            # disputed bit position): a caller error, not a runtime write
+            # failure — surface it instead of an ambiguous False.
+            raise LuxpowerDeviceError(
+                f"Refused to write register {register} bit {bit} ({param_key}): {err}"
+            ) from err
         except Exception as err:
             _LOGGER.warning(
                 "Failed to write bit %d in register %d for %s: %s",
@@ -4040,8 +4073,23 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         if minute is None:
             return await self.write_transport_bit(233, 0, True)
 
+        # A duration start must be all-local. On a HybridTransport the HTTP
+        # leg applies named keys as SEPARATE cloud calls, so a silent
+        # per-write fallback could start the charge (the enable-bit function
+        # write succeeds server-side) while the reg-234 duration write fails
+        # — reporting success with the wrong duration, and skipping the
+        # dedicated start_quick_charge(minute) cloud endpoint that our
+        # caller runs when this method returns False (review P2). Pin every
+        # write in this path to the local leg; any local failure surfaces
+        # here as False and the caller takes the correct cloud recovery.
+        from pylxpweb.transports.hybrid import HybridTransport
+
+        wire: InverterTransport = transport
+        if isinstance(transport, HybridTransport):
+            wire = transport.local_transport
+
         try:
-            if await transport.write_named_parameters(
+            if await wire.write_named_parameters(
                 {
                     self._cloud_param_key(233, 0): True,
                     self._cloud_param_key(234): minute,
@@ -4058,10 +4106,29 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             )
 
         # Bit-only start (proven path), then apply the requested duration
-        # live — reg 234 accepts writes while a charge is running.
-        if not await self.write_transport_bit(233, 0, True):
+        # live — reg 234 accepts writes while a charge is running. Same
+        # local-leg pinning as the paired frame, for the same reason.
+        try:
+            if not await wire.write_named_parameters({self._cloud_param_key(233, 0): True}):
+                return False
+        except Exception as err:
+            _LOGGER.debug(
+                "Bit-only quick-charge start rejected for %s: %s",
+                self.serial_number,
+                err,
+            )
             return False
-        if not await self.write_transport_register(234, minute):
+        self._invalidate_parameters_cache()
+        try:
+            duration_applied = await wire.write_parameters({234: minute})
+        except Exception as err:
+            _LOGGER.debug(
+                "Quick-charge duration write (reg 234) failed for %s: %s",
+                self.serial_number,
+                err,
+            )
+            duration_applied = False
+        if not duration_applied:
             _LOGGER.warning(
                 "Quick charge started for %s but the %d-minute duration could "
                 "not be applied; the firmware default length is running",

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -1939,9 +1939,10 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
     ) -> bool:
         """Write a single bit in a register using read-modify-write.
 
-        This method reads the current register value, modifies the specified bit,
-        and writes the new value back. Useful for FUNC_EN (register 21) and
-        SYS_FUNC (register 110) bit field operations.
+        This resolves the bit's named parameter and delegates to the transport's
+        operation-lock-held read-modify-write, so a concurrent sibling-bit update
+        cannot land between this operation's read and write. Useful for FUNC_EN
+        (register 21) and SYS_FUNC (register 110) bit field operations.
 
         Args:
             register: Register address (e.g., 21 for FUNC_EN)
@@ -1969,41 +1970,19 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             return False
 
         try:
-            # Read current register value
-            current_values = await self._transport.read_parameters(register, 1)
-            if register not in current_values:
-                _LOGGER.warning("Failed to read register %d for %s", register, self.serial_number)
-                return False
-
-            current_value = current_values[register]
-
-            # Modify the bit (set if value=True, clear if value=False)
-            new_value = current_value | (1 << bit) if value else current_value & ~(1 << bit)
-
-            # Write back if changed
-            if new_value != current_value:
-                success = await self._transport.write_parameters({register: new_value})
-                if success:
-                    _LOGGER.debug(
-                        "Set register %d bit %d to %s for %s (0x%04X -> 0x%04X)",
-                        register,
-                        bit,
-                        value,
-                        self.serial_number,
-                        current_value,
-                        new_value,
-                    )
-                    self._invalidate_parameters_cache()
-                return success
-            else:
+            param_key = self._cloud_param_key(register, bit)
+            success = await self._transport.write_named_parameters({param_key: value})
+            if success:
                 _LOGGER.debug(
-                    "Register %d bit %d already %s for %s",
+                    "Set register %d bit %d (%s) to %s for %s",
                     register,
                     bit,
+                    param_key,
                     value,
                     self.serial_number,
                 )
-                return True  # Already in desired state
+                self._invalidate_parameters_cache()
+            return success
 
         except Exception as err:
             _LOGGER.warning(
@@ -4048,11 +4027,12 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         """Start quick charge over the local transport.
 
         With a requested duration the activation bit (reg 233 bit 0, upper
-        bits preserved via read-modify-write — the 0x1000 flag observed live
-        is sticky config of unconfirmed meaning) and the duration (reg 234)
-        are written as ONE contiguous frame; the firmware rejects reg 234
-        alone while idle (eg4_web_monitor#251). If the paired frame fails,
-        fall back to the bit-only start and then apply the duration live.
+        bits preserved via an operation-lock-held read-modify-write — the
+        0x1000 flag observed live is sticky config of unconfirmed meaning) and
+        the duration (reg 234) are written as ONE contiguous frame; the firmware
+        rejects reg 234 alone while idle (eg4_web_monitor#251). If the paired
+        frame fails, fall back to the bit-only start and then apply the duration
+        live.
         """
         transport = self._transport
         if transport is None:
@@ -4060,29 +4040,22 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         if minute is None:
             return await self.write_transport_bit(233, 0, True)
 
-        reg: int | None = None
         try:
-            current = await transport.read_parameters(233, 1)
-            reg = current.get(233)
+            if await transport.write_named_parameters(
+                {
+                    self._cloud_param_key(233, 0): True,
+                    self._cloud_param_key(234): minute,
+                }
+            ):
+                self._invalidate_parameters_cache()
+                return True
         except Exception as err:
             _LOGGER.debug(
-                "Quick charge start: could not read register 233 for %s (%s); "
-                "trying the bit-only start",
+                "Paired quick-charge start frame (regs 233+234) rejected "
+                "for %s (%s); falling back to the bit-only start",
                 self.serial_number,
                 err,
             )
-        if reg is not None:
-            try:
-                if await transport.write_parameters({233: reg | 0x1, 234: minute}):
-                    self._invalidate_parameters_cache()
-                    return True
-            except Exception as err:
-                _LOGGER.debug(
-                    "Paired quick-charge start frame (regs 233+234) rejected "
-                    "for %s (%s); falling back to the bit-only start",
-                    self.serial_number,
-                    err,
-                )
 
         # Bit-only start (proven path), then apply the requested duration
         # live — reg 234 accepts writes while a charge is running.

--- a/tests/unit/devices/inverters/test_quick_charge_local.py
+++ b/tests/unit/devices/inverters/test_quick_charge_local.py
@@ -550,3 +550,142 @@ class TestReadQuickChargeRemainingSeconds:
 
         with patch.object(transport, "_read_input_registers", side_effect=boom):
             assert await transport.read_quick_charge_remaining_seconds() is None
+
+
+class TestWriteTransportBitGuards:
+    """write_transport_bit refuses targets the named path cannot bit-modify.
+
+    Review follow-ups on the #260 reroute (Opus findings 1-2): a single-key
+    VALUE register (e.g. holding 67) would be blind-overwritten with 0/1 by
+    the plain-value branch of write_named_parameters, and a placeholder or
+    disputed bit name is refused with ValueError inside the named path —
+    both must surface as LuxpowerDeviceError, never as a silent False or,
+    worse, a corrupted setpoint.
+    """
+
+    def _inverter(self, mock_client: LuxpowerClient) -> _Inverter:
+        transport = Mock()
+        transport.write_named_parameters = AsyncMock(return_value=True)
+        return _Inverter(
+            client=mock_client,
+            serial_number="1234567890",
+            model="FlexBOSS21",
+            transport=transport,
+        )
+
+    @pytest.mark.asyncio
+    async def test_value_register_is_refused_not_overwritten(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """Holding 67 (AC charge SOC limit) must never be blind-written."""
+        from pylxpweb.exceptions import LuxpowerDeviceError
+
+        inverter = self._inverter(mock_client)
+
+        with pytest.raises(LuxpowerDeviceError, match="not a bit-field register"):
+            await inverter.write_transport_bit(67, 0, True)
+
+        inverter._transport.write_named_parameters.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_placeholder_bit_refusal_raises_not_false(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A named-path ValueError refusal surfaces as LuxpowerDeviceError."""
+        from pylxpweb.exceptions import LuxpowerDeviceError
+
+        inverter = self._inverter(mock_client)
+        inverter._transport.write_named_parameters = AsyncMock(
+            side_effect=ValueError("Refusing to write placeholder parameter 'FUNC_110_BIT5'")
+        )
+
+        with pytest.raises(LuxpowerDeviceError, match="Refused to write register 110 bit 5"):
+            await inverter.write_transport_bit(110, 5, True)
+
+    @pytest.mark.asyncio
+    async def test_bit_field_register_still_writes(self, mock_client: LuxpowerClient) -> None:
+        """Register 21 (16-key FUNC_ bit field) keeps the named write path."""
+        inverter = self._inverter(mock_client)
+
+        result = await inverter.write_transport_bit(21, 7, True)
+
+        assert result is True
+        assert inverter._transport.write_named_parameters.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_still_returns_false(self, mock_client: LuxpowerClient) -> None:
+        """Runtime transport errors keep the documented False contract."""
+        inverter = self._inverter(mock_client)
+        inverter._transport.write_named_parameters = AsyncMock(
+            side_effect=TransportWriteError("link down")
+        )
+
+        assert await inverter.write_transport_bit(21, 7, True) is False
+
+
+class TestHybridTransportDurationStart:
+    """Duration starts on a HybridTransport must pin the local leg (Fable P2).
+
+    HybridTransport's per-write HTTP fallback applies named keys as separate
+    cloud calls, so a local NAK of the paired H233/H234 frame could start the
+    charge via the function write while the reg-234 duration write fails —
+    success with the wrong duration, and the dedicated start_quick_charge
+    cloud endpoint (the correct recovery) never runs. The device must talk to
+    the local leg directly and let a local failure fall through to that
+    endpoint with the requested minute intact.
+    """
+
+    def _hybrid(self, local: Mock) -> Any:
+        from pylxpweb.transports.hybrid import HybridTransport
+
+        hybrid = HybridTransport(local, Mock())
+        # Instance-level shadows: the device must talk to the LOCAL leg
+        # directly; touching the hybrid wrapper's fallback-capable writers
+        # is exactly the regression under test.
+        hybrid.write_named_parameters = AsyncMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("duration start must not use the hybrid fallback wrapper")
+        )
+        hybrid.write_parameters = AsyncMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("duration write must not use the hybrid fallback wrapper")
+        )
+        return hybrid
+
+    @pytest.mark.asyncio
+    async def test_local_nak_falls_back_to_dedicated_cloud_endpoint(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """All-local NAK -> start_quick_charge(minute) with the right duration."""
+        local = Mock()
+        local.write_named_parameters = AsyncMock(side_effect=TransportWriteError("firmware NAK"))
+        local.write_parameters = AsyncMock(side_effect=TransportWriteError("firmware NAK"))
+        inverter = _Inverter(
+            client=mock_client,
+            serial_number="1234567890",
+            model="FlexBOSS21",
+            transport=self._hybrid(local),
+        )
+
+        result = await inverter.enable_quick_charge(minute=30)
+
+        assert result is True
+        mock_client.api.control.start_quick_charge.assert_awaited_once_with("1234567890", minute=30)
+        # Both local attempts happened on the LOCAL leg, not the wrapper.
+        assert local.write_named_parameters.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_local_success_never_touches_cloud(self, mock_client: LuxpowerClient) -> None:
+        """A successful local paired start stays entirely local."""
+        local = Mock()
+        local.write_named_parameters = AsyncMock(return_value=True)
+        inverter = _Inverter(
+            client=mock_client,
+            serial_number="1234567890",
+            model="FlexBOSS21",
+            transport=self._hybrid(local),
+        )
+
+        result = await inverter.enable_quick_charge(minute=30)
+
+        assert result is True
+        local.write_named_parameters.assert_awaited_once()
+        mock_client.api.control.start_quick_charge.assert_not_awaited()

--- a/tests/unit/devices/inverters/test_quick_charge_local.py
+++ b/tests/unit/devices/inverters/test_quick_charge_local.py
@@ -7,8 +7,9 @@ also reads as the live remaining-minutes countdown).
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -16,6 +17,7 @@ from pylxpweb import LuxpowerClient
 from pylxpweb.devices.inverters.base import BaseInverter
 from pylxpweb.models import QuickChargeStatus, SuccessResponse
 from pylxpweb.transports.exceptions import TransportReadError, TransportWriteError
+from pylxpweb.transports.modbus import ModbusTransport
 
 
 class _Inverter(BaseInverter):
@@ -44,6 +46,7 @@ def _inverter(mock_client: LuxpowerClient, *, with_transport: bool) -> _Inverter
         transport = AsyncMock()
         transport.read_parameters = AsyncMock(return_value={233: 0})
         transport.write_parameters = AsyncMock(return_value=True)
+        transport.write_named_parameters = AsyncMock(return_value=True)
         # Input reg 210 unavailable by default (older firmware / no value) so the
         # remaining time falls back to the holding-reg 234 derivation; tests that
         # exercise the seconds path override this.
@@ -65,21 +68,108 @@ async def test_enable_local_with_minute_writes_paired_frame(mock_client):
     ok = await inv.enable_quick_charge(minute=30)
 
     assert ok is True
-    inv._transport.write_parameters.assert_awaited_once_with({233: 1, 234: 30})
+    inv._transport.write_named_parameters.assert_awaited_once_with(
+        {
+            "FUNC_QUICK_CHG_START_EN": True,
+            "SNA_HOLD_QUICK_CHARGE_MINUTE": 30,
+        }
+    )
+    inv._transport.write_parameters.assert_not_awaited()
     mock_client.api.control.start_quick_charge.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_enable_local_paired_frame_preserves_sticky_upper_bits(mock_client):
+async def test_enable_local_paired_frame_uses_lock_held_named_rmw(mock_client):
     """The 0x1000 flag observed live is sticky config of unconfirmed meaning —
-    the activation must read-modify-write bit 0, never blind-write 0x0001."""
+    the activation must use the transport's named, lock-held RMW."""
     inv = _inverter(mock_client, with_transport=True)
-    inv._transport.read_parameters = AsyncMock(return_value={233: 0x1000})
 
     ok = await inv.enable_quick_charge(minute=30)
 
     assert ok is True
-    inv._transport.write_parameters.assert_awaited_once_with({233: 0x1001, 234: 30})
+    inv._transport.write_named_parameters.assert_awaited_once_with(
+        {
+            "FUNC_QUICK_CHG_START_EN": True,
+            "SNA_HOLD_QUICK_CHARGE_MINUTE": 30,
+        }
+    )
+    inv._transport.read_parameters.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation",
+    [
+        pytest.param("start-paired", id="start-paired-h233-h234"),
+        pytest.param("start-bit-only", id="start-bit-only"),
+        pytest.param("stop", id="stop"),
+    ],
+)
+async def test_quick_charge_h233_rmw_is_atomic_with_concurrent_sibling_update(
+    operation: str,
+):
+    """Quick Charge must not erase a sibling H233 bit queued after its read."""
+    register_233 = 0x1001 if operation == "stop" else 0x1000
+    register_234 = 0
+    transport = ModbusTransport(host="192.0.2.1", serial="1234567890")
+    transport._connected = True
+    inv = _Inverter(
+        client=None,
+        serial_number="1234567890",
+        model="18kPV",
+        transport=transport,
+    )
+    first_read_started = asyncio.Event()
+    release_first_read = asyncio.Event()
+    sibling_update_started = asyncio.Event()
+    first_read = True
+
+    async def read_holding(address: int, count: int) -> list[int]:
+        nonlocal first_read
+        assert (address, count) == (233, 1)
+        snapshot = register_233
+        if first_read:
+            first_read = False
+            first_read_started.set()
+            await release_first_read.wait()
+        return [snapshot]
+
+    async def write_holding(address: int, values: list[int]) -> bool:
+        nonlocal register_233, register_234
+        assert address == 233
+        register_233 = values[0]
+        if len(values) == 2:
+            register_234 = values[1]
+        return True
+
+    async def update_sibling_bit() -> bool:
+        sibling_update_started.set()
+        return await transport.write_named_parameters({"FUNC_BATTERY_BACKUP_CTRL": True})
+
+    with (
+        patch.object(transport, "_read_holding_registers", side_effect=read_holding),
+        patch.object(transport, "_write_holding_registers", side_effect=write_holding),
+    ):
+        if operation == "start-paired":
+            quick_charge_task = asyncio.create_task(inv.enable_quick_charge(minute=30))
+        elif operation == "start-bit-only":
+            quick_charge_task = asyncio.create_task(inv.enable_quick_charge())
+        else:
+            quick_charge_task = asyncio.create_task(inv.disable_quick_charge())
+
+        await asyncio.wait_for(first_read_started.wait(), timeout=1)
+        sibling_task = asyncio.create_task(update_sibling_bit())
+        await asyncio.wait_for(sibling_update_started.wait(), timeout=1)
+        release_first_read.set()
+        results = await asyncio.wait_for(
+            asyncio.gather(quick_charge_task, sibling_task),
+            timeout=1,
+        )
+
+    assert results == [True, True]
+    expected_quick_charge_bit = 0 if operation == "stop" else 1
+    assert register_233 == 0x1002 | expected_quick_charge_bit
+    assert register_234 == (30 if operation == "start-paired" else 0)
 
 
 @pytest.mark.asyncio
@@ -99,15 +189,23 @@ async def test_enable_local_paired_frame_rejected_falls_back_bit_only_plus_live(
     proven bit-only start, then applies the duration live (reg 234 accepts
     writes while a charge runs)."""
     inv = _inverter(mock_client, with_transport=True)
-    inv._transport.write_parameters = AsyncMock(
-        side_effect=[TransportWriteError("NAK"), True, final_reg234_effect]
+    inv._transport.write_named_parameters = AsyncMock(
+        side_effect=[TransportWriteError("NAK"), True]
     )
+    inv._transport.write_parameters = AsyncMock(side_effect=[final_reg234_effect])
 
     ok = await inv.enable_quick_charge(minute=30)
 
     assert ok is True
-    writes = [c.args[0] for c in inv._transport.write_parameters.call_args_list]
-    assert writes == [{233: 1, 234: 30}, {233: 1}, {234: 30}]
+    named_writes = [c.args[0] for c in inv._transport.write_named_parameters.call_args_list]
+    assert named_writes == [
+        {
+            "FUNC_QUICK_CHG_START_EN": True,
+            "SNA_HOLD_QUICK_CHARGE_MINUTE": 30,
+        },
+        {"FUNC_QUICK_CHG_START_EN": True},
+    ]
+    inv._transport.write_parameters.assert_awaited_once_with({234: 30})
     mock_client.api.control.start_quick_charge.assert_not_called()
 
 
@@ -118,13 +216,22 @@ async def test_enable_local_reg233_read_failure_falls_back_bit_only_plus_live(
     """If reg 233 cannot be read for the RMW, the paired frame is skipped
     (never blind-write 0x0001) and the bit-only start path runs instead."""
     inv = _inverter(mock_client, with_transport=True)
-    inv._transport.read_parameters = AsyncMock(side_effect=[TransportReadError("boom"), {233: 0}])
+    inv._transport.write_named_parameters = AsyncMock(
+        side_effect=[TransportReadError("boom"), True]
+    )
 
     ok = await inv.enable_quick_charge(minute=30)
 
     assert ok is True
-    writes = [c.args[0] for c in inv._transport.write_parameters.call_args_list]
-    assert writes == [{233: 1}, {234: 30}]
+    named_writes = [c.args[0] for c in inv._transport.write_named_parameters.call_args_list]
+    assert named_writes == [
+        {
+            "FUNC_QUICK_CHG_START_EN": True,
+            "SNA_HOLD_QUICK_CHARGE_MINUTE": 30,
+        },
+        {"FUNC_QUICK_CHG_START_EN": True},
+    ]
+    inv._transport.write_parameters.assert_awaited_once_with({234: 30})
 
 
 @pytest.mark.asyncio
@@ -133,7 +240,7 @@ async def test_enable_hybrid_all_local_writes_raise_falls_back_to_cloud(mock_cli
     returning False — when the paired frame AND the bit-only start both raise,
     HYBRID must still reach the cloud start endpoint."""
     inv = _inverter(mock_client, with_transport=True)
-    inv._transport.write_parameters = AsyncMock(side_effect=TransportWriteError("NAK"))
+    inv._transport.write_named_parameters = AsyncMock(side_effect=TransportWriteError("NAK"))
 
     ok = await inv.enable_quick_charge(minute=20)
 
@@ -141,8 +248,15 @@ async def test_enable_hybrid_all_local_writes_raise_falls_back_to_cloud(mock_cli
     # Paired frame attempted, then the bit-only start (write_transport_bit
     # swallows the raise into False) — no live reg-234 attempt after a
     # failed start.
-    writes = [c.args[0] for c in inv._transport.write_parameters.call_args_list]
-    assert writes == [{233: 1, 234: 20}, {233: 1}]
+    named_writes = [c.args[0] for c in inv._transport.write_named_parameters.call_args_list]
+    assert named_writes == [
+        {
+            "FUNC_QUICK_CHG_START_EN": True,
+            "SNA_HOLD_QUICK_CHARGE_MINUTE": 20,
+        },
+        {"FUNC_QUICK_CHG_START_EN": True},
+    ]
+    inv._transport.write_parameters.assert_not_awaited()
     mock_client.api.control.start_quick_charge.assert_awaited_once_with("1234567890", minute=20)
 
 
@@ -151,7 +265,7 @@ async def test_enable_local_only_all_writes_raise_returns_false(mock_client):
     """LOCAL-only (no cloud client): raising transport writes fail honestly."""
     inv = _inverter(mock_client, with_transport=True)
     inv._client = None
-    inv._transport.write_parameters = AsyncMock(side_effect=TransportWriteError("NAK"))
+    inv._transport.write_named_parameters = AsyncMock(side_effect=TransportWriteError("NAK"))
 
     ok = await inv.enable_quick_charge(minute=20)
 
@@ -166,9 +280,10 @@ async def test_enable_local_without_minute_only_sets_bit(mock_client):
     ok = await inv.enable_quick_charge()
 
     assert ok is True
-    writes = [c.args[0] for c in inv._transport.write_parameters.call_args_list]
-    assert {233: 1} in writes
-    assert all(234 not in w for w in writes)  # no duration write
+    inv._transport.write_named_parameters.assert_awaited_once_with(
+        {"FUNC_QUICK_CHG_START_EN": True}
+    )
+    inv._transport.write_parameters.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -179,19 +294,21 @@ async def test_enable_local_rejects_bad_minute(mock_client, bad):
     with pytest.raises(ValueError, match="minute must be a positive integer"):
         await inv.enable_quick_charge(minute=bad)
 
+    inv._transport.write_named_parameters.assert_not_called()
     inv._transport.write_parameters.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_disable_local_clears_enable_bit(mock_client):
     inv = _inverter(mock_client, with_transport=True)
-    inv._transport.read_parameters = AsyncMock(return_value={233: 0x1})
 
     ok = await inv.disable_quick_charge()
 
     assert ok is True
-    writes = [c.args[0] for c in inv._transport.write_parameters.call_args_list]
-    assert {233: 0} in writes  # bit cleared
+    inv._transport.write_named_parameters.assert_awaited_once_with(
+        {"FUNC_QUICK_CHG_START_EN": False}
+    )
+    inv._transport.write_parameters.assert_not_awaited()
     mock_client.api.control.stop_quick_charge.assert_not_called()
 
 
@@ -201,7 +318,7 @@ async def test_disable_local_clears_enable_bit(mock_client):
 @pytest.mark.asyncio
 async def test_enable_hybrid_falls_back_to_cloud_on_local_failure(mock_client):
     inv = _inverter(mock_client, with_transport=True)
-    inv._transport.write_parameters = AsyncMock(return_value=False)  # local write fails
+    inv._transport.write_named_parameters = AsyncMock(return_value=False)
 
     ok = await inv.enable_quick_charge(minute=20)
 
@@ -212,8 +329,7 @@ async def test_enable_hybrid_falls_back_to_cloud_on_local_failure(mock_client):
 @pytest.mark.asyncio
 async def test_disable_hybrid_falls_back_to_cloud_on_local_failure(mock_client):
     inv = _inverter(mock_client, with_transport=True)
-    inv._transport.read_parameters = AsyncMock(return_value={233: 0x1})
-    inv._transport.write_parameters = AsyncMock(return_value=False)
+    inv._transport.write_named_parameters = AsyncMock(return_value=False)
 
     ok = await inv.disable_quick_charge()
 
@@ -226,7 +342,7 @@ async def test_enable_local_only_failure_returns_false_no_cloud(mock_client):
     """Local-only (client is None) fails honestly without a cloud attempt."""
     inv = _inverter(mock_client, with_transport=True)
     inv._client = None  # local-only: no cloud client
-    inv._transport.write_parameters = AsyncMock(return_value=False)
+    inv._transport.write_named_parameters = AsyncMock(return_value=False)
 
     ok = await inv.enable_quick_charge(minute=20)
 


### PR DESCRIPTION
## Summary

- route Quick Charge start, stop, and paired H233/H234 updates through the transport's named-parameter write path
- keep the transport operation lock held across H233 read-modify-write so concurrent sibling-bit changes cannot be erased
- retain the proven paired-frame fallback and hybrid cloud fallback behavior

## RCA

Quick Charge previously performed its own H233 read and later write around separate transport calls. The transport lock protected each call, but not the complete read-modify-write transaction. A sibling H233 update could land between them and then be overwritten by Quick Charge's stale snapshot. The named-parameter transport path already supplies the required lock-held bitfield merge, including the contiguous H233/H234 operation.

## Verification

- RED: three deterministic races reproduced lost sibling bits for paired start, bit-only start, and stop
- Quick Charge suite: 39 passed
- related named-parameter/Modbus/dongle suites: 267 passed
- full unit suite: 3071 passed; coverage 88.51%
- Ruff check/format and strict mypy (94 source files): passed

## Tracking

- bead: `eg4-xvf1`
