### PR TITLE
fix: derive bank capacity_percent from BMS pair on fake cloud zero

### DIFF
--- a/src/pylxpweb/devices/battery_bank.py
+++ b/src/pylxpweb/devices/battery_bank.py
@@ -563,10 +563,23 @@ class BatteryBank(BaseDevice):
     def capacity_percent(self) -> int | None:
         """Get capacity percentage.
 
+        A raw non-zero ``capacityPercent`` is authoritative.  The cloud
+        computes the field from the battery module array, so units that
+        report no array leave it frozen at 0 while the BMS pair stays real
+        (live 12000XP, issue eg4#514: ``capacityPercent=0`` with
+        ``currentBatteryCharge/maxBatteryCharge`` = 260/500 matching soc=52
+        exactly) — on a fake 0/None with the pair present, derive the
+        percentage from the pair instead.  A genuine 0% bank is unaffected:
+        its pair derives ~0 anyway.
+
         Returns:
             Capacity percentage (0-100), or None if not available.
         """
-        return self.data.capacityPercent
+        raw = self.data.capacityPercent
+        pair = self._bms_capacity_pair
+        if not raw and pair is not None:
+            return round(pair[1] / pair[0] * 100)
+        return raw
 
     # ========== Current Properties ==========
 

--- a/tests/unit/devices/test_battery_bank.py
+++ b/tests/unit/devices/test_battery_bank.py
@@ -1218,7 +1218,7 @@ class TestCapacityPercentFakeZeroFallback:
         )
         bank = BatteryBank(
             client=mock_client,
-            inverter_serial="60534A0404",
+            inverter_serial="1234567890",
             battery_info=battery_info,
         )
 
@@ -1234,7 +1234,7 @@ class TestCapacityPercentFakeZeroFallback:
         )
         bank = BatteryBank(
             client=mock_client,
-            inverter_serial="60534A0404",
+            inverter_serial="1234567890",
             battery_info=battery_info,
         )
 
@@ -1250,7 +1250,7 @@ class TestCapacityPercentFakeZeroFallback:
         )
         bank = BatteryBank(
             client=mock_client,
-            inverter_serial="52842P0581",
+            inverter_serial="1234567890",
             battery_info=battery_info,
         )
 
@@ -1267,7 +1267,7 @@ class TestCapacityPercentFakeZeroFallback:
         )
         bank = BatteryBank(
             client=mock_client,
-            inverter_serial="4524850115",
+            inverter_serial="1234567890",
             battery_info=battery_info,
         )
 
@@ -1283,7 +1283,7 @@ class TestCapacityPercentFakeZeroFallback:
         )
         bank = BatteryBank(
             client=mock_client,
-            inverter_serial="60534A0404",
+            inverter_serial="1234567890",
             battery_info=battery_info,
         )
 

--- a/tests/unit/devices/test_battery_bank.py
+++ b/tests/unit/devices/test_battery_bank.py
@@ -1191,3 +1191,100 @@ class TestBankCapacityPrefersBmsValues:
 
         assert bank.full_capacity == 840
         assert bank.remain_capacity == 0
+
+
+class TestCapacityPercentFakeZeroFallback:
+    """capacityPercent=0 with a live BMS pair is a fake zero (issue eg4#514).
+
+    The cloud computes ``capacityPercent`` (and ``remainCapacity``/
+    ``fullCapacity``) from the battery module array; units that report no
+    array (live 12000XP: ``batteryArray=[]``, ``totalNumber=0``) leave all
+    three frozen at 0 while ``maxBatteryCharge``/``currentBatteryCharge``
+    stay real (260/500 = 52% exactly matching soc=52 across three polled
+    cycles). A raw non-zero value stays authoritative — accounts that
+    populate the field (live 18kPV=79, FlexBOSS21=65) are untouched.
+    """
+
+    def test_fake_zero_derives_from_bms_pair(self, mock_client):
+        """The live 12000XP shape: 0 with a real pair derives 260/500=52."""
+        battery_info = BatteryInfo.model_construct(
+            maxBatteryCharge=500,
+            currentBatteryCharge=260.0,
+            fullCapacity=0,
+            remainCapacity=0,
+            capacityPercent=0,
+            batteryArray=[],
+            totalNumber=0,
+        )
+        bank = BatteryBank(
+            client=mock_client,
+            inverter_serial="60534A0404",
+            battery_info=battery_info,
+        )
+
+        assert bank.capacity_percent == 52
+
+    def test_none_derives_from_bms_pair(self, mock_client):
+        """An absent capacityPercent also derives when the pair is live."""
+        battery_info = BatteryInfo.model_construct(
+            maxBatteryCharge=500,
+            currentBatteryCharge=370.0,
+            capacityPercent=None,
+            batteryArray=[],
+        )
+        bank = BatteryBank(
+            client=mock_client,
+            inverter_serial="60534A0404",
+            battery_info=battery_info,
+        )
+
+        assert bank.capacity_percent == 74
+
+    def test_real_nonzero_value_stays_primary(self, mock_client):
+        """A populated capacityPercent wins even if the pair disagrees."""
+        battery_info = BatteryInfo.model_construct(
+            maxBatteryCharge=840,
+            currentBatteryCharge=546.0,  # pair would derive 65
+            capacityPercent=64,
+            batteryArray=[],
+        )
+        bank = BatteryBank(
+            client=mock_client,
+            inverter_serial="52842P0581",
+            battery_info=battery_info,
+        )
+
+        assert bank.capacity_percent == 64
+
+    def test_zero_without_pair_is_unchanged(self, mock_client):
+        """No BMS pair (live GridBOSS shape): the raw 0 passes through."""
+        battery_info = BatteryInfo.model_construct(
+            maxBatteryCharge=None,
+            currentBatteryCharge=None,
+            capacityPercent=0,
+            batteryArray=[],
+            totalNumber=0,
+        )
+        bank = BatteryBank(
+            client=mock_client,
+            inverter_serial="4524850115",
+            battery_info=battery_info,
+        )
+
+        assert bank.capacity_percent == 0
+
+    def test_genuinely_empty_bank_derives_zero(self, mock_client):
+        """A truly empty BMS-backed bank still reads ~0 via the pair."""
+        battery_info = BatteryInfo.model_construct(
+            maxBatteryCharge=500,
+            currentBatteryCharge=1.0,
+            capacityPercent=0,
+            batteryArray=[],
+        )
+        bank = BatteryBank(
+            client=mock_client,
+            inverter_serial="60534A0404",
+            battery_info=battery_info,
+        )
+
+        assert bank.capacity_percent == 0  # round(1/500*100)

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.39b7"
+version = "0.9.39b8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Bug

joyfulhouse/eg4_web_monitor#514 — **Bank Capacity Percent is always 0** on a 12000XP in CLOUD mode.

## Root cause

The cloud computes `capacityPercent` (and `remainCapacity`/`fullCapacity`) from the battery module array. Units that report no array to the cloud (reporter's 12000XP debug log: `batteryArray=[]`, `totalNumber=0`) leave all three frozen at 0 — while the BMS pair `maxBatteryCharge`/`currentBatteryCharge` stays live and correct (260/500 = 52% matching `soc=52` **exactly**, across all three logged poll cycles: 52/74/75%). `BatteryBank.capacity_percent` passed the fake 0 through verbatim. The LOCAL path (`BatteryBankData.capacity_percent`) already derives current/max and was never affected.

## Fix

`capacity_percent` keeps the raw cloud value as **primary**; only when it reads 0 or None *and* `_bms_capacity_pair` is present does it derive `round(current / max × 100)`. Live-verified on the maintainer's account that populated devices return a real `capacityPercent` (18kPV=79, FlexBOSS21=65) matching pair-derivation exactly — those are byte-for-byte unchanged, as are no-pair devices (GridBOSS all-zero shape) and genuine 0% banks (their pair derives ~0 anyway).

Also syncs `uv.lock` to the 0.9.39b8 version bump (missed in the release commit; any `uv` invocation regenerates it).

## Test plan

- New regression class `TestCapacityPercentFakeZeroFallback` (5 cases): the live 12000XP shape 0→52%, None→derive, real-non-zero-stays-primary, no-pair unchanged, genuine-empty-bank ~0.
- Full suite: **3182 passed** locally.
- Lint/format/mypy strict: clean.

## Tri-vendor adversarial review

Claude (code-reviewer agent), Codex `gpt-5.6-sol` @ xhigh, Gemini 3.1 Pro — **all three: NO BLOCKING ISSUES**.

**Risk-accepted MEDIUM** (Claude): the priority order here (raw-first, pair-fallback) is intentionally the opposite of `remain_capacity`/`full_capacity` (pair-first). Deliberate maintainer decision: raw `capacityPercent` is live-verified correct on populated accounts (it matches pair-derivation exactly, including on the double-counting 18kPV bank where `capacityPercent=59` = pair ratio), so the conservative change only rescues the provably-fake 0/None case. Codex's in-sandbox run showed 8 transport-test failures (loopback-socket tests blocked by its read-only sandbox) — not present in the native run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)