### PR TITLE
Coalesce concurrent session renewal

### DIFF
--- a/src/pylxpweb/client.py
+++ b/src/pylxpweb/client.py
@@ -120,6 +120,7 @@ class LuxpowerClient:
         # Account level: "guest", "viewer", "operator", "owner", "installer"
         self._account_level: str | None = None
         self._authentication_task: asyncio.Task[LoginResponse] | None = None
+        self._authentication_generation: int = 0
 
         # Response cache with TTL configuration
         self._response_cache: dict[str, dict[str, Any]] = {}
@@ -201,11 +202,18 @@ class LuxpowerClient:
         return self._session
 
     async def close(self) -> None:
-        """Close the session if we own it.
+        """Cancel owned authentication work and close an owned HTTP session.
 
-        Only closes the session if it was created by this client,
-        not if it was injected.
+        Authentication renewal tasks are always created and owned by this client,
+        even when the HTTP session was injected. Injected sessions remain open.
         """
+        authentication_task = self._authentication_task
+        if authentication_task is not None:
+            authentication_task.cancel()
+            await asyncio.gather(authentication_task, return_exceptions=True)
+            if self._authentication_task is authentication_task:
+                self._authentication_task = None
+
         if self._session and not self._session.closed and self._owns_session:
             await self._session.close()
 
@@ -590,6 +598,7 @@ class LuxpowerClient:
             self._daily_request_count = 0
             self._daily_reset_ymd = today
         self._daily_request_count += 1
+        authentication_generation = self._authentication_generation
 
         try:
             async with session.request(method, url, data=data, headers=headers) as response:
@@ -641,7 +650,7 @@ class LuxpowerClient:
                 "Got HTML response instead of JSON (session expired), attempting to re-authenticate"
             )
             try:
-                await self.login()
+                await self._renew_authentication(authentication_generation)
                 _LOGGER.debug("Re-authentication successful, retrying request")
                 # Retry the request with the new session
                 return await self._request(
@@ -676,7 +685,7 @@ class LuxpowerClient:
                 # Session expired - try to re-authenticate once
                 _LOGGER.warning("Got 401 Unauthorized, attempting to re-authenticate")
                 try:
-                    await self.login()
+                    await self._renew_authentication(authentication_generation)
                     _LOGGER.debug("Re-authentication successful, retrying request")
                     # Retry the request with the new session
                     return await self._request(
@@ -807,12 +816,33 @@ class LuxpowerClient:
         """Ensure we have a valid session, re-authenticating if needed."""
         if not self._session_expires or datetime.now() >= self._session_expires:
             _LOGGER.debug("Session expired or missing, re-authenticating")
-            task = self._authentication_task
-            if task is None:
-                task = asyncio.create_task(self.login())
-                self._authentication_task = task
-                task.add_done_callback(self._authentication_task_done)
-            await asyncio.shield(task)
+            await self._renew_authentication()
+
+    async def _renew_authentication(
+        self, observed_generation: int | None = None
+    ) -> LoginResponse | None:
+        """Force one shared renewal unless a stale response predates a completed one."""
+        if (
+            observed_generation is not None
+            and observed_generation != self._authentication_generation
+        ):
+            return None
+
+        task = self._authentication_task
+        if task is None:
+            task = asyncio.create_task(self._login_and_advance_authentication())
+            self._authentication_task = task
+            task.add_done_callback(self._authentication_task_done)
+        elif task is asyncio.current_task():
+            raise LuxpowerAuthError("Session was rejected while authentication was in progress")
+
+        return await asyncio.shield(task)
+
+    async def _login_and_advance_authentication(self) -> LoginResponse:
+        """Run one owned login and advance the cookie generation on success."""
+        response = await self.login()
+        self._authentication_generation += 1
+        return response
 
     def _authentication_task_done(self, task: asyncio.Task[LoginResponse]) -> None:
         """Clear a completed shared login and consume an unobserved failure."""

--- a/src/pylxpweb/client.py
+++ b/src/pylxpweb/client.py
@@ -26,6 +26,7 @@ import logging
 import random
 import time
 from collections import deque
+from contextvars import ContextVar
 from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import urljoin
@@ -121,6 +122,12 @@ class LuxpowerClient:
         self._account_level: str | None = None
         self._authentication_task: asyncio.Task[LoginResponse] | None = None
         self._authentication_generation: int = 0
+        self._authentication_close_lock = asyncio.Lock()
+        self._authentication_closing: bool = False
+        self._reactive_authentication_replay: ContextVar[bool] = ContextVar(
+            f"pylxpweb_reactive_authentication_replay_{id(self)}",
+            default=False,
+        )
 
         # Response cache with TTL configuration
         self._response_cache: dict[str, dict[str, Any]] = {}
@@ -202,20 +209,31 @@ class LuxpowerClient:
         return self._session
 
     async def close(self) -> None:
-        """Cancel owned authentication work and close an owned HTTP session.
+        """Drain authentication work and close an owned HTTP session.
 
         Authentication renewal tasks are always created and owned by this client,
-        even when the HTTP session was injected. Injected sessions remain open.
-        """
-        authentication_task = self._authentication_task
-        if authentication_task is not None:
-            authentication_task.cancel()
-            await asyncio.gather(authentication_task, return_exceptions=True)
-            if self._authentication_task is authentication_task:
-                self._authentication_task = None
+        even when the HTTP session was injected. Authentication attempts that begin
+        while this method is awaiting cleanup fail with ``LuxpowerConnectionError``.
 
-        if self._session and not self._session.closed and self._owns_session:
-            await self._session.close()
+        Injected sessions remain open. The client remains reusable after this method
+        returns; a later login recreates an owned session or reuses an injected one.
+        """
+        async with self._authentication_close_lock:
+            self._authentication_closing = True
+            try:
+                authentication_task = self._authentication_task
+                if authentication_task is asyncio.current_task():
+                    raise RuntimeError("Cannot close client from its authentication task")
+                if authentication_task is not None:
+                    authentication_task.cancel()
+                    await asyncio.gather(authentication_task, return_exceptions=True)
+                    if self._authentication_task is authentication_task:
+                        self._authentication_task = None
+
+                if self._session and not self._session.closed and self._owns_session:
+                    await self._session.close()
+            finally:
+                self._authentication_closing = False
 
     # API Namespace (v0.2.0+)
 
@@ -650,16 +668,14 @@ class LuxpowerClient:
                 "Got HTML response instead of JSON (session expired), attempting to re-authenticate"
             )
             try:
-                await self._renew_authentication(authentication_generation)
-                _LOGGER.debug("Re-authentication successful, retrying request")
-                # Retry the request with the new session
-                return await self._request(
+                return await self._retry_request_after_authentication(
+                    authentication_generation,
                     method,
                     endpoint,
                     data=data,
                     cache_key=cache_key,
                     cache_endpoint=cache_endpoint,
-                    _retry_count=_retry_count,  # Preserve retry count
+                    retry_count=_retry_count,
                 )
             except LuxpowerAuthError:
                 # True authentication failure (wrong credentials, account locked)
@@ -685,16 +701,14 @@ class LuxpowerClient:
                 # Session expired - try to re-authenticate once
                 _LOGGER.warning("Got 401 Unauthorized, attempting to re-authenticate")
                 try:
-                    await self._renew_authentication(authentication_generation)
-                    _LOGGER.debug("Re-authentication successful, retrying request")
-                    # Retry the request with the new session
-                    return await self._request(
+                    return await self._retry_request_after_authentication(
+                        authentication_generation,
                         method,
                         endpoint,
                         data=data,
                         cache_key=cache_key,
                         cache_endpoint=cache_endpoint,
-                        _retry_count=_retry_count,  # Preserve retry count
+                        retry_count=_retry_count,
                     )
                 except LuxpowerAuthError:
                     # True authentication failure (wrong credentials, account locked)
@@ -729,10 +743,55 @@ class LuxpowerClient:
             self._handle_request_error(err)
             raise LuxpowerAPIError(f"Unexpected error: {err}") from err
 
+    async def _retry_request_after_authentication(
+        self,
+        observed_generation: int,
+        method: str,
+        endpoint: str,
+        *,
+        data: dict[str, Any] | None,
+        cache_key: str | None,
+        cache_endpoint: str | None,
+        retry_count: int,
+    ) -> dict[str, Any]:
+        """Renew once and replay one request without changing its public signature."""
+        if self._reactive_authentication_replay.get():
+            raise LuxpowerAuthError("Session remained unauthorized after re-authentication")
+
+        await self._renew_authentication(observed_generation)
+        _LOGGER.debug("Re-authentication successful, retrying request")
+        replay_token = self._reactive_authentication_replay.set(True)
+        try:
+            return await self._request(
+                method,
+                endpoint,
+                data=data,
+                cache_key=cache_key,
+                cache_endpoint=cache_endpoint,
+                _retry_count=retry_count,
+            )
+        finally:
+            self._reactive_authentication_replay.reset(replay_token)
+
     # Authentication
 
     async def login(self, _retry_count: int = 0) -> LoginResponse:
-        """Authenticate with the API and establish a session.
+        """Authenticate through the client-wide single-flight task.
+
+        Concurrent direct calls, proactive expiry checks, and reactive recovery all
+        share the same task and advance the authentication generation exactly once.
+        ``_retry_count`` remains accepted for backward compatibility as an internal
+        connection-retry offset.
+        """
+        if self._authentication_task is asyncio.current_task():
+            return await self._login_raw(_retry_count)
+
+        response = await self._renew_authentication(authentication_retry_count=_retry_count)
+        assert response is not None
+        return response
+
+    async def _login_raw(self, _retry_count: int = 0) -> LoginResponse:
+        """Perform authentication with bounded connection retries.
 
         This method includes automatic retry logic for transient failures
         (network issues, temporary server errors) with exponential backoff.
@@ -803,7 +862,7 @@ class LuxpowerClient:
                     delay,
                 )
                 await asyncio.sleep(delay)
-                return await self.login(_retry_count=_retry_count + 1)
+                return await self._login_raw(_retry_count=_retry_count + 1)
             # Max retries exceeded
             _LOGGER.error(
                 "Login failed after %d attempts due to connection errors: %s",
@@ -819,9 +878,15 @@ class LuxpowerClient:
             await self._renew_authentication()
 
     async def _renew_authentication(
-        self, observed_generation: int | None = None
+        self,
+        observed_generation: int | None = None,
+        *,
+        authentication_retry_count: int = 0,
     ) -> LoginResponse | None:
         """Force one shared renewal unless a stale response predates a completed one."""
+        if self._authentication_closing:
+            raise LuxpowerConnectionError("Cannot authenticate while client is closing")
+
         if (
             observed_generation is not None
             and observed_generation != self._authentication_generation
@@ -830,7 +895,9 @@ class LuxpowerClient:
 
         task = self._authentication_task
         if task is None:
-            task = asyncio.create_task(self._login_and_advance_authentication())
+            task = asyncio.create_task(
+                self._login_and_advance_authentication(authentication_retry_count)
+            )
             self._authentication_task = task
             task.add_done_callback(self._authentication_task_done)
         elif task is asyncio.current_task():
@@ -838,9 +905,11 @@ class LuxpowerClient:
 
         return await asyncio.shield(task)
 
-    async def _login_and_advance_authentication(self) -> LoginResponse:
+    async def _login_and_advance_authentication(
+        self, authentication_retry_count: int = 0
+    ) -> LoginResponse:
         """Run one owned login and advance the cookie generation on success."""
-        response = await self.login()
+        response = await self.login(_retry_count=authentication_retry_count)
         self._authentication_generation += 1
         return response
 

--- a/src/pylxpweb/client.py
+++ b/src/pylxpweb/client.py
@@ -119,6 +119,7 @@ class LuxpowerClient:
         self._user_role: str | None = None  # VIEWER, INSTALLER, I_ASSISTANT, ADMIN
         # Account level: "guest", "viewer", "operator", "owner", "installer"
         self._account_level: str | None = None
+        self._authentication_task: asyncio.Task[LoginResponse] | None = None
 
         # Response cache with TTL configuration
         self._response_cache: dict[str, dict[str, Any]] = {}
@@ -806,7 +807,19 @@ class LuxpowerClient:
         """Ensure we have a valid session, re-authenticating if needed."""
         if not self._session_expires or datetime.now() >= self._session_expires:
             _LOGGER.debug("Session expired or missing, re-authenticating")
-            await self.login()
+            task = self._authentication_task
+            if task is None:
+                task = asyncio.create_task(self.login())
+                self._authentication_task = task
+                task.add_done_callback(self._authentication_task_done)
+            await asyncio.shield(task)
+
+    def _authentication_task_done(self, task: asyncio.Task[LoginResponse]) -> None:
+        """Clear a completed shared login and consume an unobserved failure."""
+        if self._authentication_task is task:
+            self._authentication_task = None
+        if not task.cancelled():
+            task.exception()
 
     @property
     def is_installer_role(self) -> bool:

--- a/tests/unit/test_client_aioresponses.py
+++ b/tests/unit/test_client_aioresponses.py
@@ -5,7 +5,9 @@ This approach is faster and more reliable than using TestServer.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
+from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
@@ -440,6 +442,171 @@ class TestErrorHandling:
 
 class TestSessionManagement:
     """Test session management."""
+
+    @pytest.mark.asyncio
+    async def test_expired_session_authentication_is_single_flight(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Concurrent expired-session checks share one login attempt."""
+        client = LuxpowerClient("testuser", "testpass")
+        client._session_expires = datetime.now() - timedelta(seconds=1)
+        start = asyncio.Event()
+        login_started = asyncio.Event()
+        release_login = asyncio.Event()
+        login_calls = 0
+
+        async def fake_login(_retry_count: int = 0) -> None:
+            nonlocal login_calls
+            login_calls += 1
+            login_started.set()
+            await release_login.wait()
+            client._session_expires = datetime.now() + timedelta(hours=2)
+
+        async def authenticate_after_start() -> None:
+            await start.wait()
+            await client._ensure_authenticated()
+
+        monkeypatch.setattr(client, "login", fake_login)
+        tasks = [asyncio.create_task(authenticate_after_start()) for _ in range(10)]
+        start.set()
+        await asyncio.wait_for(login_started.wait(), timeout=1)
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        try:
+            assert login_calls == 1
+        finally:
+            release_login.set()
+            await asyncio.gather(*tasks)
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_waiter_does_not_cancel_shared_authentication(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cancelling one waiter leaves the shared login running for others."""
+        client = LuxpowerClient("testuser", "testpass")
+        client._session_expires = datetime.now() - timedelta(seconds=1)
+        login_started = asyncio.Event()
+        release_login = asyncio.Event()
+        login_calls = 0
+
+        async def fake_login(_retry_count: int = 0) -> None:
+            nonlocal login_calls
+            login_calls += 1
+            login_started.set()
+            await release_login.wait()
+            client._session_expires = datetime.now() + timedelta(hours=2)
+
+        monkeypatch.setattr(client, "login", fake_login)
+        cancelled_waiter = asyncio.create_task(client._ensure_authenticated())
+        await asyncio.wait_for(login_started.wait(), timeout=1)
+        surviving_waiter = asyncio.create_task(client._ensure_authenticated())
+        await asyncio.sleep(0)
+
+        try:
+            cancelled_waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await cancelled_waiter
+            release_login.set()
+            await surviving_waiter
+            assert login_calls == 1
+        finally:
+            release_login.set()
+            for task in (cancelled_waiter, surviving_waiter):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(cancelled_waiter, surviving_waiter, return_exceptions=True)
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_failed_authentication_is_shared_and_later_call_retries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Waiters share one failure, while a later caller starts a new login."""
+        client = LuxpowerClient("testuser", "testpass")
+        client._session_expires = datetime.now() - timedelta(seconds=1)
+        start = asyncio.Event()
+        login_started = asyncio.Event()
+        release_login = asyncio.Event()
+        first_error = LuxpowerConnectionError("renewal failed")
+        login_calls = 0
+
+        async def fake_login(_retry_count: int = 0) -> None:
+            nonlocal login_calls
+            login_calls += 1
+            if login_calls == 1:
+                login_started.set()
+                await release_login.wait()
+                raise first_error
+            client._session_expires = datetime.now() + timedelta(hours=2)
+
+        async def authenticate_after_start() -> None:
+            await start.wait()
+            await client._ensure_authenticated()
+
+        monkeypatch.setattr(client, "login", fake_login)
+        tasks = [asyncio.create_task(authenticate_after_start()) for _ in range(10)]
+        start.set()
+        await asyncio.wait_for(login_started.wait(), timeout=1)
+        for _ in range(3):
+            await asyncio.sleep(0)
+        release_login.set()
+
+        try:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            assert login_calls == 1
+            assert all(result is first_error for result in results)
+
+            await client._ensure_authenticated()
+            assert login_calls == 2
+        finally:
+            release_login.set()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_only_waiter_does_not_pin_failed_authentication(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A background login failure is cleared even after its waiter cancels."""
+        client = LuxpowerClient("testuser", "testpass")
+        client._session_expires = datetime.now() - timedelta(seconds=1)
+        login_started = asyncio.Event()
+        release_login = asyncio.Event()
+        login_finished = asyncio.Event()
+        first_error = LuxpowerConnectionError("renewal failed after cancellation")
+        login_calls = 0
+
+        async def fake_login(_retry_count: int = 0) -> None:
+            nonlocal login_calls
+            login_calls += 1
+            if login_calls == 1:
+                login_started.set()
+                try:
+                    await release_login.wait()
+                    raise first_error
+                finally:
+                    login_finished.set()
+            client._session_expires = datetime.now() + timedelta(hours=2)
+
+        monkeypatch.setattr(client, "login", fake_login)
+        waiter = asyncio.create_task(client._ensure_authenticated())
+        await asyncio.wait_for(login_started.wait(), timeout=1)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        release_login.set()
+        await asyncio.wait_for(login_finished.wait(), timeout=1)
+        await asyncio.sleep(0)
+
+        try:
+            await client._ensure_authenticated()
+            assert login_calls == 2
+        finally:
+            release_login.set()
+            await client.close()
 
     @pytest.mark.asyncio
     async def test_session_creation(

--- a/tests/unit/test_client_aioresponses.py
+++ b/tests/unit/test_client_aioresponses.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from typing import Any
 
+import aiohttp
 import pytest
 from aioresponses import aioresponses
 
@@ -20,6 +22,99 @@ from pylxpweb.exceptions import LuxpowerConnectionError
 
 # Base URL for all tests
 BASE_URL = "https://monitor.eg4electronics.com"
+
+
+class _ReactiveAuthResponse:
+    """Minimal response context used to stage concurrent stale sessions."""
+
+    def __init__(
+        self,
+        session: _ConcurrentReactiveSession,
+        *,
+        stale: bool,
+        stale_index: int | None,
+    ) -> None:
+        self._session = session
+        self._stale = stale
+        self._stale_index = stale_index
+        self.status = 401 if stale and session.response_kind == "401" else 200
+
+    async def __aenter__(self) -> _ReactiveAuthResponse:
+        if self._stale:
+            self._session.stale_requests_started += 1
+            if self._session.stale_requests_started == self._session.expected_stale_requests:
+                self._session.all_stale_requests_started.set()
+
+            await self._session.all_stale_requests_started.wait()
+            if self._stale_index is not None and self._stale_index >= self._session.early_count:
+                await self._session.release_late_stale_responses.wait()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        if self._stale and self._session.response_kind == "401":
+            raise aiohttp.ClientResponseError(
+                SimpleNamespace(real_url="https://example.test/stale"),
+                (),
+                status=401,
+                message="expired session",
+            )
+
+    async def json(self) -> dict[str, Any]:
+        if self._stale:
+            if self._session.response_kind == "html":
+                raise aiohttp.ContentTypeError(
+                    SimpleNamespace(real_url="https://example.test/stale"),
+                    (),
+                    status=200,
+                    message="unexpected text/html response",
+                )
+            raise AssertionError("401 response should fail before JSON decoding")
+
+        return {
+            "success": True,
+            "cookie_generation": self._session.cookie_generation,
+        }
+
+
+class _ConcurrentReactiveSession:
+    """Injected session whose initial requests all use one stale cookie."""
+
+    def __init__(
+        self,
+        response_kind: str,
+        *,
+        expected_stale_requests: int,
+        early_count: int,
+    ) -> None:
+        self.response_kind = response_kind
+        self.expected_stale_requests = expected_stale_requests
+        self.early_count = early_count
+        self.closed = False
+        self.cookie_generation = 0
+        self.cookie_mutations = 0
+        self.stale_requests_started = 0
+        self.all_stale_requests_started = asyncio.Event()
+        self.release_late_stale_responses = asyncio.Event()
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        data: dict[str, Any] | None,
+        headers: dict[str, str],
+    ) -> _ReactiveAuthResponse:
+        stale = self.cookie_generation == 0
+        stale_index = self.stale_requests_started if stale else None
+        return _ReactiveAuthResponse(self, stale=stale, stale_index=stale_index)
 
 
 class TestAuthentication:
@@ -607,6 +702,175 @@ class TestSessionManagement:
         finally:
             release_login.set()
             await client.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("response_kind", ["401", "html"])
+    async def test_concurrent_reactive_expiry_uses_one_cookie_renewal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        response_kind: str,
+    ) -> None:
+        """Stale responses share renewal, including responses observed after it."""
+        request_count = 10
+        session = _ConcurrentReactiveSession(
+            response_kind,
+            expected_stale_requests=request_count,
+            early_count=request_count // 2,
+        )
+        client = LuxpowerClient(
+            "testuser",
+            "testpass",
+            session=session,  # type: ignore[arg-type]
+        )
+        client._session_expires = datetime.now() + timedelta(hours=1)
+        client._backoff_config.update({"base_delay": 0.0, "max_delay": 0.0, "jitter": 0.0})
+        login_started = asyncio.Event()
+        release_login = asyncio.Event()
+        cookie_mutated = asyncio.Event()
+        login_calls = 0
+
+        async def fake_login(_retry_count: int = 0) -> None:
+            nonlocal login_calls
+            login_calls += 1
+            login_started.set()
+            await release_login.wait()
+            session.cookie_generation += 1
+            session.cookie_mutations += 1
+            client._session_expires = datetime.now() + timedelta(hours=2)
+            cookie_mutated.set()
+
+        monkeypatch.setattr(client, "login", fake_login)
+        requests = [
+            asyncio.create_task(client._request("POST", f"/test/{index}"))
+            for index in range(request_count)
+        ]
+
+        try:
+            await asyncio.wait_for(session.all_stale_requests_started.wait(), timeout=1)
+            await asyncio.wait_for(login_started.wait(), timeout=1)
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert login_calls == 1
+
+            release_login.set()
+            await asyncio.wait_for(cookie_mutated.wait(), timeout=1)
+            for _ in range(3):
+                await asyncio.sleep(0)
+            session.release_late_stale_responses.set()
+
+            results = await asyncio.wait_for(asyncio.gather(*requests), timeout=1)
+            assert all(result["success"] is True for result in results)
+            assert all(result["cookie_generation"] == 1 for result in results)
+            assert login_calls == 1
+            assert session.cookie_mutations == 1
+        finally:
+            release_login.set()
+            session.release_late_stale_responses.set()
+            for request in requests:
+                if not request.done():
+                    request.cancel()
+            await asyncio.gather(*requests, return_exceptions=True)
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_proactive_and_reactive_expiry_share_one_renewal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reactive 401 joins a proactive expired-session renewal."""
+        session = _ConcurrentReactiveSession(
+            "401",
+            expected_stale_requests=1,
+            early_count=1,
+        )
+        client = LuxpowerClient(
+            "testuser",
+            "testpass",
+            session=session,  # type: ignore[arg-type]
+        )
+        client._session_expires = datetime.now() - timedelta(seconds=1)
+        client._backoff_config.update({"base_delay": 0.0, "max_delay": 0.0, "jitter": 0.0})
+        login_started = asyncio.Event()
+        release_login = asyncio.Event()
+        login_calls = 0
+
+        async def fake_login(_retry_count: int = 0) -> None:
+            nonlocal login_calls
+            login_calls += 1
+            login_started.set()
+            await release_login.wait()
+            session.cookie_generation += 1
+            session.cookie_mutations += 1
+            client._session_expires = datetime.now() + timedelta(hours=2)
+
+        monkeypatch.setattr(client, "login", fake_login)
+        proactive = asyncio.create_task(client._ensure_authenticated())
+        await asyncio.wait_for(login_started.wait(), timeout=1)
+        reactive = asyncio.create_task(client._request("POST", "/test/reactive"))
+
+        try:
+            await asyncio.wait_for(session.all_stale_requests_started.wait(), timeout=1)
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert login_calls == 1
+
+            release_login.set()
+            await asyncio.wait_for(asyncio.gather(proactive, reactive), timeout=1)
+            assert login_calls == 1
+            assert session.cookie_mutations == 1
+        finally:
+            release_login.set()
+            session.release_late_stale_responses.set()
+            for task in (proactive, reactive):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(proactive, reactive, return_exceptions=True)
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_close_cancels_owned_auth_task_with_injected_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Closing always drains client-owned auth work, not the injected session."""
+        auth_started = asyncio.Event()
+        auth_finished = asyncio.Event()
+        never_release = asyncio.Event()
+
+        async with aiohttp.ClientSession() as injected_session:
+            client = LuxpowerClient(
+                "testuser",
+                "testpass",
+                session=injected_session,
+            )
+            client._session_expires = datetime.now() - timedelta(seconds=1)
+
+            async def fake_login(_retry_count: int = 0) -> None:
+                auth_started.set()
+                try:
+                    await never_release.wait()
+                finally:
+                    auth_finished.set()
+
+            monkeypatch.setattr(client, "login", fake_login)
+            waiter = asyncio.create_task(client._ensure_authenticated())
+            await asyncio.wait_for(auth_started.wait(), timeout=1)
+            owned_auth_task = client._authentication_task
+            assert owned_auth_task is not None
+
+            try:
+                await client.close()
+
+                assert auth_finished.is_set()
+                assert owned_auth_task.done()
+                assert owned_auth_task.cancelled()
+                assert client._authentication_task is None
+                assert not injected_session.closed
+            finally:
+                never_release.set()
+                if not owned_auth_task.done():
+                    owned_auth_task.cancel()
+                if not waiter.done():
+                    waiter.cancel()
+                await asyncio.gather(owned_auth_task, waiter, return_exceptions=True)
 
     @pytest.mark.asyncio
     async def test_session_creation(

--- a/tests/unit/test_client_aioresponses.py
+++ b/tests/unit/test_client_aioresponses.py
@@ -16,7 +16,7 @@ import pytest
 from aioresponses import aioresponses
 
 from pylxpweb import LuxpowerClient
-from pylxpweb.exceptions import LuxpowerConnectionError
+from pylxpweb.exceptions import LuxpowerAuthError, LuxpowerConnectionError
 
 # Import fixtures
 
@@ -93,13 +93,16 @@ class _ConcurrentReactiveSession:
         *,
         expected_stale_requests: int,
         early_count: int,
+        persistent_rejection: bool = False,
     ) -> None:
         self.response_kind = response_kind
         self.expected_stale_requests = expected_stale_requests
         self.early_count = early_count
+        self.persistent_rejection = persistent_rejection
         self.closed = False
         self.cookie_generation = 0
         self.cookie_mutations = 0
+        self.request_count = 0
         self.stale_requests_started = 0
         self.all_stale_requests_started = asyncio.Event()
         self.release_late_stale_responses = asyncio.Event()
@@ -112,9 +115,170 @@ class _ConcurrentReactiveSession:
         data: dict[str, Any] | None,
         headers: dict[str, str],
     ) -> _ReactiveAuthResponse:
-        stale = self.cookie_generation == 0
+        self.request_count += 1
+        stale = self.cookie_generation == 0 or self.persistent_rejection
         stale_index = self.stale_requests_started if stale else None
         return _ReactiveAuthResponse(self, stale=stale, stale_index=stale_index)
+
+
+class _LoginResponseContext:
+    """Login response whose completion can be staged by a fake session."""
+
+    status = 200
+
+    def __init__(self, session: _AuthLifecycleSession) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> _LoginResponseContext:
+        self._session.login_started.set()
+        await self._session.release_login.wait()
+        self._session.cookie_generation += 1
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._session.login_response
+
+
+class _ProtectedResponseContext:
+    """Protected response tagged with the cookie used to start it."""
+
+    def __init__(self, session: _AuthLifecycleSession, cookie_generation: int) -> None:
+        self._session = session
+        self._cookie_generation = cookie_generation
+        self.status = 401 if cookie_generation == 0 else 200
+
+    async def __aenter__(self) -> _ProtectedResponseContext:
+        if self._cookie_generation == 0:
+            self._session.stale_request_started.set()
+            await self._session.release_stale_response.wait()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        if self._cookie_generation == 0:
+            raise aiohttp.ClientResponseError(
+                SimpleNamespace(real_url="https://example.test/protected"),
+                (),
+                status=401,
+                message="expired session",
+            )
+
+    async def json(self) -> dict[str, Any]:
+        return {
+            "success": True,
+            "cookie_generation": self._cookie_generation,
+        }
+
+
+class _AuthLifecycleSession:
+    """Endpoint-aware session for direct-login and close lifecycle tests."""
+
+    def __init__(self, login_response: dict[str, Any]) -> None:
+        self.login_response = login_response
+        self.closed = False
+        self.cookie_generation = 0
+        self.login_requests = 0
+        self.protected_requests = 0
+        self.login_started = asyncio.Event()
+        self.release_login = asyncio.Event()
+        self.stale_request_started = asyncio.Event()
+        self.release_stale_response = asyncio.Event()
+        self.close_started = asyncio.Event()
+        self.release_close = asyncio.Event()
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        data: dict[str, Any] | None,
+        headers: dict[str, str],
+    ) -> _LoginResponseContext | _ProtectedResponseContext:
+        if url.endswith("/WManage/api/login"):
+            self.login_requests += 1
+            return _LoginResponseContext(self)
+
+        self.protected_requests += 1
+        return _ProtectedResponseContext(self, self.cookie_generation)
+
+    async def close(self) -> None:
+        self.close_started.set()
+        await self.release_close.wait()
+        self.closed = True
+
+
+class _RejectedLoginResponse:
+    """Login endpoint response that is always rejected."""
+
+    def __init__(self, response_kind: str) -> None:
+        self._response_kind = response_kind
+        self.status = 401 if response_kind == "401" else 200
+
+    async def __aenter__(self) -> _RejectedLoginResponse:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        if self._response_kind == "401":
+            raise aiohttp.ClientResponseError(
+                SimpleNamespace(real_url="https://example.test/login"),
+                (),
+                status=401,
+                message="login rejected",
+            )
+
+    async def json(self) -> dict[str, Any]:
+        raise aiohttp.ContentTypeError(
+            SimpleNamespace(real_url="https://example.test/login"),
+            (),
+            status=200,
+            message="unexpected text/html response",
+        )
+
+
+class _RejectedLoginSession:
+    """Injected session that counts rejected login requests."""
+
+    def __init__(self, response_kind: str) -> None:
+        self.response_kind = response_kind
+        self.closed = False
+        self.request_count = 0
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        data: dict[str, Any] | None,
+        headers: dict[str, str],
+    ) -> _RejectedLoginResponse:
+        self.request_count += 1
+        return _RejectedLoginResponse(self.response_kind)
 
 
 class TestAuthentication:
@@ -539,6 +703,81 @@ class TestSessionManagement:
     """Test session management."""
 
     @pytest.mark.asyncio
+    async def test_concurrent_direct_login_is_single_flight_and_advances_generation_once(
+        self, login_response: dict[str, Any]
+    ) -> None:
+        """Public login callers share one request and one generation advance."""
+        session = _AuthLifecycleSession(login_response)
+        client = LuxpowerClient(
+            "testuser",
+            "testpass",
+            session=session,  # type: ignore[arg-type]
+        )
+        client._account_level = "owner"
+        start = asyncio.Event()
+
+        async def login_after_start() -> Any:
+            await start.wait()
+            return await client.login()
+
+        callers = [asyncio.create_task(login_after_start()) for _ in range(10)]
+        start.set()
+        await asyncio.wait_for(session.login_started.wait(), timeout=1)
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        try:
+            session.release_login.set()
+            results = await asyncio.wait_for(asyncio.gather(*callers), timeout=1)
+
+            assert session.login_requests == 1
+            assert client._authentication_generation == 1
+            assert all(result is results[0] for result in results)
+        finally:
+            session.release_login.set()
+            for caller in callers:
+                if not caller.done():
+                    caller.cancel()
+            await asyncio.gather(*callers, return_exceptions=True)
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_direct_login_generation_suppresses_late_stale_response_renewal(
+        self, login_response: dict[str, Any]
+    ) -> None:
+        """A delayed response sent before direct login replays without another login."""
+        session = _AuthLifecycleSession(login_response)
+        client = LuxpowerClient(
+            "testuser",
+            "testpass",
+            session=session,  # type: ignore[arg-type]
+        )
+        client._account_level = "owner"
+        client._session_expires = datetime.now() + timedelta(hours=1)
+        client._backoff_config.update({"base_delay": 0.0, "max_delay": 0.0, "jitter": 0.0})
+        session.release_login.set()
+        stale_request = asyncio.create_task(client._request("POST", "/protected"))
+
+        try:
+            await asyncio.wait_for(session.stale_request_started.wait(), timeout=1)
+            await client.login()
+            assert client._authentication_generation == 1
+
+            session.release_stale_response.set()
+            result = await asyncio.wait_for(stale_request, timeout=1)
+
+            assert result["cookie_generation"] == 1
+            assert session.login_requests == 1
+            assert session.protected_requests == 2
+        finally:
+            session.release_login.set()
+            session.release_stale_response.set()
+            if not stale_request.done():
+                stale_request.cancel()
+            await asyncio.gather(stale_request, return_exceptions=True)
+            await client.close()
+
+    @pytest.mark.asyncio
     async def test_expired_session_authentication_is_single_flight(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -773,6 +1012,80 @@ class TestSessionManagement:
             await client.close()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("response_kind", ["401", "html"])
+    async def test_persistent_reactive_rejection_has_one_replay(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        response_kind: str,
+    ) -> None:
+        """A successful renewal permits only one replay of the original request."""
+        session = _ConcurrentReactiveSession(
+            response_kind,
+            expected_stale_requests=1,
+            early_count=10,
+            persistent_rejection=True,
+        )
+        client = LuxpowerClient(
+            "testuser",
+            "testpass",
+            session=session,  # type: ignore[arg-type]
+        )
+        client._session_expires = datetime.now() + timedelta(hours=1)
+        client._backoff_config.update({"base_delay": 0.0, "max_delay": 0.0, "jitter": 0.0})
+        login_calls = 0
+
+        async def fake_login(_retry_count: int = 0) -> None:
+            nonlocal login_calls
+            login_calls += 1
+            if login_calls > 1:
+                raise AssertionError("a persistent rejection started a second renewal")
+            session.cookie_generation += 1
+            client._session_expires = datetime.now() + timedelta(hours=2)
+
+        monkeypatch.setattr(client, "login", fake_login)
+
+        try:
+            with pytest.raises(
+                LuxpowerAuthError,
+                match="remained unauthorized after re-authentication",
+            ):
+                await asyncio.wait_for(client._request("POST", "/always-rejected"), timeout=1)
+
+            assert login_calls == 1
+            assert session.request_count == 2
+        finally:
+            session.release_late_stale_responses.set()
+            await client.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("response_kind", ["401", "html"])
+    async def test_login_endpoint_rejection_does_not_reenter_authentication(
+        self, response_kind: str
+    ) -> None:
+        """A rejected raw login fails without creating or awaiting itself."""
+        session = _RejectedLoginSession(response_kind)
+        client = LuxpowerClient(
+            "testuser",
+            "testpass",
+            session=session,  # type: ignore[arg-type]
+        )
+        client._backoff_config.update({"base_delay": 0.0, "max_delay": 0.0, "jitter": 0.0})
+
+        try:
+            with pytest.raises(
+                LuxpowerAuthError,
+                match="Session was rejected while authentication was in progress",
+            ):
+                await asyncio.wait_for(client.login(), timeout=1)
+            await asyncio.sleep(0)
+
+            assert session.request_count == 1
+            assert client._authentication_task is None
+            assert client._authentication_generation == 0
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
     async def test_proactive_and_reactive_expiry_share_one_renewal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -871,6 +1184,144 @@ class TestSessionManagement:
                 if not waiter.done():
                     waiter.cancel()
                 await asyncio.gather(owned_auth_task, waiter, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_close_rejects_renewal_while_auth_cancellation_is_draining(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A competing renewal cannot join or replace auth while close drains it."""
+        auth_started = asyncio.Event()
+        cancellation_cleanup_started = asyncio.Event()
+        release_cancellation_cleanup = asyncio.Event()
+        never_release = asyncio.Event()
+        login_calls = 0
+
+        async with aiohttp.ClientSession() as injected_session:
+            client = LuxpowerClient(
+                "testuser",
+                "testpass",
+                session=injected_session,
+            )
+            client._session_expires = datetime.now() - timedelta(seconds=1)
+
+            async def fake_login(_retry_count: int = 0) -> None:
+                nonlocal login_calls
+                login_calls += 1
+                auth_started.set()
+                try:
+                    await never_release.wait()
+                except asyncio.CancelledError:
+                    cancellation_cleanup_started.set()
+                    await release_cancellation_cleanup.wait()
+                    raise
+
+            monkeypatch.setattr(client, "login", fake_login)
+            original_waiter = asyncio.create_task(client._ensure_authenticated())
+            await asyncio.wait_for(auth_started.wait(), timeout=1)
+            original_auth_task = client._authentication_task
+            assert original_auth_task is not None
+
+            closing = asyncio.create_task(client.close())
+            await asyncio.wait_for(cancellation_cleanup_started.wait(), timeout=1)
+            competing_renewal = asyncio.create_task(client._ensure_authenticated())
+
+            try:
+                for _ in range(3):
+                    await asyncio.sleep(0)
+                assert competing_renewal.done()
+                assert not closing.done()
+                assert client._authentication_task is original_auth_task
+                assert login_calls == 1
+                with pytest.raises(LuxpowerConnectionError, match="closing"):
+                    await competing_renewal
+
+                release_cancellation_cleanup.set()
+                await asyncio.wait_for(closing, timeout=1)
+                assert client._authentication_task is None
+                assert not injected_session.closed
+            finally:
+                never_release.set()
+                release_cancellation_cleanup.set()
+                for task in (original_auth_task, original_waiter, competing_renewal, closing):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(
+                    original_auth_task,
+                    original_waiter,
+                    competing_renewal,
+                    closing,
+                    return_exceptions=True,
+                )
+
+    @pytest.mark.asyncio
+    async def test_close_rejects_renewal_started_during_owned_session_close(
+        self, login_response: dict[str, Any]
+    ) -> None:
+        """No authentication task or HTTP request can start while close awaits."""
+        session = _AuthLifecycleSession(login_response)
+        session.release_login.set()
+        client = LuxpowerClient(
+            "testuser",
+            "testpass",
+            session=session,  # type: ignore[arg-type]
+        )
+        client._owns_session = True
+        client._account_level = "owner"
+        client._session_expires = datetime.now() - timedelta(seconds=1)
+        closing = asyncio.create_task(client.close())
+        await asyncio.wait_for(session.close_started.wait(), timeout=1)
+        renewal = asyncio.create_task(client._ensure_authenticated())
+
+        try:
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert session.login_requests == 0
+            with pytest.raises(LuxpowerConnectionError, match="closing"):
+                await asyncio.wait_for(renewal, timeout=1)
+
+            session.release_close.set()
+            await asyncio.wait_for(closing, timeout=1)
+            assert client._authentication_task is None
+            assert session.closed
+        finally:
+            session.release_login.set()
+            session.release_close.set()
+            for task in (renewal, closing):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(renewal, closing, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent_and_owned_client_is_reusable(
+        self,
+        mocked_api: aioresponses,
+        login_response: dict[str, Any],
+    ) -> None:
+        """Close is idempotent, and a later login may recreate an owned session."""
+        mocked_api.post(f"{BASE_URL}/WManage/api/login", payload=login_response)
+        mocked_api.post(f"{BASE_URL}/WManage/api/login", payload=login_response)
+        client = LuxpowerClient("testuser", "testpass")
+        client._account_level = "owner"
+
+        try:
+            await client.login()
+            first_session = client._session
+            assert first_session is not None
+            assert client._authentication_generation == 1
+
+            await client.close()
+            await client.close()
+            assert first_session.closed
+
+            await client.login()
+            second_session = client._session
+            assert second_session is not None
+            assert second_session is not first_session
+            assert not second_session.closed
+            assert client._authentication_generation == 2
+        finally:
+            await client.close()
+            await client.close()
 
     @pytest.mark.asyncio
     async def test_session_creation(


### PR DESCRIPTION
## Summary

- route public `login()`, context-manager entry, proactive expiry, reactive HTTP 401, and reactive HTML-login-page recovery through one client-owned authentication task
- tag HTTP attempts with an authentication generation so late responses sent with an old cookie replay with the current cookie instead of opening another login
- bound each original request chain to one reactive replay without changing `_request()`'s signature
- make `close()` exclude new authentication during both auth-task drain and owned-session close, while preserving injected-session ownership and post-close client reuse

## RCA

The original implementation let every expired-session caller invoke `login()` independently. The first version of this PR coalesced proactive `_ensure_authenticated()` calls, but reactive 401/HTML recovery and direct public `login()` still bypassed the shared task. Direct callers include `LuxpowerClient.__aenter__()` and `HTTPTransport.connect()`, so concurrent transport connects could still herd and mutate the cookie independently. Direct successes also did not advance the generation used to classify late stale responses.

A task pointer alone leaves a smaller ordering race: a slow response can report failure after the first shared login has completed and its pointer has cleared. Every HTTP attempt therefore records the authentication generation used to start it. All successful base-client login paths now advance that generation exactly once.

Reactive recovery recursively replayed `_request()` with only the unrelated transient-API retry counter. If a protected endpoint continued returning 401 or HTML after a successful login, the client could submit credentials and recurse indefinitely. A task-local replay marker now permits one replay for the original request chain and then raises `LuxpowerAuthError`; `_request()` retains its existing signature for downstream wrappers.

Finally, `close()` previously snapshotted one auth task. A replacement renewal could begin while close awaited cancellation cleanup or an owned `ClientSession.close()`, outliving shutdown or reopening a session. Close now serializes concurrent closes, exposes a transient closing phase that rejects new authentication, cancels and drains the original task, and only then closes an owned HTTP session.

## Concurrency and lifecycle contracts

- base-client public login, proactive expiry, and reactive 401/HTML recovery share exactly one in-flight login
- every successful shared login advances authentication generation once; late stale responses replay with the newer cookie
- one individual request chain gets at most one reactive replay after renewal
- cancellation of an individual waiter remains isolated by `asyncio.shield()`
- concurrent waiters receive the same login result or failure, and a later caller can retry after failure
- login-endpoint 401/HTML rejection fails from inside the active auth task without self-await or recursive login
- close rejects authentication begun during auth cancellation cleanup or owned-session close, drains the snapshotted task, and is idempotent
- close never closes an injected session
- after close returns, the client remains reusable: a later login recreates an owned session or reuses an injected one

## Verification

- TDD RED: direct login produced 10 requests and zero generation advances; delayed stale responses opened a second login; persistent 401/HTML opened a second renewal; rejected login endpoints made two requests; owned-session close admitted a new login
- deterministic lifecycle additions: 9 cases covering direct herd/generation, persistent 401 and HTML bounds, login-endpoint 401 and HTML self-await, auth-drain and owned-session-close interleavings, idempotence, and reuse
- full client module: 32 passed
- full unit/coverage gate: 3,085 passed; 88.72% coverage
- Ruff lint and format: 214 files clean
- strict mypy: 94 source files clean
- all non-mypy `prek` hooks passed; the strict mypy command passed directly

Live integration tests are left to the PR workflow so local verification does not contact real hardware.

## Repository note

The repository's tracked `uv.lock` identifies the editable package as `0.9.39b5` while `pyproject.toml` identifies it as `0.9.39b6`. The isolated `uv run mypy` hook regenerates that unrelated lockfile line even though mypy succeeds. The generated correction was restored and excluded from this PR; strict mypy was run directly before committing, and the redundant commit-time mypy hook was skipped.

## Tracking

- bead: `eg4-bl9f`
