### PR TITLE
fix(dongle): assemble fragmented TCP frames

### DIFF
--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -86,6 +86,7 @@ _FRAME_CRC_SIZE = 2
 _MIN_ADVERTISED_FRAME_LENGTH = _FRAME_FIXED_FIELDS_SIZE + _FRAME_CRC_SIZE
 _MAX_PACKET_SIZE = RECV_BUFFER_SIZE
 _MAX_PREFIX_SCAN_BYTES = RECV_BUFFER_SIZE
+_SHUTDOWN_CLOSE_TIMEOUT = 0.25
 
 # Write resilience settings (joyfulhouse/eg4_web_monitor#201)
 # The dongle drops its TCP connection mid-sequence during parameter writes
@@ -252,6 +253,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         # under _connect_lock ever takes _lock, so no cycle.
         self._connect_lock = asyncio.Lock()
         self._transaction_id = 0
+        self._shutdown_requested = False
 
     @property
     def capabilities(self) -> TransportCapabilities:
@@ -382,7 +384,9 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         Raises:
             TransportConnectionError: If all connection attempts fail
         """
+        self._raise_if_shutdown()
         async with self._connect_lock:
+            self._raise_if_shutdown()
             if self._connected:
                 return  # another task already (re)connected
 
@@ -394,6 +398,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
             await self._close_connection()
 
             for attempt in range(self._connection_retries):
+                self._raise_if_shutdown()
                 try:
                     if attempt > 0:
                         _LOGGER.info(
@@ -411,6 +416,9 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                         asyncio.open_connection(self._host, self._port),
                         timeout=self._timeout,
                     )
+                    if self._shutdown_requested:
+                        await self._close_connection()
+                        self._raise_if_shutdown()
 
                     # Discard any initial data the dongle sends after
                     # connection (some dongles send unsolicited packets that
@@ -419,6 +427,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     # instead of leaking a connected-looking transport with
                     # a broken socket.
                     await self._discard_initial_data()
+                    self._raise_if_shutdown()
 
                     self._connected = True
                     _LOGGER.info(
@@ -434,6 +443,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                 except TimeoutError as err:
                     last_error = err
                     await self._close_connection()
+                    self._raise_if_shutdown()
                     _LOGGER.warning(
                         "Timeout connecting to dongle at %s:%s (attempt %d/%d)",
                         self._host,
@@ -444,6 +454,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                 except OSError as err:
                     last_error = err
                     await self._close_connection()
+                    self._raise_if_shutdown()
                     _LOGGER.warning(
                         "Connection failed to %s:%s: %s (attempt %d/%d)",
                         self._host,
@@ -481,6 +492,39 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         async with self._lock:
             await self._teardown_connection()
         _LOGGER.debug("Dongle transport disconnected for %s", self._serial)
+
+    async def async_shutdown(self) -> None:
+        """Terminally close the socket without waiting for a held transaction lock.
+
+        Home Assistant unloads must close the stream before cancelling the task
+        that owns ``_lock``; otherwise a muted dongle can hold shutdown behind
+        the full response timeout.  This method is deliberately terminal.  It
+        marks the transport first, detaches and closes the current writer, and
+        makes an in-flight or later ``connect()`` close its result instead of
+        resurrecting the socket.  Ordinary reusable disconnects retain the
+        fully serialised :meth:`disconnect` contract.
+        """
+        self._shutdown_requested = True
+        self._connected = False
+        self._reader = None
+        self._receive_buffer.clear()
+        writer = self._writer
+        self._writer = None
+        if writer is not None:
+            with contextlib.suppress(Exception):
+                writer.close()
+                await asyncio.wait_for(
+                    writer.wait_closed(),
+                    timeout=min(self._timeout, _SHUTDOWN_CLOSE_TIMEOUT),
+                )
+        _LOGGER.debug("Dongle transport shut down for %s", self._serial)
+
+    def _raise_if_shutdown(self) -> None:
+        """Reject socket creation or use after terminal shutdown."""
+        if self._shutdown_requested:
+            raise TransportConnectionError(
+                f"Dongle transport for {self._serial} has been shut down"
+            )
 
     def _build_packet(
         self,
@@ -796,8 +840,11 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         """
         last_error: TransportReadError | None = None
 
+        self._raise_if_shutdown()
         async with self._lock:
+            self._raise_if_shutdown()
             for attempt in range(max_retries + 1):
+                self._raise_if_shutdown()
                 try:
                     # (Re)connect when there is no live connection: first
                     # use, after _teardown_connection(), or an external
@@ -854,6 +901,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     # Retry only after a fresh connection.
                     last_error = err
                     await self._teardown_connection()
+                    self._raise_if_shutdown()
                     if attempt < max_retries:
                         _LOGGER.debug(
                             "[%s] Frame error (attempt %d/%d): %s, reconnecting...",
@@ -875,6 +923,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     # below — dials a fresh connection instead of polling
                     # the dead flow forever (#226).
                     await self._teardown_connection()
+                    self._raise_if_shutdown()
                     if retry_on_timeout and attempt < max_retries:
                         _LOGGER.warning(
                             "[%s] Timeout on attempt %d/%d, will reconnect and resend",
@@ -895,6 +944,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     # Tear down the broken connection; next iteration
                     # will reconnect via the top-of-loop guard.
                     await self._teardown_connection()
+                    self._raise_if_shutdown()
 
                     if attempt < max_retries:
                         _LOGGER.warning(

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -466,6 +466,17 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                         attempt + 1,
                         self._connection_retries,
                     )
+                except BaseException:
+                    # CancelledError (or any unexpected error) raised between
+                    # installing the reader/writer and setting _connected would
+                    # otherwise leave an orphaned open socket occupying the
+                    # dongle's single TCP slot — invisible to later cleanup
+                    # because _connected stays False. Close before propagating;
+                    # shutdown-triggered TransportConnectionError takes the
+                    # same path (an extra close on an already-closed socket is
+                    # a no-op).
+                    await self._close_connection()
+                    raise
 
             # All retries exhausted
             await self._close_connection()

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -410,6 +410,9 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                             retry_delay,
                         )
                         await asyncio.sleep(retry_delay)
+                        # Shutdown may arrive while this task is parked in the
+                        # retry backoff. Never start a new TCP dial afterward.
+                        self._raise_if_shutdown()
                         retry_delay *= 2  # Exponential backoff
 
                     self._reader, self._writer = await asyncio.wait_for(
@@ -501,8 +504,10 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         the full response timeout.  This method is deliberately terminal.  It
         marks the transport first, detaches and closes the current writer, and
         makes an in-flight or later ``connect()`` close its result instead of
-        resurrecting the socket.  Ordinary reusable disconnects retain the
-        fully serialised :meth:`disconnect` contract.
+        resurrecting the socket. Retry and I/O boundaries re-check the terminal
+        flag after awaited backoffs, drains, writes, and reads, so shutdown does
+        not permit another dial or sequence retry. Ordinary reusable disconnects
+        retain the fully serialised :meth:`disconnect` contract.
         """
         self._shutdown_requested = True
         self._connected = False
@@ -869,10 +874,15 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
 
                     # Drain any pending data before sending (handles unsolicited packets)
                     await self._drain_buffer()
+                    self._raise_if_shutdown()
 
                     # Send packet
-                    self._writer.write(packet)
-                    await self._writer.drain()
+                    writer = self._writer
+                    if writer is None:
+                        raise TransportConnectionError("Socket not initialized")
+                    writer.write(packet)
+                    await writer.drain()
+                    self._raise_if_shutdown()
 
                     # Assemble one complete protocol frame.  The single
                     # wait_for bounds the entire prefix/header/body sequence;
@@ -881,6 +891,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                         self._receive_frame(),
                         timeout=self._timeout,
                     )
+                    self._raise_if_shutdown()
 
                     # Parse response with cross-request validation.  The
                     # request's own TCP function (packet byte 7) is the
@@ -963,6 +974,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     raise TransportReadError(f"[{self._serial}] Socket error: {err}") from err
                 except TransportReadError as err:
                     last_error = err
+                    self._raise_if_shutdown()
                     if attempt < max_retries:
                         _LOGGER.debug(
                             "[%s] Read error (attempt %d/%d): %s, retrying...",
@@ -1565,6 +1577,8 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         there is no inner request-level resend multiplying this.
 
         Raises:
+            TransportConnectionError: If terminal shutdown is requested. This
+                is never retried or recast as a generic write failure.
             TransportWriteError: If the write sequence fails after all
                 attempts.  A ``TransportError`` subclass, so HYBRID-mode
                 consumers can still dispatch their cloud API fallback.
@@ -1575,6 +1589,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
             last_error: TransportError | None = None
 
             for attempt in range(1, attempts + 1):
+                self._raise_if_shutdown()
                 try:
                     result = await super().write_named_parameters(parameters)
                 except (
@@ -1583,6 +1598,10 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     TransportTimeoutError,
                     TransportWriteError,
                 ) as err:
+                    # A terminal close is not a transient link failure. Preserve
+                    # its connection-error contract instead of entering the
+                    # sequence retry/backoff and eventually recasting it.
+                    self._raise_if_shutdown()
                     last_error = err
                     if attempt < attempts:
                         _LOGGER.warning(
@@ -1594,15 +1613,19 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                             err,
                         )
                         await self._force_reconnect()
+                        self._raise_if_shutdown()
                         await asyncio.sleep(WRITE_RETRY_DELAY * attempt)
+                        self._raise_if_shutdown()
                     continue
 
+                self._raise_if_shutdown()
                 if not self._verify_writes:
                     return result
 
                 try:
                     mismatches = await self._verify_named_parameters(parameters)
                 except TransportError as err:
+                    self._raise_if_shutdown()
                     # The write itself was acknowledged by the inverter; a
                     # failed verification READ must not fail the operation.
                     _LOGGER.debug(
@@ -1613,6 +1636,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     )
                     return result
 
+                self._raise_if_shutdown()
                 if not mismatches:
                     return result
 

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -80,6 +80,12 @@ MODBUS_WRITE_MULTI = 0x10  # Write multiple holding registers
 DEFAULT_PORT = 8000
 DEFAULT_TIMEOUT = 10.0
 RECV_BUFFER_SIZE = 4096
+_FRAME_HEADER_SIZE = 6
+_FRAME_FIXED_FIELDS_SIZE = 14
+_FRAME_CRC_SIZE = 2
+_MIN_ADVERTISED_FRAME_LENGTH = _FRAME_FIXED_FIELDS_SIZE + _FRAME_CRC_SIZE
+_MAX_PACKET_SIZE = RECV_BUFFER_SIZE
+_MAX_PREFIX_SCAN_BYTES = RECV_BUFFER_SIZE
 
 # Write resilience settings (joyfulhouse/eg4_web_monitor#201)
 # The dongle drops its TCP connection mid-sequence during parameter writes
@@ -143,6 +149,10 @@ def _mismatch_context(expected: str, received: str) -> str:
     share one grep-able shape (joyfulhouse/pylxpweb#213).
     """
     return f"expected [{expected}], received [{received}]"
+
+
+class _DongleFrameError(TransportReadError):
+    """A stream-framing failure that makes the current socket unusable."""
 
 
 class DongleTransport(RegisterDataMixin, BaseTransport):
@@ -232,6 +242,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         self._verify_writes = verify_writes
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
+        self._receive_buffer = bytearray()
         self._lock = asyncio.Lock()
         # Serialises connect() itself: _send_receive reconnects under
         # self._lock, but external callers (e.g. a coordinator write path
@@ -462,27 +473,13 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
     async def disconnect(self) -> None:
         """Close TCP connection to the dongle.
 
-        Uses timeout on wait_closed() to prevent hanging if the connection
-        is in a bad state. The dongle only supports one connection at a time,
-        so proper cleanup is essential.
+        Serialises with both in-flight transactions and connection lifecycle
+        changes.  If a connect is already establishing a socket, disconnect
+        waits and closes that result; if disconnect starts first, a later
+        connect waits until the old socket is fully closed before dialing.
         """
-        if self._writer:
-            try:
-                self._writer.close()
-                # Use timeout to prevent indefinite hang if connection is stuck
-                await asyncio.wait_for(self._writer.wait_closed(), timeout=5.0)
-            except TimeoutError:
-                _LOGGER.warning(
-                    "Timeout waiting for connection close to %s:%s",
-                    self._host,
-                    self._port,
-                )
-            except Exception:  # noqa: BLE001
-                pass  # Ignore other errors during disconnect
-
-        self._reader = None
-        self._writer = None
-        self._connected = False
+        async with self._lock:
+            await self._teardown_connection()
         _LOGGER.debug("Dongle transport disconnected for %s", self._serial)
 
     def _build_packet(
@@ -575,6 +572,11 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         stale data from previous requests. This method clears the buffer
         before sending a new request to ensure clean communication.
         """
+        # Any bytes retained after extracting a previous frame are stale at
+        # this request boundary (typically an unsolicited heartbeat or a
+        # coalesced late reply), just like bytes waiting in StreamReader.
+        self._receive_buffer.clear()
+
         if not self._reader:
             return
 
@@ -599,6 +601,103 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     break
         except Exception as err:
             _LOGGER.debug("Error draining buffer: %s", err)
+
+    async def _receive_frame(self) -> bytes:
+        """Read one complete packet from the TCP byte stream.
+
+        TCP reads do not preserve protocol-message boundaries: the two-byte
+        prefix, six-byte outer header, and body may all arrive separately.
+        Locate the prefix with a bounded junk scan, validate the advertised
+        packet size before reading its body, and retain any over-read bytes
+        for the next request-boundary drain.
+
+        The caller owns the single overall response timeout.  This helper
+        deliberately does not start a new timeout per fragment.
+        """
+        reader = self._reader
+        if reader is None:
+            raise TransportConnectionError("Socket not initialized")
+
+        discarded = 0
+
+        async def read_more(expected_size: int | None = None) -> None:
+            chunk = await reader.read(RECV_BUFFER_SIZE)
+            if chunk:
+                self._receive_buffer.extend(chunk)
+                return
+
+            if not self._receive_buffer and discarded == 0:
+                raise _DongleFrameError(
+                    f"[{self._serial}] Empty response from dongle. This may indicate: "
+                    "(1) Dongle firmware is blocking local Modbus access, "
+                    "(2) Connection was closed by dongle, or "
+                    "(3) Dongle requires more time to respond. "
+                    "Try increasing timeout or check dongle firmware version."
+                )
+
+            expected = f" of {expected_size} advertised bytes" if expected_size is not None else ""
+            raise _DongleFrameError(
+                f"[{self._serial}] Connection closed before complete frame: "
+                f"received {len(self._receive_buffer)} bytes{expected}"
+            )
+
+        # Locate a prefix without allowing a peer to grow the retained junk
+        # indefinitely.  Preserve one trailing 0xA1 because the 0xA1 0x1A
+        # prefix itself may straddle two TCP reads.
+        while True:
+            packet_start = self._receive_buffer.find(PACKET_PREFIX)
+            if packet_start >= 0:
+                if packet_start:
+                    discarded += packet_start
+                    if discarded > _MAX_PREFIX_SCAN_BYTES:
+                        raise _DongleFrameError(
+                            f"[{self._serial}] Packet prefix scan exceeded "
+                            f"{_MAX_PREFIX_SCAN_BYTES} bytes"
+                        )
+                    _LOGGER.debug(
+                        "Found packet start after discarding %d bytes of junk data",
+                        discarded,
+                    )
+                    del self._receive_buffer[:packet_start]
+                break
+
+            preserve = int(
+                bool(self._receive_buffer) and self._receive_buffer[-1] == PACKET_PREFIX[0]
+            )
+            junk_size = len(self._receive_buffer) - preserve
+            if junk_size:
+                discarded += junk_size
+                if discarded > _MAX_PREFIX_SCAN_BYTES:
+                    raise _DongleFrameError(
+                        f"[{self._serial}] Packet prefix scan exceeded "
+                        f"{_MAX_PREFIX_SCAN_BYTES} bytes"
+                    )
+                del self._receive_buffer[:junk_size]
+            await read_more()
+
+        while len(self._receive_buffer) < _FRAME_HEADER_SIZE:
+            await read_more()
+
+        advertised_length = struct.unpack("<H", self._receive_buffer[4:6])[0]
+        if advertised_length < _MIN_ADVERTISED_FRAME_LENGTH:
+            raise _DongleFrameError(
+                f"[{self._serial}] Invalid advertised frame length "
+                f"{advertised_length}; minimum is {_MIN_ADVERTISED_FRAME_LENGTH}"
+            )
+
+        packet_size = _FRAME_HEADER_SIZE + advertised_length
+        if packet_size > _MAX_PACKET_SIZE:
+            raise _DongleFrameError(
+                f"[{self._serial}] Advertised packet size {packet_size} exceeds maximum "
+                f"{_MAX_PACKET_SIZE}"
+            )
+
+        while len(self._receive_buffer) < packet_size:
+            await read_more(packet_size)
+
+        packet = bytes(self._receive_buffer[:packet_size])
+        del self._receive_buffer[:packet_size]
+        return packet
 
     async def _teardown_connection(self) -> None:
         """Tear down the connection, serialised on ``_connect_lock``.
@@ -627,6 +726,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         """
         self._connected = False
         self._reader = None
+        self._receive_buffer.clear()
         writer = self._writer
         self._writer = None
         if writer is not None:
@@ -727,37 +827,13 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     self._writer.write(packet)
                     await self._writer.drain()
 
-                    # Receive response with slightly longer timeout for dongles
+                    # Assemble one complete protocol frame.  The single
+                    # wait_for bounds the entire prefix/header/body sequence;
+                    # fragmented reads do not each restart the timeout.
                     response = await asyncio.wait_for(
-                        self._reader.read(RECV_BUFFER_SIZE),
+                        self._receive_frame(),
                         timeout=self._timeout,
                     )
-
-                    if not response:
-                        # recv returned b'' = EOF: the dongle closed the
-                        # connection (or the transport died locally).  This
-                        # socket can never yield a response again — tear it
-                        # down so the retry below (or the next request)
-                        # reconnects instead of re-reading a dead socket.
-                        await self._teardown_connection()
-                        if attempt < max_retries:
-                            _LOGGER.debug(
-                                "[%s] Empty response from dongle (attempt %d/%d), retrying...",
-                                self._serial,
-                                attempt + 1,
-                                max_retries + 1,
-                            )
-                            # Small delay before retry
-                            await asyncio.sleep(0.5)
-                            continue
-                        # Final attempt failed
-                        raise TransportReadError(
-                            f"[{self._serial}] Empty response from dongle. This may indicate: "
-                            "(1) Dongle firmware is blocking local Modbus access, "
-                            "(2) Connection was closed by dongle, or "
-                            "(3) Dongle requires more time to respond. "
-                            "Try increasing timeout or check dongle firmware version."
-                        )
 
                     # Parse response with cross-request validation.  The
                     # request's own TCP function (packet byte 7) is the
@@ -772,6 +848,23 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                         expected_tcp_func=packet[7],
                     )
 
+                except _DongleFrameError as err:
+                    # EOF, invalid/oversized advertised lengths, or an
+                    # exhausted prefix scan leaves stream alignment unusable.
+                    # Retry only after a fresh connection.
+                    last_error = err
+                    await self._teardown_connection()
+                    if attempt < max_retries:
+                        _LOGGER.debug(
+                            "[%s] Frame error (attempt %d/%d): %s, reconnecting...",
+                            self._serial,
+                            attempt + 1,
+                            max_retries + 1,
+                            err,
+                        )
+                        await asyncio.sleep(0.5)
+                        continue
+                    raise
                 except TimeoutError as err:
                     # The connection is suspect after ANY response timeout:
                     # the dongle went mute, or the path dropped silently
@@ -923,10 +1016,47 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         # Adjust response to start at the packet
         response = response[packet_start:]
 
-        # Minimum response: prefix(2) + version(2) + length(2) + addr(1) + func(1)
-        # + dongle(10) + data_len(2) + some data
-        if len(response) < 20:
+        if len(response) < _FRAME_HEADER_SIZE:
             raise TransportReadError(f"[{self._serial}] Response too short: {len(response)} bytes")
+
+        advertised_length = struct.unpack("<H", response[4:6])[0]
+        if advertised_length < _MIN_ADVERTISED_FRAME_LENGTH:
+            raise TransportReadError(
+                f"[{self._serial}] Invalid advertised frame length "
+                f"{advertised_length}; minimum is {_MIN_ADVERTISED_FRAME_LENGTH}"
+            )
+
+        packet_size = _FRAME_HEADER_SIZE + advertised_length
+        if packet_size > _MAX_PACKET_SIZE:
+            raise TransportReadError(
+                f"[{self._serial}] Advertised packet size {packet_size} exceeds maximum "
+                f"{_MAX_PACKET_SIZE}"
+            )
+        if packet_size > len(response):
+            raise TransportReadError(
+                f"[{self._serial}] Response truncated: advertised {packet_size} bytes, "
+                f"got {len(response)}"
+            )
+
+        # The outer length covers fixed address/function/serial/data-length
+        # fields plus the inner data and CRC.  Requiring both length fields
+        # to agree prevents accepting a CRC-valid prefix of a malformed frame.
+        data_length = struct.unpack("<H", response[18:20])[0]
+        expected_advertised_length = _FRAME_FIXED_FIELDS_SIZE + data_length
+        if advertised_length != expected_advertised_length:
+            raise TransportReadError(
+                f"[{self._serial}] Frame length mismatch: outer advertises "
+                f"{advertised_length}, inner requires {expected_advertised_length}"
+            )
+        if data_length < _FRAME_CRC_SIZE:
+            raise TransportReadError(
+                f"[{self._serial}] Invalid data length {data_length}; minimum is {_FRAME_CRC_SIZE}"
+            )
+
+        # Ignore bytes following the advertised frame.  Stream reads extract
+        # exactly one packet before this parser, while direct parser callers
+        # may supply a buffer containing trailing data.
+        response = response[:packet_size]
 
         # --- TCP function validation (must precede the data-frame checks) ---
         # The dongle shares the 0xA1 0x1A prefix across ALL its frames — the
@@ -958,9 +1088,6 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     f"0x{response_tcp_func:02x} ({label}): {context} "
                     "— misrouted/unsolicited frame"
                 )
-
-        # Extract data length (frame_length and tcp_func available at bytes 4-6 and 7 if needed)
-        data_length = struct.unpack("<H", response[18:20])[0]
 
         # Data starts at offset 20
         data_start = 20

--- a/src/pylxpweb/transports/hybrid.py
+++ b/src/pylxpweb/transports/hybrid.py
@@ -217,6 +217,30 @@ class HybridTransport(BaseTransport):
         self._connected = False
         _LOGGER.debug("Hybrid transport disconnected for %s", self._serial)
 
+    async def async_shutdown(self) -> None:
+        """Terminally shut down both sides, preferring their fast paths.
+
+        ``DongleTransport.async_shutdown()`` interrupts in-flight
+        transactions instead of queueing behind the transaction lock (whose
+        worst case spans the whole retry loop). Without this forwarder a
+        hybrid caller could only reach the blocking ``disconnect()`` on the
+        local side. Sides without an ``async_shutdown`` fall back to their
+        ordinary ``disconnect()``. Like the dongle's, this is terminal —
+        discard the transport afterwards.
+        """
+        for side in (self._local, self._http):
+            shutdown = getattr(type(side), "async_shutdown", None)
+            try:
+                if shutdown is not None:
+                    await shutdown(side)
+                else:
+                    await side.disconnect()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Error shutting down %s transport: %s", type(side).__name__, err)
+
+        self._connected = False
+        _LOGGER.debug("Hybrid transport shut down for %s", self._serial)
+
     async def read_runtime(self) -> InverterRuntimeData:
         """Read runtime data, preferring local transport.
 

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -18,6 +18,7 @@ from pylxpweb.transports.dongle import (
     MODBUS_WRITE_SINGLE,
     PACKET_PREFIX,
     PROTOCOL_VERSION,
+    RECV_BUFFER_SIZE,
     TCP_FUNC_HEARTBEAT,
     TCP_FUNC_TRANSLATED,
     DongleTransport,
@@ -262,6 +263,95 @@ class TestDongleConnection:
         assert transport._writer is None
 
     @pytest.mark.asyncio
+    async def test_disconnect_waits_for_inflight_connect_and_closes_result(self) -> None:
+        """A disconnect racing an in-flight dial must close the winning socket."""
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+        )
+        open_started = asyncio.Event()
+        release_open = asyncio.Event()
+
+        reader = AsyncMock()
+        reader.read = AsyncMock(side_effect=TimeoutError())
+        writer = MagicMock()
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+
+        async def delayed_open_connection(_host: str, _port: int) -> tuple[AsyncMock, MagicMock]:
+            open_started.set()
+            await release_open.wait()
+            return reader, writer
+
+        with patch("asyncio.open_connection", side_effect=delayed_open_connection):
+            connect_task = asyncio.create_task(transport.connect())
+            await asyncio.wait_for(open_started.wait(), timeout=1.0)
+            disconnect_task = asyncio.create_task(transport.disconnect())
+            try:
+                await asyncio.sleep(0)
+                assert not disconnect_task.done()
+            finally:
+                release_open.set()
+                await asyncio.gather(connect_task, disconnect_task, return_exceptions=True)
+
+        assert transport.is_connected is False
+        assert transport._reader is None
+        assert transport._writer is None
+        writer.close.assert_called_once()
+        writer.wait_closed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_waits_for_inflight_disconnect_and_keeps_new_socket(self) -> None:
+        """A connect racing teardown must dial after the old socket is closed."""
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+        )
+        close_started = asyncio.Event()
+        release_close = asyncio.Event()
+
+        old_reader = AsyncMock()
+        old_writer = MagicMock()
+        old_writer.close = MagicMock()
+
+        async def delayed_wait_closed() -> None:
+            close_started.set()
+            await release_close.wait()
+
+        old_writer.wait_closed = AsyncMock(side_effect=delayed_wait_closed)
+        transport._reader = old_reader
+        transport._writer = old_writer
+        transport._connected = True
+
+        new_reader = AsyncMock()
+        new_reader.read = AsyncMock(side_effect=TimeoutError())
+        new_writer = MagicMock()
+        new_writer.close = MagicMock()
+        new_writer.wait_closed = AsyncMock()
+
+        with patch(
+            "asyncio.open_connection", return_value=(new_reader, new_writer)
+        ) as open_connection:
+            disconnect_task = asyncio.create_task(transport.disconnect())
+            await asyncio.wait_for(close_started.wait(), timeout=1.0)
+            connect_task = asyncio.create_task(transport.connect())
+            try:
+                await asyncio.sleep(0)
+                assert not connect_task.done()
+            finally:
+                release_close.set()
+                await asyncio.gather(disconnect_task, connect_task, return_exceptions=True)
+
+        open_connection.assert_awaited_once_with("192.168.1.100", DEFAULT_PORT)
+        old_writer.close.assert_called_once()
+        assert transport.is_connected is True
+        assert transport._reader is new_reader
+        assert transport._writer is new_writer
+        new_writer.close.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_context_manager(self) -> None:
         """Test async context manager."""
         transport = DongleTransport(
@@ -419,6 +509,185 @@ def _build_write_ack_frame(
     response += data_frame
     response += struct.pack("<H", crc)
     return response
+
+
+class TestDongleFrameAssembly:
+    """Regression tests for TCP stream framing by advertised packet length."""
+
+    @staticmethod
+    def _connected_transport(
+        reader: AsyncMock, *, timeout: float = 1.0
+    ) -> tuple[DongleTransport, MagicMock]:
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+            timeout=timeout,
+        )
+        writer = MagicMock()
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+        transport._reader = reader
+        transport._writer = writer
+        transport._connected = True
+        return transport, writer
+
+    @staticmethod
+    def _read_packet(transport: DongleTransport) -> bytes:
+        return transport._build_packet(
+            tcp_func=TCP_FUNC_TRANSLATED,
+            modbus_func=MODBUS_READ_INPUT,
+            start_register=0,
+            register_count=2,
+        )
+
+    @pytest.mark.asyncio
+    async def test_fragmented_prefix_header_and_body_are_assembled(self) -> None:
+        """Legal TCP fragmentation must not be treated as a truncated reply."""
+        response = _build_mock_response(register_values=[111, 222])
+        reader = AsyncMock()
+        reader.read = AsyncMock(
+            side_effect=[
+                b"stale" + response[:1],
+                response[1:4],
+                response[4:6],
+                response[6:17],
+                response[17:],
+            ]
+        )
+        transport, _writer = self._connected_transport(reader)
+
+        with patch.object(transport, "_drain_buffer", new=AsyncMock()):
+            registers = await transport._send_receive(
+                self._read_packet(transport),
+                max_retries=0,
+                expected_func=MODBUS_READ_INPUT,
+                expected_register=0,
+                expected_count=2,
+            )
+
+        assert registers == [111, 222]
+        assert reader.read.await_count == 5
+
+    @pytest.mark.asyncio
+    async def test_partial_frame_then_eof_tears_down_connection(self) -> None:
+        """EOF after a valid header reports a partial frame and poisons the socket."""
+        response = _build_mock_response(register_values=[111, 222])
+        reader = AsyncMock()
+        reader.read = AsyncMock(side_effect=[response[:13], b""])
+        transport, writer = self._connected_transport(reader)
+
+        with (
+            patch.object(transport, "_drain_buffer", new=AsyncMock()),
+            pytest.raises(TransportReadError, match="closed before complete frame"),
+        ):
+            await transport._send_receive(self._read_packet(transport), max_retries=0)
+
+        assert transport.is_connected is False
+        assert transport._reader is None
+        assert transport._writer is None
+        writer.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_advertised_length_is_rejected_before_body_read(self) -> None:
+        """A length too short for the fixed header and CRC cannot define a frame."""
+        header = PACKET_PREFIX + struct.pack("<HH", PROTOCOL_VERSION, 15)
+        reader = AsyncMock()
+        reader.read = AsyncMock(return_value=header)
+        transport, writer = self._connected_transport(reader)
+
+        with (
+            patch.object(transport, "_drain_buffer", new=AsyncMock()),
+            pytest.raises(TransportReadError, match="Invalid advertised frame length"),
+        ):
+            await transport._send_receive(self._read_packet(transport), max_retries=0)
+
+        reader.read.assert_awaited_once()
+        writer.close.assert_called_once()
+        assert transport.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_oversize_advertised_length_is_rejected_before_body_read(self) -> None:
+        """A peer cannot force an unbounded allocation/read with its length field."""
+        header = PACKET_PREFIX + struct.pack("<HH", PROTOCOL_VERSION, RECV_BUFFER_SIZE)
+        reader = AsyncMock()
+        reader.read = AsyncMock(return_value=header)
+        transport, writer = self._connected_transport(reader)
+
+        with (
+            patch.object(transport, "_drain_buffer", new=AsyncMock()),
+            pytest.raises(TransportReadError, match="exceeds maximum"),
+        ):
+            await transport._send_receive(self._read_packet(transport), max_retries=0)
+
+        reader.read.assert_awaited_once()
+        writer.close.assert_called_once()
+        assert transport.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_fragment_assembly_uses_one_overall_timeout(self) -> None:
+        """Each fragment must not restart the response timeout budget."""
+        first_chunk = PACKET_PREFIX + struct.pack("<HH", PROTOCOL_VERSION, 32)
+        block_forever = asyncio.Event()
+        calls = 0
+
+        async def fragmented_read(_size: int) -> bytes:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return first_chunk
+            await block_forever.wait()
+            return b""
+
+        reader = AsyncMock()
+        reader.read = AsyncMock(side_effect=fragmented_read)
+        transport, writer = self._connected_transport(reader, timeout=0.02)
+        started = asyncio.get_running_loop().time()
+
+        with (
+            patch.object(transport, "_drain_buffer", new=AsyncMock()),
+            pytest.raises(TransportTimeoutError, match="Timeout waiting"),
+        ):
+            await transport._send_receive(self._read_packet(transport), max_retries=0)
+
+        elapsed = asyncio.get_running_loop().time() - started
+        assert elapsed < 0.5
+        assert reader.read.await_count == 2
+        writer.close.assert_called_once()
+        assert transport.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_prefix_search_is_bounded(self) -> None:
+        """Junk without a prefix cannot grow the receive buffer indefinitely."""
+        reader = AsyncMock()
+        reader.read = AsyncMock(return_value=b"x" * (RECV_BUFFER_SIZE + 1))
+        transport, writer = self._connected_transport(reader)
+
+        with (
+            patch.object(transport, "_drain_buffer", new=AsyncMock()),
+            pytest.raises(TransportReadError, match="prefix scan exceeded"),
+        ):
+            await transport._send_receive(self._read_packet(transport), max_retries=0)
+
+        reader.read.assert_awaited_once()
+        writer.close.assert_called_once()
+        assert transport.is_connected is False
+
+    def test_parser_rejects_outer_and_inner_length_disagreement(self) -> None:
+        """The outer frame length and inner data length must describe one packet."""
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+        )
+        response = bytearray(_build_mock_response())
+        advertised = struct.unpack("<H", response[4:6])[0]
+        response[4:6] = struct.pack("<H", advertised - 1)
+
+        with pytest.raises(TransportReadError, match="length mismatch"):
+            transport._parse_response(bytes(response))
 
 
 class TestDongleResponseParsing:
@@ -1999,6 +2268,7 @@ class _ScriptedDongleServer:
 
     def __init__(self, response: bytes) -> None:
         self._response = response
+        self.response_chunks: list[bytes] | None = None
         self._server: asyncio.Server | None = None
         self.mode = "reply"
         self.accepted = 0
@@ -2027,8 +2297,14 @@ class _ScriptedDongleServer:
                     break
                 self.requests_received += 1
                 if self.mode == "reply":
-                    writer.write(self._response)
-                    await writer.drain()
+                    chunks = self.response_chunks or [self._response]
+                    for chunk in chunks:
+                        writer.write(chunk)
+                        await writer.drain()
+                        if self.response_chunks is not None:
+                            # Give StreamReader a chance to observe each TCP
+                            # fragment instead of coalescing the whole reply.
+                            await asyncio.sleep(0.001)
                 # mode == "mute": swallow the request, never respond
         except (ConnectionError, OSError):
             pass
@@ -2313,6 +2589,29 @@ class TestDongleSilentPathLoss:
             # review: no bare sleep).
             assert await transport._read_input_registers(0, 1) == [3]
             assert server.accepted == 1
+        finally:
+            await transport.disconnect()
+            await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_loopback_server_fragmented_response_is_assembled(self) -> None:
+        """Real StreamReader fragmentation is assembled into one validated frame."""
+        response = _build_mock_response(start_register=0, register_values=[13, 21])
+        server = _ScriptedDongleServer(response)
+        server.response_chunks = [
+            b"stale" + response[:1],
+            response[1:4],
+            response[4:6],
+            response[6:19],
+            response[19:],
+        ]
+        port = await server.start()
+        transport = self._transport(port, timeout=0.5)
+        try:
+            await transport.connect()
+            assert await transport._read_input_registers(0, 2) == [13, 21]
+            assert server.accepted == 1
+            assert server.requests_received == 1
         finally:
             await transport.disconnect()
             await server.stop()

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -173,6 +173,48 @@ class TestDongleConnection:
         assert transport.is_connected is False
 
     @pytest.mark.asyncio
+    async def test_connect_cancelled_during_initial_data_closes_socket(self) -> None:
+        """Cancellation between socket install and _connected=True must close.
+
+        The dongle has ONE TCP slot. If the caller's task is cancelled while
+        connect() is parked in the initial-data wait, the freshly installed
+        reader/writer would otherwise stay open with _connected False —
+        invisible to disconnect()-style cleanup and blocking every later
+        client until a retry's clean-slate close (codex review P2).
+        """
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+        )
+
+        read_started = asyncio.Event()
+        hang_forever = asyncio.Event()
+
+        async def hanging_read(_n: int) -> bytes:
+            read_started.set()
+            await hang_forever.wait()
+            return b""
+
+        mock_reader = MagicMock()
+        mock_reader.read = hanging_read
+        mock_writer = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+
+        with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+            task = asyncio.create_task(transport.connect())
+            await asyncio.wait_for(read_started.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        mock_writer.close.assert_called_once()
+        mock_writer.wait_closed.assert_awaited_once()
+        assert transport.is_connected is False
+        assert transport._writer is None
+
+    @pytest.mark.asyncio
     async def test_disconnect(self) -> None:
         """Test disconnection."""
         transport = DongleTransport(

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -268,6 +268,79 @@ class TestDongleConnection:
         assert transport._writer is None
 
     @pytest.mark.asyncio
+    async def test_async_shutdown_during_connect_backoff_prevents_second_dial(
+        self,
+    ) -> None:
+        """Terminal shutdown in retry sleep must stop before another TCP dial."""
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+            connection_retries=2,
+        )
+        backoff_started = asyncio.Event()
+        release_backoff = asyncio.Event()
+
+        async def controlled_backoff(delay: float) -> None:
+            assert delay == 1.0
+            backoff_started.set()
+            await release_backoff.wait()
+
+        open_connection = AsyncMock(side_effect=ConnectionRefusedError("first dial failed"))
+        with (
+            patch("asyncio.open_connection", open_connection),
+            patch("asyncio.sleep", side_effect=controlled_backoff) as sleep,
+        ):
+            connect_task = asyncio.create_task(transport.connect())
+            await asyncio.wait_for(backoff_started.wait(), timeout=1.0)
+            await transport.async_shutdown()
+            release_backoff.set()
+
+            with pytest.raises(TransportConnectionError, match="shut down"):
+                await connect_task
+
+        open_connection.assert_awaited_once()
+        sleep.assert_awaited_once_with(1.0)
+        assert transport.is_connected is False
+        assert transport._reader is None
+        assert transport._writer is None
+
+    @pytest.mark.asyncio
+    async def test_terminal_read_error_does_not_enter_request_retry_backoff(
+        self,
+    ) -> None:
+        """A request observing terminal shutdown rejects before retry sleep."""
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+        )
+        reader = AsyncMock()
+        writer = AsyncMock()
+        writer.write = MagicMock()
+        writer.close = MagicMock()
+        transport._reader = reader
+        transport._writer = writer
+        transport._connected = True
+        transport._drain_buffer = AsyncMock()  # type: ignore[method-assign]
+
+        async def shutdown_then_fail() -> bytes:
+            await transport.async_shutdown()
+            raise TransportReadError("request ended during terminal shutdown")
+
+        transport._receive_frame = shutdown_then_fail  # type: ignore[method-assign]
+        retry_sleep = AsyncMock()
+
+        with (
+            patch("asyncio.sleep", retry_sleep),
+            pytest.raises(TransportConnectionError, match="shut down"),
+        ):
+            await transport._send_receive(b"\x00" * 10, max_retries=2)
+
+        retry_sleep.assert_not_awaited()
+        writer.close.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_teardown_connection_awaits_wait_closed(self) -> None:
         """_teardown_connection closes AND awaits wait_closed(), clearing state.
 
@@ -1621,6 +1694,25 @@ class TestDongleWriteSequenceResilience:
 
     Regression tests for joyfulhouse/eg4_web_monitor#201.
     """
+
+    @pytest.mark.asyncio
+    async def test_terminal_shutdown_rejects_without_sequence_retry_or_recast(
+        self,
+    ) -> None:
+        """Terminal connection errors escape immediately as their original type."""
+        transport = _make_write_test_transport()
+        await transport.async_shutdown()
+        transport._force_reconnect = AsyncMock()  # type: ignore[method-assign]
+        retry_sleep = AsyncMock()
+
+        with (
+            patch("asyncio.sleep", retry_sleep),
+            pytest.raises(TransportConnectionError, match="shut down"),
+        ):
+            await transport.write_named_parameters({"FUNC_EPS_EN": True})
+
+        transport._force_reconnect.assert_not_awaited()
+        retry_sleep.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_drop_on_read_rereads_and_writes(self) -> None:

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -195,6 +195,79 @@ class TestDongleConnection:
             assert transport.is_connected is False
 
     @pytest.mark.asyncio
+    async def test_async_shutdown_bypasses_inflight_transaction_lock(self) -> None:
+        """Terminal shutdown closes the socket while a request owns ``_lock``."""
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+        )
+        receive_started = asyncio.Event()
+        never_respond = asyncio.Event()
+
+        async def blocked_receive() -> bytes:
+            receive_started.set()
+            await never_respond.wait()
+            return b""
+
+        reader = AsyncMock()
+        writer = AsyncMock()
+        writer.write = MagicMock()
+        writer.close = MagicMock()
+        transport._reader = reader
+        transport._writer = writer
+        transport._connected = True
+        transport._drain_buffer = AsyncMock()  # type: ignore[method-assign]
+        transport._receive_frame = blocked_receive  # type: ignore[method-assign]
+
+        request = asyncio.create_task(transport._send_receive(b"\x00" * 10, max_retries=0))
+        await asyncio.wait_for(receive_started.wait(), timeout=1.0)
+        try:
+            await asyncio.wait_for(transport.async_shutdown(), timeout=0.1)
+            assert transport._lock.locked() is True
+            writer.close.assert_called_once()
+            assert transport.is_connected is False
+        finally:
+            request.cancel()
+            await asyncio.gather(request, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_async_shutdown_closes_late_connect_and_is_terminal(self) -> None:
+        """A socket produced after shutdown is closed and cannot reconnect."""
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="CE12345678",
+        )
+        open_started = asyncio.Event()
+        release_open = asyncio.Event()
+        reader = AsyncMock()
+        writer = AsyncMock()
+        writer.close = MagicMock()
+
+        async def delayed_open_connection(_host: str, _port: int) -> tuple[AsyncMock, AsyncMock]:
+            open_started.set()
+            await release_open.wait()
+            return reader, writer
+
+        with patch("asyncio.open_connection", side_effect=delayed_open_connection) as open_:
+            connect_task = asyncio.create_task(transport.connect())
+            await asyncio.wait_for(open_started.wait(), timeout=1.0)
+            await asyncio.wait_for(transport.async_shutdown(), timeout=0.1)
+            release_open.set()
+
+            with pytest.raises(TransportConnectionError, match="shut down"):
+                await connect_task
+            with pytest.raises(TransportConnectionError, match="shut down"):
+                await transport.connect()
+
+        assert open_.await_count == 1
+        writer.close.assert_called_once()
+        assert transport.is_connected is False
+        assert transport._reader is None
+        assert transport._writer is None
+
+    @pytest.mark.asyncio
     async def test_teardown_connection_awaits_wait_closed(self) -> None:
         """_teardown_connection closes AND awaits wait_closed(), clearing state.
 

--- a/tests/unit/transports/test_hybrid.py
+++ b/tests/unit/transports/test_hybrid.py
@@ -408,3 +408,51 @@ class TestHybridTransportRecovery:
             transport._check_local_recovery()
             assert transport._local_failed_at is None
             assert transport._using_local is True
+
+
+class TestHybridAsyncShutdown:
+    """async_shutdown forwards to each side's fast path (Opus review P2).
+
+    Without this forwarder a hybrid caller could only reach the local side's
+    reusable disconnect(), which queues behind the transaction lock — worst
+    case the whole retry loop — while DongleTransport.async_shutdown()
+    interrupts in-flight transactions immediately.
+    """
+
+    @pytest.mark.asyncio
+    async def test_forwards_to_side_async_shutdown_when_present(
+        self, mock_http_transport: MagicMock
+    ) -> None:
+        class _LocalWithShutdown:
+            def __init__(self) -> None:
+                self.serial = "CE12345678"
+                self.capabilities = MagicMock()
+                self.shutdown_calls = 0
+                self.disconnect = AsyncMock()
+
+            async def async_shutdown(self) -> None:
+                self.shutdown_calls += 1
+
+        local = _LocalWithShutdown()
+        transport = HybridTransport(local, mock_http_transport)
+
+        await transport.async_shutdown()
+
+        assert local.shutdown_calls == 1
+        local.disconnect.assert_not_awaited()
+        # The plain-MagicMock HTTP side has no type-level async_shutdown,
+        # so it takes the ordinary disconnect fallback.
+        mock_http_transport.disconnect.assert_awaited_once()
+        assert transport.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_side_failure_does_not_block_other_side(
+        self, mock_local_transport: MagicMock, mock_http_transport: MagicMock
+    ) -> None:
+        mock_local_transport.disconnect = AsyncMock(side_effect=OSError("stuck socket"))
+        transport = HybridTransport(mock_local_transport, mock_http_transport)
+
+        await transport.async_shutdown()
+
+        mock_http_transport.disconnect.assert_awaited_once()
+        assert transport.is_connected is False


### PR DESCRIPTION
## Summary

- assemble DongleTransport replies from the TCP byte stream using the protocol-advertised outer frame length
- bound prefix recovery, packet size, partial EOF, and the entire fragmented read under one configured response timeout
- validate outer and inner length fields agree before parsing CRC/data
- serialize disconnect with transactions and connection establishment so racing lifecycle calls cannot orphan or replace the live stream

## Root cause

`StreamReader.read(4096)` returns currently available bytes, not one protocol message. The transport parsed the first read immediately and ignored bytes 4-5, so a legal split prefix/header/body looked like junk or truncation. EOF after a partial frame was retried without an explicit framing diagnosis, and no advertised-size cap protected recovery.

Separately, `disconnect()` did not participate in `_lock` / `_connect_lock`. It could return while `connect()` was still dialing (leaving the later socket live), or `connect()` could observe the old `_connected=True` while teardown was awaiting `wait_closed()` and then return before disconnect cleared the state.

The reference `ant0nkr/luxpower-ha-integration` framing logic also derives total packet size as the outer advertised length plus six bytes and bounds packet recovery. This change adopts that protocol contract while retaining pylxpweb-specific CRC, serial/function/register attribution, retry behavior, and its larger existing 4096-byte compatibility ceiling.

## Safety / behavior

- A private byte buffer preserves split prefixes and body fragments and extracts exactly one advertised packet.
- Prefix scanning and packet size are capped at 4096 bytes; invalid/oversize headers fail before reading an attacker-controlled body.
- One `wait_for` wraps the complete assembly sequence, so each fragment cannot restart the timeout budget.
- EOF/framing corruption tears down the boundary-poisoned socket before retrying on a fresh connection.
- Lock order remains `_lock -> _connect_lock`; disconnect now uses the same order.
- Parser callers independently enforce outer/inner length consistency.

## Tests

Regression coverage includes:

- fragmented prefix, header, and body with leading junk
- real loopback TCP/`StreamReader` fragmentation
- partial-frame EOF and immediate teardown
- invalid and oversized advertised lengths rejected before body reads
- bounded prefix search and one overall assembly timeout
- outer/inner length disagreement
- both connect-wins/disconnect-wins lifecycle interleavings

Verification:

- `pytest tests/unit/ -q` — **3071 passed, 1 skipped**
- `pytest tests/unit/transports/test_dongle.py` — **106 passed**
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy --strict src/pylxpweb/` — 94 source files clean
- pre-commit hooks pass; local hook mypy was run directly because its global `uv run mypy` environment resolves an incompatible pydantic plugin/core pair

Tracks dependency audit bead `eg4-06er.9`.

## Terminal retry reconciliation

A paired review with joyfulhouse/eg4_web_monitor#529 found one remaining terminal race: `connect()` checked the shutdown flag before entering retry backoff, but not after the awaited sleep. Shutdown during that sleep could therefore start one more TCP dial from the obsolete entry. Named-parameter writes also caught the terminal `TransportConnectionError`, entered sequence backoff, and eventually recast it as a generic `TransportWriteError`.

The terminal contract is now enforced after every awaited boundary that can lead to socket I/O:

- connect retry backoff re-checks before `open_connection()`
- request drain, writer drain, and frame receipt re-check before continuing
- request validation retries reject before sleeping once shutdown is visible
- named-write sequence retries preserve the terminal `TransportConnectionError`, do not reconnect or sleep, and re-check after reconnect/backoff/verification awaits

Deterministic regressions prove shutdown during connect backoff performs exactly one dial, terminal request errors do not enter retry sleep, and named writes neither retry nor recast terminal shutdown.

Reconciliation verification at `3465790`:

- dongle transport suite: **106 passed**
- full unit suite: **3071 passed, 1 skipped**
- Ruff and Ruff format: passed
- strict mypy: **94 source files clean**
- prek non-mypy hooks: passed; strict mypy was run directly in the worktree environment
- `git diff --check`: clean