### PR TITLE
fix: stamp _battery_cache_time only on a delivered battery read

### DIFF
--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -167,8 +167,18 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         self._energy_cache_ttl = timedelta(minutes=5)  # 5-minute TTL for energy
         self._energy_cache_lock = asyncio.Lock()
 
-        # Battery data cache
+        # Battery data cache.  _battery_cache_time is a SUCCESS signal: it is
+        # stamped only when a battery fetch actually delivered data, so
+        # consumers (eg4_web_monitor's device-removal completeness check) can
+        # treat it as "a battery read has genuinely succeeded".  The transport
+        # leg's read_battery() deliberately returns None on a failed/short BMS
+        # block read (eg4_web_monitor#261) — that must NOT stamp it.
         self._battery_cache_time: datetime | None = None
+        # TTL gate for the transport battery read.  Stamped on every attempt
+        # (success or None) so a bank that legitimately reads None every time
+        # (a no-BMS secondary) keeps its polling cadence instead of being
+        # re-read every cycle.
+        self._battery_read_attempt_time: datetime | None = None
         self._battery_cache_ttl = timedelta(seconds=30)  # 30-second TTL for battery
         self._battery_cache_lock = asyncio.Lock()
         # Dedicated clock for the hybrid supplemental cloud battery refresh
@@ -768,7 +778,9 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                 self._energy_cache_time, self._energy_cache_ttl, force
             )
             battery_expired = self._is_cache_expired(
-                self._battery_cache_time, self._battery_cache_ttl, force
+                self._battery_read_attempt_time or self._battery_cache_time,
+                self._battery_cache_ttl,
+                force,
             )
 
         # Combined read path: when transport supports read_all_input_data
@@ -1040,7 +1052,8 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
                     # Supplement with cloud metadata (battery type, model)
                     await self._fetch_battery_metadata()
                     self._apply_battery_metadata()
-                self._battery_cache_time = datetime.now()
+                    self._battery_cache_time = datetime.now()
+                self._battery_read_attempt_time = datetime.now()
             except Exception as err:
                 # Keep existing cached data on transport errors.  Debug level:
                 # this fires every poll during a link outage.

--- a/tests/unit/devices/inverters/test_base.py
+++ b/tests/unit/devices/inverters/test_base.py
@@ -325,6 +325,99 @@ class TestCombinedTransportRefresh:
         assert inverter._transport_runtime is mock_runtime
 
 
+class TestTransportBatterySuccessStamp:
+    """_battery_cache_time is a success signal, not an attempt log.
+
+    read_battery() deliberately returns None on a failed/short BMS block read
+    (eg4_web_monitor#261).  eg4_web_monitor's device-removal completeness
+    check (its PR #489) reads _battery_cache_time as "a battery fetch has
+    genuinely succeeded" — an attempt-stamped clock would let a cold-restart
+    battery-read outage masquerade as a confirmed empty bank and authorize
+    deleting live battery module devices.  The TTL gate rides the separate
+    attempt stamp so polling cadence is unchanged.
+    """
+
+    def _inverter_with_battery_read(
+        self, mock_client: LuxpowerClient, read_battery: AsyncMock
+    ) -> ConcreteInverter:
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_transport = AsyncMock(spec=["read_runtime", "read_energy", "read_battery"])
+        mock_transport.read_runtime = AsyncMock(return_value=None)
+        mock_transport.read_energy = AsyncMock(return_value=None)
+        mock_transport.read_battery = read_battery
+        inverter._transport = mock_transport
+        return inverter
+
+    @pytest.mark.asyncio
+    async def test_none_read_stamps_attempt_but_not_success(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A None battery read must not stamp the success clock."""
+        inverter = self._inverter_with_battery_read(mock_client, AsyncMock(return_value=None))
+
+        await inverter._fetch_battery()
+
+        assert inverter._battery_cache_time is None
+        assert inverter._battery_read_attempt_time is not None
+
+    @pytest.mark.asyncio
+    async def test_none_read_keeps_polling_cadence(self, mock_client: LuxpowerClient) -> None:
+        """A perpetually-None bank (no-BMS secondary) is still TTL-gated."""
+        read_battery = AsyncMock(return_value=None)
+        inverter = self._inverter_with_battery_read(mock_client, read_battery)
+
+        await inverter.refresh(force=True)
+        assert read_battery.await_count == 1
+
+        # Immediately after, the attempt stamp is fresh: an unforced refresh
+        # must not re-read the battery block even though no success was ever
+        # recorded.
+        await inverter.refresh()
+        assert read_battery.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_successful_read_stamps_success(self, mock_client: LuxpowerClient) -> None:
+        """A delivered battery bank stamps the success clock."""
+        from pylxpweb.transports.data import BatteryBankData
+
+        mock_battery = Mock(spec=BatteryBankData)
+        mock_battery.is_corrupt = Mock(return_value=False)
+        mock_battery.battery_count = 2
+        inverter = self._inverter_with_battery_read(
+            mock_client, AsyncMock(return_value=mock_battery)
+        )
+
+        with (
+            patch.object(inverter, "_fetch_battery_metadata", AsyncMock()),
+            patch.object(inverter, "_apply_battery_metadata", Mock()),
+        ):
+            await inverter._fetch_battery()
+
+        assert inverter._transport_battery is mock_battery
+        assert inverter._battery_cache_time is not None
+        assert inverter._battery_read_attempt_time is not None
+
+    @pytest.mark.asyncio
+    async def test_corrupt_read_stamps_neither(self, mock_client: LuxpowerClient) -> None:
+        """A corrupt read keeps both clocks unset so the next cycle retries."""
+        from pylxpweb.transports.data import BatteryBankData
+
+        mock_battery = Mock(spec=BatteryBankData)
+        mock_battery.is_corrupt = Mock(return_value=True)
+        inverter = self._inverter_with_battery_read(
+            mock_client, AsyncMock(return_value=mock_battery)
+        )
+        inverter.validate_data = True
+
+        await inverter._fetch_battery()
+
+        assert inverter._battery_cache_time is None
+        assert inverter._battery_read_attempt_time is None
+        assert inverter._transport_battery is None
+
+
 class TestInverterDeviceInfo:
     """Test inverter device info generation."""
 


### PR DESCRIPTION
The transport leg of `_fetch_battery` stamped `_battery_cache_time` outside the `transport_battery is not None` check, so a failed/short BMS block read — which `read_battery()` deliberately maps to `None` (eg4_web_monitor#261) — still advanced the clock.

eg4_web_monitor's device-removal completeness check (its PR joyfulhouse/eg4_web_monitor#489) reads that clock as proof a battery fetch has genuinely succeeded; the unconditional stamp let a cold-restart battery-read outage masquerade as a confirmed empty bank on exactly one leg (battery TTL expiring while runtime stays fresh, or transports without the combined read — the combined path's stamp was already success-gated).

Fix: `_battery_cache_time` is now a success-only signal. The read TTL rides a new `_battery_read_attempt_time` stamped on every attempt, so a bank that legitimately reads None every cycle (a no-BMS secondary) keeps its polling cadence instead of being re-read every cycle. The corrupt-read and exception paths stamp neither, exactly as before. HTTP path unchanged (already success-only).

Four regression tests pin: None-read stamps attempt but not success, cadence preserved on perpetual-None, success stamps both, corrupt stamps neither. Full suite: 3177 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)