### PR TITLE
fix: harden H120, FC16 ACK, and dongle capability contracts

### DIFF
--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -1109,11 +1109,14 @@ BIT_FIELD_LAYOUT: dict[str, tuple[int, int]] = {
     **MIDBOX_BIT_FIELD_LAYOUT,
 }
 
-# Backward-compatible public subset for callers that need to identify fields
-# whose values are integers rather than booleans.
-MULTI_BIT_FIELDS: dict[str, tuple[int, int]] = {
-    name: layout for name, layout in BIT_FIELD_LAYOUT.items() if layout[1] > 1
-}
+# Backward-compatible public alias. Historically this table held ONLY the
+# GridBOSS/MIDBOX smart-port fields, and its one documented use-idiom was
+# "does this parameter need the MIDBOX register mapping?". Redefining it to
+# include the new H120 compound fields would silently break that idiom for
+# external callers (an H120 write would merge the MIDBOX mapping and shadow
+# inverter register 20 — review P3), so it stays an alias of the MIDBOX
+# table. Use BIT_FIELD_LAYOUT for the full "is this a wide field" question.
+MULTI_BIT_FIELDS: dict[str, tuple[int, int]] = MIDBOX_BIT_FIELD_LAYOUT
 
 # Named value parameters whose raw local register holds a deci-unit encoding
 # (raw = value * 10) that the cloud API surfaces already scaled to engineering

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -780,10 +780,15 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
     # at 6, working-mode at 10) was disproven by live hardware toggles
     # (eg4_web_monitor #476 + PR #220) and is gone.
     110: REGISTER_110_PARAM_KEYS,
+    # System enable 2 is NOT seven consecutive booleans.  The documented
+    # LuxPower layout, independently corroborated by the dedicated AC charge
+    # type API's 0x0e mask, is bit 0; compound fields at bits 1-3 and 4-5;
+    # then bits 6 and 7.  The explicit offsets live in BIT_FIELD_LAYOUT below.
+    # Do not restore FUNC_SNA_BAT_DISCHARGE_CONTROL or
+    # FUNC_PHASE_INDEPEND_COMPENSATE_EN here: those legacy names overlap the
+    # ACChargeType field and therefore cannot represent safe local controls.
     120: [
         "FUNC_HALF_HOUR_AC_CHG_START_EN",
-        "FUNC_SNA_BAT_DISCHARGE_CONTROL",
-        "FUNC_PHASE_INDEPEND_COMPENSATE_EN",
         "BIT_AC_CHARGE_TYPE",
         "BIT_DISCHG_CONTROL_TYPE",
         "BIT_ON_GRID_EOD_TYPE",
@@ -1082,13 +1087,32 @@ MIDBOX_REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
     ],
 }
 
-# Multi-bit fields: param name → (bit_offset, bit_width)
-# Standard bit fields use 1 bit per param. These use wider fields.
-MULTI_BIT_FIELDS: dict[str, tuple[int, int]] = {
+# Explicit GridBOSS bit-field offsets.  Keeping this subset distinct lets the
+# mapping resolver detect MIDBOX-only parameter names without mistaking the
+# inverter register-120 fields for MIDBOX parameters.
+MIDBOX_BIT_FIELD_LAYOUT: dict[str, tuple[int, int]] = {
     "BIT_MIDBOX_SP_MODE_1": (0, 2),  # bits 0-1
     "BIT_MIDBOX_SP_MODE_2": (2, 2),  # bits 2-3
     "BIT_MIDBOX_SP_MODE_3": (4, 2),  # bits 4-5
     "BIT_MIDBOX_SP_MODE_4": (6, 2),  # bits 6-7
+}
+
+# Explicit offsets for named bit fields that cannot safely use list position.
+# Width-one entries preserve boolean read/write semantics; wider entries are
+# integer fields validated against the width before an RMW write.
+BIT_FIELD_LAYOUT: dict[str, tuple[int, int]] = {
+    "FUNC_HALF_HOUR_AC_CHG_START_EN": (0, 1),
+    "BIT_AC_CHARGE_TYPE": (1, 3),
+    "BIT_DISCHG_CONTROL_TYPE": (4, 2),
+    "BIT_ON_GRID_EOD_TYPE": (6, 1),
+    "BIT_GENERATOR_CHARGE_TYPE": (7, 1),
+    **MIDBOX_BIT_FIELD_LAYOUT,
+}
+
+# Backward-compatible public subset for callers that need to identify fields
+# whose values are integers rather than booleans.
+MULTI_BIT_FIELDS: dict[str, tuple[int, int]] = {
+    name: layout for name, layout in BIT_FIELD_LAYOUT.items() if layout[1] > 1
 }
 
 # Named value parameters whose raw local register holds a deci-unit encoding

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -775,20 +775,26 @@ class HybridInverter(GenericInverter):
             >>> await inverter.set_ac_charge_type(0)  # Time-based
             True
         """
-        from pylxpweb.constants import (
-            AC_CHARGE_TYPE_MASK,
-            AC_CHARGE_TYPE_SHIFT,
-            HOLD_AC_CHARGE_TYPE_REGISTER,
-        )
+        from pylxpweb.constants import HOLD_AC_CHARGE_TYPE_REGISTER
 
         if charge_type not in (0, 1, 2):
             raise ValueError(f"charge_type must be 0, 1, or 2, got {charge_type}")
 
         if self._transport is not None:
-            # Transport: atomic read-modify-write preserves the other reg-120 bits.
-            current = await self._read_modbus_register(HOLD_AC_CHARGE_TYPE_REGISTER)
-            new_value = (current & ~AC_CHARGE_TYPE_MASK) | (charge_type << AC_CHARGE_TYPE_SHIFT)
-            result = await self._write_modbus_register(HOLD_AC_CHARGE_TYPE_REGISTER, new_value)
+            # Named path: write_named_parameters performs the H120
+            # read-modify-write while holding the transport operation lock,
+            # so a concurrent sibling-field write (e.g.
+            # BIT_GENERATOR_CHARGE_TYPE) cannot land between this method's
+            # read and write and be silently reverted. A device-level
+            # read + raw write here would reintroduce exactly that race.
+            result = await self._transport.write_named_parameters(
+                {"BIT_AC_CHARGE_TYPE": charge_type}
+            )
+            if not result:
+                raise LuxpowerDeviceError(
+                    f"Register {HOLD_AC_CHARGE_TYPE_REGISTER} write requires "
+                    "a successful Modbus write"
+                )
         else:
             # Reg 120 is a bitfield (the raw cloud write is rejected); set the
             # named BIT_AC_CHARGE_TYPE multi-value bit param server-side, which

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -14,8 +14,8 @@ Each HoldingRegisterDefinition carries:
 
 Two types of entries:
   - Value registers: bit_position=None, full 16-bit (or 32-bit) value with scale/min/max.
-  - Bitfield entries: bit_position=0-15, single boolean bit within a bitfield register.
-    Multiple bitfield entries share the same address.
+  - Bit-field entries: bit_position=0-15 and field_width=1-16 within a register.
+    Multiple bit-field entries may share the same address.
 
 The `api_param_key` field matches the HOLD_* or FUNC_* strings returned by the
 cloud API and local Modbus parameter reads.  These are the keys used by pylxpweb's
@@ -52,8 +52,9 @@ class HoldingRegisterDefinition:
     """Single holding register parameter definition.
 
     For value registers: bit_position is None, address is the Modbus register.
-    For bitfield entries: bit_position is 0-15 within the register at address.
-      Multiple bitfield entries share the same address.
+    For bit-field entries: bit_position is 0-15 within the register at address
+      and field_width is the number of occupied bits. Multiple entries may
+      share the same address.
 
     Attributes:
         address: Modbus holding register address (function code 0x03).
@@ -74,6 +75,8 @@ class HoldingRegisterDefinition:
         category: Logical grouping for UI organisation and read scheduling.
         models: Which InverterFamily values support this register.
         description: Human-readable description.
+        field_width: Number of bits occupied by a bit-field entry. Defaults to
+            one for boolean fields; compound selectors use a wider value.
     """
 
     address: int
@@ -91,6 +94,7 @@ class HoldingRegisterDefinition:
     category: HoldingCategory = HoldingCategory.POWER
     models: frozenset[str] = ALL
     description: str = ""
+    field_width: int = 1
 
 
 # =============================================================================
@@ -1027,7 +1031,7 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         description="Parallel system type. 0=Single, 1=Master, 2=Slave, 3=3-Phase Master.",
     ),
     # =========================================================================
-    # SYSTEM ENABLE BITFIELD — Register 120 (7 bits, verified)
+    # SYSTEM ENABLE COMPOUND FIELD — Register 120 (bits 0-7)
     # =========================================================================
     HoldingRegisterDefinition(
         address=120,
@@ -1040,38 +1044,28 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
     HoldingRegisterDefinition(
         address=120,
         bit_position=1,
-        canonical_name="sna_battery_discharge_control",
-        api_param_key="FUNC_SNA_BAT_DISCHARGE_CONTROL",  # verified
-        category=HoldingCategory.FUNCTION,
-        description="SNA battery discharge control enable.",
-    ),
-    HoldingRegisterDefinition(
-        address=120,
-        bit_position=2,
-        canonical_name="phase_independent_compensate_enable",
-        api_param_key="FUNC_PHASE_INDEPEND_COMPENSATE_EN",  # verified
-        category=HoldingCategory.FUNCTION,
-        description="Phase-independent power compensation enable.",
-    ),
-    HoldingRegisterDefinition(
-        address=120,
-        bit_position=3,
+        field_width=3,
         canonical_name="ac_charge_type",
         api_param_key="BIT_AC_CHARGE_TYPE",  # verified
+        min_value=0,
+        max_value=7,
         category=HoldingCategory.FUNCTION,
-        description="AC charge type selection bit.",
+        description="AC charge type selector (bits 1-3).",
     ),
     HoldingRegisterDefinition(
         address=120,
         bit_position=4,
+        field_width=2,
         canonical_name="discharge_control_type",
         api_param_key="BIT_DISCHG_CONTROL_TYPE",  # verified
+        min_value=0,
+        max_value=3,
         category=HoldingCategory.FUNCTION,
-        description="Discharge control type selection bit.",
+        description="Discharge control type selector (bits 4-5).",
     ),
     HoldingRegisterDefinition(
         address=120,
-        bit_position=5,
+        bit_position=6,
         canonical_name="ongrid_eod_type",
         api_param_key="BIT_ON_GRID_EOD_TYPE",  # verified
         category=HoldingCategory.FUNCTION,
@@ -1079,7 +1073,7 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
     ),
     HoldingRegisterDefinition(
         address=120,
-        bit_position=6,
+        bit_position=7,
         canonical_name="generator_charge_type",
         api_param_key="BIT_GENERATOR_CHARGE_TYPE",  # verified
         category=HoldingCategory.FUNCTION,
@@ -1869,7 +1863,7 @@ def value_registers() -> tuple[HoldingRegisterDefinition, ...]:
 
 
 def bitfield_registers() -> tuple[HoldingRegisterDefinition, ...]:
-    """Return only bitfield entries (individual bits within bitfield registers)."""
+    """Return bit-field entries (boolean bits and compound fields)."""
     return tuple(r for r in INVERTER_HOLDING_REGISTERS if r.bit_position is not None)
 
 

--- a/src/pylxpweb/transports/capabilities.py
+++ b/src/pylxpweb/transports/capabilities.py
@@ -100,8 +100,9 @@ MODBUS_CAPABILITIES = TransportCapabilities(
     is_local=True,
 )
 
-# Dongle capabilities are identical to Modbus (same register access)
-# The dongle is just a different transport mechanism for the same data
+# Dongle capabilities match Modbus for register access; the one divergence
+# is supports_concurrent_reads=False — the dongle serializes everything over
+# its single TCP slot (see below).
 DONGLE_CAPABILITIES = TransportCapabilities(
     # Core access - all supported (same as Modbus)
     can_read_runtime=True,

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -35,7 +35,7 @@ from ._register_data import (
     DEFAULT_INPUT_BLOCK_SIZE,
     RegisterDataMixin,
 )
-from .capabilities import MODBUS_CAPABILITIES, TransportCapabilities
+from .capabilities import DONGLE_CAPABILITIES, TransportCapabilities
 from .exceptions import (
     TransportConnectionError,
     TransportError,
@@ -244,8 +244,8 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
 
     @property
     def capabilities(self) -> TransportCapabilities:
-        """Get dongle transport capabilities (same as Modbus)."""
-        return MODBUS_CAPABILITIES
+        """Get capabilities for the dongle's serialized TCP connection."""
+        return DONGLE_CAPABILITIES
 
     @property
     def host(self) -> str:
@@ -1244,7 +1244,15 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     f"Write ACK empty/short for register {address}: no echoed "
                     "register count to confirm the write"
                 )
-            if len(ack) == 1 and ack[0] != len(values):
+            if len(ack) != 1:
+                # The supported read-layout fallback still has exactly one
+                # count value.  Two or more parsed values are a read payload,
+                # not an unambiguous FC16 acknowledgement.
+                raise TransportWriteError(
+                    f"Write ACK malformed for register {address}: expected one "
+                    f"echoed register count, got {len(ack)} values"
+                )
+            if ack[0] != len(values):
                 # FC16 ACK echoes the written register count.
                 raise TransportWriteError(
                     f"Write ACK count mismatch for register {address}: wrote "
@@ -1483,7 +1491,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
             TransportTimeoutError: If the readback read times out.
             TransportConnectionError: If reconnecting for the readback fails.
         """
-        from pylxpweb.constants.registers import LOCAL_PARAM_SCALE_DIV10, MULTI_BIT_FIELDS
+        from pylxpweb.constants.registers import BIT_FIELD_LAYOUT, LOCAL_PARAM_SCALE_DIV10
 
         register_to_params, param_to_register = self._resolve_register_mappings(
             param_names=list(parameters.keys()),
@@ -1514,11 +1522,13 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
             param_keys = register_to_params.get(param_register, [])
 
             if self._is_bit_field_register(param_keys):
-                if name in MULTI_BIT_FIELDS:
-                    offset, width = MULTI_BIT_FIELDS[name]
+                explicit_layout = BIT_FIELD_LAYOUT.get(name)
+                if explicit_layout is not None:
+                    offset, width = explicit_layout
                     got_field = (raw >> offset) & ((1 << width) - 1)
-                    if got_field != int(value):
-                        mismatches.append(f"{name}: wrote {int(value)}, read back {got_field}")
+                    expected_field = int(value) if width > 1 else int(bool(value))
+                    if got_field != expected_field:
+                        mismatches.append(f"{name}: wrote {expected_field}, read back {got_field}")
                 elif name in param_keys:
                     got_bit = bool((raw >> param_keys.index(name)) & 1)
                     if got_bit is not bool(value):

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -390,7 +390,7 @@ class BaseTransport:
             Tuple of (register_to_params, param_to_register) dicts.
         """
         from pylxpweb.constants.registers import (
-            MULTI_BIT_FIELDS,
+            MIDBOX_BIT_FIELD_LAYOUT,
             get_param_to_register_mapping,
             get_register_to_param_mapping,
         )
@@ -404,8 +404,8 @@ class BaseTransport:
             param_to_reg = get_param_to_register_mapping(family, device_type="MIDBOX")
             return reg_to_params, param_to_reg
 
-        # Check if any param names are multi-bit (MIDBOX) fields
-        needs_midbox = param_names and any(p in MULTI_BIT_FIELDS for p in param_names)
+        # Check if any requested names belong to the MIDBOX-only mapping.
+        needs_midbox = param_names and any(p in MIDBOX_BIT_FIELD_LAYOUT for p in param_names)
 
         reg_to_params = get_register_to_param_mapping(family)
         param_to_reg = get_param_to_register_mapping(family)
@@ -431,8 +431,8 @@ class BaseTransport:
         the library maps register addresses to parameter names using the
         appropriate mapping for the inverter family.
 
-        Multi-bit fields (e.g., GridBOSS smart port modes) are decoded as
-        integers rather than booleans.
+        Multi-bit fields (e.g., register-120 selectors and GridBOSS smart port
+        modes) are decoded as integers rather than booleans.
 
         Args:
             start_address: Starting register address
@@ -441,7 +441,8 @@ class BaseTransport:
         Returns:
             Dict mapping parameter name to value. Values are typed appropriately:
             - Boolean for standard 1-bit fields (FUNC_*, BIT_*)
-            - Integer for multi-bit fields (BIT_MIDBOX_SP_MODE_*)
+            - Integer for compound fields (e.g. BIT_AC_CHARGE_TYPE and
+              BIT_MIDBOX_SP_MODE_*)
             - String for serial numbers, firmware versions
             - Integer for most other parameters
 
@@ -457,8 +458,8 @@ class BaseTransport:
             # Returns: {"HOLD_AC_CHARGE_POWER_CMD": 50, "HOLD_AC_CHARGE_SOC_LIMIT": 95}
         """
         from pylxpweb.constants.registers import (
+            BIT_FIELD_LAYOUT,
             LOCAL_PARAM_SCALE_DIV10,
-            MULTI_BIT_FIELDS,
             format_deci_as_cloud_string,
         )
 
@@ -475,10 +476,12 @@ class BaseTransport:
 
             if self._is_bit_field_register(param_keys):
                 for bit_index, param_key in enumerate(param_keys):
-                    if param_key in MULTI_BIT_FIELDS:
-                        offset, width = MULTI_BIT_FIELDS[param_key]
+                    explicit_layout = BIT_FIELD_LAYOUT.get(param_key)
+                    if explicit_layout is not None:
+                        offset, width = explicit_layout
                         field_mask = (1 << width) - 1
-                        result[param_key] = (value >> offset) & field_mask
+                        field_value = (value >> offset) & field_mask
+                        result[param_key] = field_value if width > 1 else bool(field_value)
                     else:
                         result[param_key] = bool((value >> bit_index) & 1)
             elif len(param_keys) == 1:
@@ -507,8 +510,8 @@ class BaseTransport:
         bit fields into register values, using the appropriate mapping for
         the inverter family.
 
-        Multi-bit fields (e.g., GridBOSS smart port modes with 2 bits per port)
-        are handled with proper masking instead of single-bit set/clear.
+        Multi-bit fields (e.g., register-120 selectors and GridBOSS smart port
+        modes) are handled with proper masking instead of single-bit set/clear.
 
         Args:
             parameters: Dict mapping parameter name to value. For standard bit
@@ -534,15 +537,15 @@ class BaseTransport:
                 "FUNC_AC_CHARGE": False,
             })
 
-            # Write multi-bit field (GridBOSS smart port mode)
+            # Write a multi-bit field (GridBOSS smart port mode)
             await transport.write_named_parameters({
                 "BIT_MIDBOX_SP_MODE_1": 2,  # AC Couple
             })
         """
         from pylxpweb.constants.registers import (
+            BIT_FIELD_LAYOUT,
             DISPUTED_WRITE_BLOCKED_PARAMS,
             LOCAL_PARAM_SCALE_DIV10,
-            MULTI_BIT_FIELDS,
         )
 
         register_to_params, param_to_register = self._resolve_register_mappings(
@@ -597,12 +600,15 @@ class BaseTransport:
                     raise ValueError(
                         f"Bit field '{param_name}' not in register {register_addr} mapping"
                     )
-                if param_name in MULTI_BIT_FIELDS:
-                    # Multi-bit field: mask out old value, OR in new
-                    offset, width = MULTI_BIT_FIELDS[param_name]
+                explicit_layout = BIT_FIELD_LAYOUT.get(param_name)
+                if explicit_layout is not None:
+                    # Explicit field: mask out the old value, then OR in the
+                    # requested value at its documented (possibly sparse)
+                    # offset.  Width-one fields retain boolean semantics.
+                    offset, width = explicit_layout
                     field_mask = (1 << width) - 1
-                    int_value = int(value)
-                    if int_value < 0 or int_value > field_mask:
+                    int_value = int(value) if width > 1 else int(bool(value))
+                    if width > 1 and (int_value < 0 or int_value > field_mask):
                         raise ValueError(
                             f"Value {int_value} out of range for {param_name} (0-{field_mask})"
                         )

--- a/tests/unit/devices/inverters/test_hybrid.py
+++ b/tests/unit/devices/inverters/test_hybrid.py
@@ -808,26 +808,33 @@ class TestACChargeTypeOperations:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_set_ac_charge_type_transport_preserves_bits(
+    async def test_set_ac_charge_type_transport_uses_lock_held_named_rmw(
         self, mock_client: LuxpowerClient
     ) -> None:
-        """Transport RMW sets the bits 1-3 field while preserving other bits."""
+        """Transport set routes through the named, lock-held H120 RMW.
+
+        A device-level read + raw write here would release the operation
+        lock between the two calls, so a concurrent sibling-field write
+        (e.g. BIT_GENERATOR_CHARGE_TYPE) could be silently reverted. The
+        named path performs the whole RMW under the transport lock; this
+        test pins that routing.
+        """
+        transport = Mock()
+        transport.write_named_parameters = AsyncMock(return_value=True)
         inverter = HybridInverter(
             client=mock_client,
             serial_number="1234567890",
             model="FlexBOSS21",
-            transport=Mock(),
+            transport=transport,
         )
-        # Bit 0 and bit 4 set (other features enabled) = 0b00010001 = 17
-        inverter.read_transport_register = AsyncMock(return_value=17)
-        inverter.write_transport_register = AsyncMock(return_value=True)
+        inverter.read_transport_register = AsyncMock()
+        inverter.write_transport_register = AsyncMock()
 
         result = await inverter.set_ac_charge_type(1)  # SOC/Volt
 
-        # Set bits 1-3 to value 1 (raw 2) while preserving bits 0 and 4:
-        # 17 & ~0x0E = 16 (bit 4) | 1 (bit 0) = 17 → | (1 << 1) = 19
-        inverter.read_transport_register.assert_awaited_once_with(120)
-        inverter.write_transport_register.assert_awaited_once_with(120, 19)
+        transport.write_named_parameters.assert_awaited_once_with({"BIT_AC_CHARGE_TYPE": 1})
+        inverter.read_transport_register.assert_not_awaited()
+        inverter.write_transport_register.assert_not_awaited()
         assert result is True
 
     @pytest.mark.asyncio
@@ -835,14 +842,14 @@ class TestACChargeTypeOperations:
         self, mock_client: LuxpowerClient
     ) -> None:
         """Transport-mode Modbus write failure raises (control-op convention)."""
+        transport = Mock()
+        transport.write_named_parameters = AsyncMock(return_value=False)
         inverter = HybridInverter(
             client=mock_client,
             serial_number="1234567890",
             model="FlexBOSS21",
-            transport=Mock(),
+            transport=transport,
         )
-        inverter.read_transport_register = AsyncMock(return_value=0)
-        inverter.write_transport_register = AsyncMock(return_value=False)
 
         with pytest.raises(LuxpowerDeviceError, match="requires a successful Modbus write"):
             await inverter.set_ac_charge_type(1)

--- a/tests/unit/test_reg120_bitfield.py
+++ b/tests/unit/test_reg120_bitfield.py
@@ -1,0 +1,28 @@
+"""Register-120 compound-field metadata contract."""
+
+from pylxpweb.registers import bitfield_entries_for_address
+
+
+class TestRegister120Bitfield:
+    """The canonical catalog must agree with named-parameter RMW semantics."""
+
+    def test_compound_field_offsets_and_widths(self) -> None:
+        """H120 contains five fields, not seven consecutive booleans."""
+        entries = bitfield_entries_for_address(120)
+
+        assert [
+            (entry.api_param_key, entry.bit_position, entry.field_width) for entry in entries
+        ] == [
+            ("FUNC_HALF_HOUR_AC_CHG_START_EN", 0, 1),
+            ("BIT_AC_CHARGE_TYPE", 1, 3),
+            ("BIT_DISCHG_CONTROL_TYPE", 4, 2),
+            ("BIT_ON_GRID_EOD_TYPE", 6, 1),
+            ("BIT_GENERATOR_CHARGE_TYPE", 7, 1),
+        ]
+
+    def test_overlapping_legacy_boolean_names_are_absent(self) -> None:
+        """Compound AC-charge bits cannot also be advertised as booleans."""
+        api_keys = {entry.api_param_key for entry in bitfield_entries_for_address(120)}
+
+        assert "FUNC_SNA_BAT_DISCHARGE_CONTROL" not in api_keys
+        assert "FUNC_PHASE_INDEPEND_COMPENSATE_EN" not in api_keys

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from pylxpweb.registers import PV4_6_INPUT_REGISTER_GROUP
+from pylxpweb.transports.capabilities import DONGLE_CAPABILITIES
 from pylxpweb.transports.dongle import (
     DEFAULT_PORT,
     MODBUS_READ_HOLDING,
@@ -107,6 +108,8 @@ class TestDongleTransport:
         assert caps.can_write_parameters is True
         assert caps.can_discover_devices is False
         assert caps.is_local is True
+        assert caps.supports_concurrent_reads is False
+        assert caps is DONGLE_CAPABILITIES
 
 
 class TestDongleConnection:
@@ -1584,6 +1587,41 @@ class TestDongleWriteVerification:
         mock_write.assert_called_once_with(20, [0b0110])
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("parameter", "requested", "raw"),
+        [
+            ("FUNC_HALF_HOUR_AC_CHG_START_EN", True, 0x0001),
+            ("BIT_AC_CHARGE_TYPE", 5, 0x000A),
+            ("BIT_DISCHG_CONTROL_TYPE", 3, 0x0030),
+            ("BIT_ON_GRID_EOD_TYPE", True, 0x0040),
+            ("BIT_GENERATOR_CHARGE_TYPE", True, 0x0080),
+        ],
+    )
+    async def test_verification_uses_register_120_explicit_layout(
+        self,
+        parameter: str,
+        requested: bool | int,
+        raw: int,
+    ) -> None:
+        """H120 readback compares each field at its real sparse offset."""
+        transport = _make_write_test_transport()
+        transport.read_parameters = AsyncMock(return_value={120: raw})  # type: ignore[method-assign]
+
+        mismatches = await transport._verify_named_parameters({parameter: requested})
+
+        assert mismatches == []
+
+    @pytest.mark.asyncio
+    async def test_verification_reports_register_120_compound_mismatch(self) -> None:
+        """A different H120 compound value is reported diagnostically."""
+        transport = _make_write_test_transport()
+        transport.read_parameters = AsyncMock(return_value={120: 0x0004})  # type: ignore[method-assign]
+
+        mismatches = await transport._verify_named_parameters({"BIT_AC_CHARGE_TYPE": 5})
+
+        assert mismatches == ["BIT_AC_CHARGE_TYPE: wrote 5, read back 2"]
+
+    @pytest.mark.asyncio
     async def test_verification_skipped_when_not_cheap(self) -> None:
         """Writes spanning many registers skip the readback (not cheap)."""
         transport = _make_write_test_transport()
@@ -1794,6 +1832,30 @@ class TestWriteAckEchoValidation:
             patch("asyncio.sleep", AsyncMock()),
             pytest.raises(TransportWriteError, match="count mismatch"),
         ):
+            await transport._write_holding_registers(110, [1, 2])
+
+    @pytest.mark.asyncio
+    async def test_fc16_read_style_count_match_succeeds(self) -> None:
+        """The supported one-value read-layout fallback may confirm FC16."""
+        transport = self._connected_transport()
+        echo = _build_mock_response(
+            modbus_func=MODBUS_WRITE_MULTI,
+            start_register=110,
+            register_values=[2],
+        )
+        transport._reader.read = AsyncMock(side_effect=[b"", echo])
+
+        with patch("asyncio.sleep", AsyncMock()):
+            assert await transport._write_holding_registers(110, [1, 2]) is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ack", [[0x9999, 0x8888], [2, 0x8888]])
+    async def test_fc16_multi_value_read_style_ack_raises(self, ack: list[int]) -> None:
+        """A read payload is not an FC16 count echo, even if its first value matches."""
+        transport = self._connected_transport()
+        transport._send_receive = AsyncMock(return_value=ack)  # type: ignore[method-assign]
+
+        with pytest.raises(TransportWriteError, match="malformed"):
             await transport._write_holding_registers(110, [1, 2])
 
     @pytest.mark.asyncio

--- a/tests/unit/transports/test_named_parameters.py
+++ b/tests/unit/transports/test_named_parameters.py
@@ -302,6 +302,111 @@ class TestWriteNamedParametersModbus:
             await mock_modbus_transport.write_named_parameters({"UNKNOWN_PARAM": 123})
 
 
+class TestRegister120CompoundFields:
+    """Register 120 is one bit, two compound fields, then two sparse bits."""
+
+    @pytest.fixture
+    def mock_modbus_transport(self) -> ModbusTransport:
+        transport = ModbusTransport(
+            host="192.168.1.100",
+            serial="CE12345678",
+        )
+        transport._connected = True
+        transport.read_parameters = AsyncMock(return_value={120: 0})
+        transport.write_parameters = AsyncMock(return_value=True)
+        return transport
+
+    @pytest.mark.asyncio
+    async def test_read_field_matrix_uses_documented_offsets_and_widths(
+        self, mock_modbus_transport: ModbusTransport
+    ) -> None:
+        """Every low-byte combination decodes without overlapping fake bits."""
+        for half_hour in (False, True):
+            for ac_charge_type in range(8):
+                for discharge_type in range(4):
+                    for on_grid_eod in (False, True):
+                        for generator_charge in (False, True):
+                            raw = (
+                                0xA500
+                                | int(half_hour)
+                                | (ac_charge_type << 1)
+                                | (discharge_type << 4)
+                                | (int(on_grid_eod) << 6)
+                                | (int(generator_charge) << 7)
+                            )
+                            mock_modbus_transport.read_parameters = AsyncMock(
+                                return_value={120: raw}
+                            )
+
+                            result = await mock_modbus_transport.read_named_parameters(120, 1)
+
+                            assert result == {
+                                "FUNC_HALF_HOUR_AC_CHG_START_EN": half_hour,
+                                "BIT_AC_CHARGE_TYPE": ac_charge_type,
+                                "BIT_DISCHG_CONTROL_TYPE": discharge_type,
+                                "BIT_ON_GRID_EOD_TYPE": on_grid_eod,
+                                "BIT_GENERATOR_CHARGE_TYPE": generator_charge,
+                            }
+
+    @pytest.mark.asyncio
+    async def test_write_all_fields_preserves_unmapped_upper_bits(
+        self, mock_modbus_transport: ModbusTransport
+    ) -> None:
+        """A combined RMW changes only H120's documented low-byte fields."""
+        mock_modbus_transport.read_parameters = AsyncMock(return_value={120: 0xA555})
+
+        result = await mock_modbus_transport.write_named_parameters(
+            {
+                "FUNC_HALF_HOUR_AC_CHG_START_EN": True,
+                "BIT_AC_CHARGE_TYPE": 5,
+                "BIT_DISCHG_CONTROL_TYPE": 2,
+                "BIT_ON_GRID_EOD_TYPE": False,
+                "BIT_GENERATOR_CHARGE_TYPE": True,
+            }
+        )
+
+        assert result is True
+        mock_modbus_transport.write_parameters.assert_awaited_once_with({120: 0xA5AB})
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("parameter", "value"),
+        [
+            ("BIT_AC_CHARGE_TYPE", -1),
+            ("BIT_AC_CHARGE_TYPE", 8),
+            ("BIT_DISCHG_CONTROL_TYPE", -1),
+            ("BIT_DISCHG_CONTROL_TYPE", 4),
+        ],
+    )
+    async def test_write_compound_field_rejects_values_outside_width(
+        self,
+        mock_modbus_transport: ModbusTransport,
+        parameter: str,
+        value: int,
+    ) -> None:
+        mock_modbus_transport.read_parameters = AsyncMock(return_value={120: 0})
+
+        with pytest.raises(ValueError, match="out of range"):
+            await mock_modbus_transport.write_named_parameters({parameter: value})
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "unsupported_parameter",
+        [
+            "FUNC_SNA_BAT_DISCHARGE_CONTROL",
+            "FUNC_PHASE_INDEPEND_COMPENSATE_EN",
+        ],
+    )
+    async def test_overlapping_legacy_names_are_not_locally_writable(
+        self,
+        mock_modbus_transport: ModbusTransport,
+        unsupported_parameter: str,
+    ) -> None:
+        """Names that overlap ACChargeType bits must not imply safe local writes."""
+        with pytest.raises(ValueError, match="Unknown parameter name"):
+            await mock_modbus_transport.write_named_parameters({unsupported_parameter: True})
+
+
 class TestReadNamedParametersHTTP:
     """Tests for HTTP transport read_named_parameters."""
 
@@ -657,7 +762,7 @@ class TestMultiBitFieldReadWrite:
         """Test that multi-bit fields work even without _device_type set.
 
         The _resolve_register_mappings method auto-detects MIDBOX params
-        from MULTI_BIT_FIELDS.
+        from the MIDBOX-only field layout.
         """
         transport = ModbusTransport(
             host="192.168.1.100",


### PR DESCRIPTION
## Summary

Hardens three dependency contracts found by the parallel register/race/performance audit:

- model holding register 120 as five real fields with explicit offsets and widths;
- reject ambiguous multi-value FC16 read-layout acknowledgements;
- report the dongle's actual single-stream capability set.

This is intentionally a draft while CI and automated review run. It is based directly on `origin/main` at `ee16a6a` (`v0.9.39b6`).

## Root cause analysis

### H120 compound fields

`REGISTER_TO_PARAM_KEYS[120]` listed seven `FUNC_*`/`BIT_*` names. The generic named-parameter layer classifies that shape as a bit field and used list position as bit position, so it decoded and wrote seven unrelated booleans.

That model conflicts with two independent contracts:

- the pinned ant0nkr/luxpower reference describes bit 0, a 3-bit AC-charge selector at bits 1-3, a 2-bit discharge selector at bits 4-5, and selectors at bits 6 and 7;
- pylxpweb's dedicated AC-charge-type API already uses the correct `0x0e` mask.

The two extra legacy cloud names overlap the AC-charge compound field and cannot safely imply local boolean controls. The canonical register catalog repeated the same seven-bit fiction, so fixing only the runtime map would have left the advertised source of truth inconsistent.

### FC16 acknowledgement validation

Some dongle firmware returns write acknowledgements in a read-style layout. `_parse_response()` therefore returns a list of parsed 16-bit values. `_write_holding_registers()` validated the echoed register count only when `len(ack) == 1`; any list with two or more values skipped the condition and returned success, even when it was a misrouted read payload or its first value happened to match the write count.

### Dongle capability identity

`DongleTransport.capabilities` returned `MODBUS_CAPABILITIES`, which advertises concurrent reads. A dedicated `DONGLE_CAPABILITIES` singleton already correctly says `supports_concurrent_reads=False`, matching the dongle's single serialized TCP connection, but the transport never returned it.

## Changes

- Add an explicit field-layout contract for sparse/compound fields while retaining `MULTI_BIT_FIELDS` as the integer-field compatibility subset.
- Split MIDBOX-only layout detection from the general layout so H120 fields cannot accidentally select GridBOSS mappings.
- Decode, range-check, mask, write, and post-write-verify all five H120 fields at their actual positions.
- Remove the two overlapping legacy names from local H120 mapping and canonical metadata; HTTP reads remain server-native and unaffected.
- Extend `HoldingRegisterDefinition` with appended `field_width` metadata, preserving all existing positional argument slots.
- Require exactly one parsed FC16 acknowledgement value, then validate that it equals the written register count.
- Return `DONGLE_CAPABILITIES` from `DongleTransport`.

## Compatibility and safety

- No new H120 Home Assistant control is exposed here. This makes the dependency safe before any integration entity is considered.
- Local writes using the two overlapping legacy names now fail closed as unknown instead of mutating the wrong H120 bits.
- Normal FC16 16-byte acknowledgements and the supported one-value read-layout fallback remain accepted.
- Length-framed dongle receive assembly is a separate audited issue and is deliberately not mixed into this PR.

## Validation

- Baseline RED probe against `ee16a6a`: 11/11 new runtime assertions failed (H120 decode/write/range/aliases, FC16 multi-value ACK, and dongle capability metadata).
- Canonical H120 metadata RED probe: 2/2 assertions failed before `field_width` and catalog correction.
- Focused contract suite: `35 passed`.
- Full unit suite: `3087 passed, 19 warnings`.
- `ruff check src tests`: passed.
- `ruff format --check src tests`: passed.
- `mypy --strict src/pylxpweb`: passed (`94 source files`).
- Commit hooks: YAML/EOF/whitespace/large-file/Ruff/Ruff-format passed. The uv-wrapped mypy hook was skipped only because it rewrites the already-drifted tracked lock version (`0.9.39b5` vs package `0.9.39b6`); the same strict mypy command passed directly and `uv.lock` is intentionally untouched.

Live integration tests are not run locally because that suite uses protected credentials and includes real inverter/DST writes. The repository's protected GitHub integration job remains the authoritative live check.

## Integration context

This implements dependency findings DEP-03, DEP-04, and DEP-06 from joyfulhouse/eg4_web_monitor draft audit PR #524. The Home Assistant integration currently exposes no H120 entity, so it can consume this safely as a prerequisite for any future mapped control. The other dependency audit fixes (atomic Quick Charge and authentication single-flight) remain isolated in their own draft PRs.
