### PR TITLE
fix: exclude non-measurement generator registers on EG4_OFFGRID (#544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.39b10] - 2026-08-08
+
+### Changed
+
+- **Input register 123 is no longer published as generator power on the
+  EG4_OFFGRID family, and "using generator" no longer derives from it**
+  ([eg4_web_monitor#544](https://github.com/joyfulhouse/eg4_web_monitor/issues/544)).
+  Decoding a 12000XP's own firmware (`ceaa-0709`) showed the Modbus FC04
+  handler for register 123 returns a word of the ARM comms processor's own RAM
+  that a timer task increments once per second with no bound check, so it wraps
+  at 65536 — seconds since boot, not watts. A whole-image writer audit found
+  only that increment and the power-on clear; no DSP measurement path reaches
+  it. The reporting user saw 28,646 W with nothing connected to the GEN port,
+  and their two samples fit the wrap with zero free parameters
+  (`(5610 − 28646) mod 65536 = 42,500 s`, within 33 seconds of the real
+  interval between captures).
+
+  - `generator_power` now returns `None` on positively-identified EG4_OFFGRID.
+    Other families — including an **unresolved** one — are unchanged, so a
+    transient feature-detection failure cannot blank a genuine measurement.
+  - `is_using_generator` is derived from the GEN terminal's own voltage and
+    frequency (registers 121/122, genuine measurements on every family that
+    read 0 with nothing attached) instead of `generator_power > 0`. That
+    predicate was wrong on **both** families: on EG4_OFFGRID the counter pinned
+    it True until the 16-bit wrap, and on EG4_HYBRID register 123 reports
+    whatever crosses the *multiplexed* GEN terminal — including AC-coupled PV,
+    measured at ~3 kW on a FlexBOSS21 with no generator anywhere on site. The
+    property now means "GEN input is energised", not "drawing power"; a running
+    but unloaded generator answers True. The portal's `_12KUsingGenerator` flag
+    is still used where the measurements are genuinely absent.
+  - `ac_couple_power`'s fallback to register 123 is gated off for EG4_OFFGRID.
+    Registers 121/122/153 and 123 sit in different read blocks, so a partial
+    local read could lose 153 while keeping 123 and republish the counter as
+    tens of kW of "AC couple power". Register 153 is confirmed present on that
+    family ([eg4_web_monitor#196](https://github.com/joyfulhouse/eg4_web_monitor/issues/196)
+    measured `I153 = 1409 W` tracking cloud `acCouplePower`), so the fallback
+    bought it nothing.
+
+  Register-map descriptions for 123–126 are updated with the firmware findings.
+  The long-standing UNVERIFIED note on 124/125/126 is **resolved**: 124 is
+  byte-assembled from a frame metadata byte plus a local status bitmask, and
+  125/126 are the two halves of one 32-bit status word — which is why a
+  reported "lifetime" of 135,494.5 kWh decodes to the bit pattern `0x0014ACC1`,
+  whose low word `0xACC1` also appeared on a *different* 12000XP in #196 five
+  months earlier.
 
 ### Fixed
 

--- a/docs/PROPERTY_REFERENCE.md
+++ b/docs/PROPERTY_REFERENCE.md
@@ -147,13 +147,17 @@ print(f"Bus 2: {inverter.bus2_voltage}V")
 | `ac_couple_power` | `int` | W | AC coupled power | 0 |
 | `generator_voltage` | `float` | V | Generator voltage | 0.0 |
 | `generator_frequency` | `float` | Hz | Generator frequency | 0.0 |
-| `generator_power` | `int` | W | Generator power | 0 |
-| `is_using_generator` | `bool` | - | Whether generator is in use | False |
+| `generator_power` | `int \| None` | W | GEN-terminal power. **`None` on EG4_OFFGRID**, where the register is a 1 Hz counter, not watts ([eg4_web_monitor#544](https://github.com/joyfulhouse/eg4_web_monitor/issues/544)). On EG4_HYBRID/LXP it measures the *multiplexed* GEN terminal, so it also carries AC-coupled PV and smart-load throughput — it is not generator-specific. | `None` |
+| `is_using_generator` | `bool` | - | Whether the GEN input is **energised** — derived from generator voltage AND frequency. Means "energised", not "drawing power": a running but unloaded generator is `True`. | False |
 
 **Example**:
 ```python
 if inverter.is_using_generator:
-    print(f"Generator: {inverter.generator_power}W @ {inverter.generator_frequency}Hz")
+    print(f"Generator input energised @ {inverter.generator_frequency}Hz")
+    # generator_power is None on EG4_OFFGRID, and elsewhere measures the
+    # multiplexed GEN terminal rather than the generator alone.
+    if inverter.generator_power is not None:
+        print(f"GEN terminal: {inverter.generator_power}W")
 if inverter.ac_couple_power > 0:
     print(f"AC Couple: {inverter.ac_couple_power}W")
 ```
@@ -622,9 +626,14 @@ Some properties (like PV3, generator) may not be available on all devices:
 if inverter.pv3_voltage > 0:
     print(f"PV3: {inverter.pv3_voltage}V @ {inverter.pv3_power}W")
 
-# Generator returns 0 if not active
-if inverter.generator_power > 0:
-    print(f"Generator: {inverter.generator_power}W")
+# generator_power is None on EG4_OFFGRID (the register is a counter there),
+# and on other families it measures the multiplexed GEN terminal rather than
+# the generator specifically -- so guard for None, and use is_using_generator
+# to ask whether a generator is actually running.
+if inverter.is_using_generator:
+    print("Generator input is energised")
+if inverter.generator_power is not None and inverter.generator_power > 0:
+    print(f"GEN terminal: {inverter.generator_power}W")
 ```
 
 ### Type Safety

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -164,8 +164,11 @@ For systems with generator or AC coupling:
 ```python
 print(f"Generator Voltage: {inverter.generator_voltage}V")
 print(f"Generator Frequency: {inverter.generator_frequency}Hz")
-print(f"Generator Power: {inverter.generator_power}W")
-print(f"Using Generator: {inverter.is_using_generator}")
+# None on EG4_OFFGRID (register 123 is a 1 Hz counter there, not watts);
+# elsewhere it is the multiplexed GEN terminal, not generator-specific.
+print(f"GEN terminal Power: {inverter.generator_power}W")
+# True when the GEN input is energised (voltage AND frequency present).
+print(f"Generator input energised: {inverter.is_using_generator}")
 print(f"AC Couple Power: {inverter.ac_couple_power}W")
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.39b9"
+version = "0.9.39b10"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/src/pylxpweb/devices/inverters/_runtime_properties.py
+++ b/src/pylxpweb/devices/inverters/_runtime_properties.py
@@ -474,23 +474,58 @@ class InverterRuntimePropertiesMixin:
     # ===========================================
 
     @property
+    def _model_family(self) -> InverterFamily | None:
+        """This device's detected family, or None when unresolved.
+
+        ``UNKNOWN`` is reported as None: ``detect_features()`` returns the
+        default WITHOUT raising when its parameter fetch fails, so UNKNOWN is
+        what the pipeline emits for a device whose family could not be
+        determined — never evidence of what the hardware is.
+        """
+        features = getattr(self, "_features", None)
+        family = getattr(features, "model_family", None)
+        if family is None or family is InverterFamily.UNKNOWN:
+            return None
+        return family  # type: ignore[no-any-return]
+
+    @property
+    def _is_offgrid_family(self) -> bool:
+        """Whether this device is positively identified as EG4_OFFGRID."""
+        return self._model_family is InverterFamily.EG4_OFFGRID
+
+    @property
     def ac_couple_power(self) -> int:
         """Get AC coupled power in watts.
 
         Prefers register 153 (ac_couple_power) from local transport when
-        available.  Falls back to register 123 (generator_power) for
-        EG4_HYBRID devices where both registers carry equivalent AC
-        couple data.  Cloud path uses acCouplePower field.
+        available.  Cloud path uses the acCouplePower field.
 
-        On EG4_OFFGRID (12000XP/6000XP), register 123 is a seconds
-        counter — only register 153 is correct.
+        Falls back to register 123 ONLY for positively-identified EG4_HYBRID,
+        where the two registers carry equivalent AC couple data.  The gate is
+        POSITIVE rather than "not off-grid" because an unresolved family is not
+        evidence of anything: register 123 is a free-running 1 Hz counter on
+        EG4_OFFGRID (eg4_web_monitor#544, proven from a 12000XP's own firmware
+        — the FC04 handler returns a word of ARM RAM that a timer task
+        increments with no bound check), and regs 121/122/153 sit in a
+        different read block from 123, so a partial read that lost 153 while
+        keeping 123 would otherwise republish the counter as tens of kW of "AC
+        couple power" on any device whose detection had not settled.  Register
+        153 is confirmed present on the off-grid family anyway
+        (eg4_web_monitor#196 measured I153=1409 W tracking cloud
+        acCouplePower), so the fallback buys it nothing there.
+
+        Known ambiguity: a missing reading returns 0, indistinguishable from a
+        measured zero — pre-existing to this property's ``int`` contract.
+        Widening to ``int | None`` is deferred to the next minor version.
         """
         if self._transport_runtime is not None:
             # Prefer reg 153 (ac_couple_power) — correct for all families
             val = self._transport_runtime.ac_couple_power
             if val is not None:
                 return int(val)
-            # Fall back to reg 123 (generator_power) — valid on EG4_HYBRID
+            if self._model_family is not InverterFamily.EG4_HYBRID:
+                return 0
+            # Fall back to reg 123 — equivalent AC couple data on this family
             val = self._transport_runtime.generator_power
             return int(val) if val is not None else 0
         if self._runtime is None:
@@ -499,26 +534,74 @@ class InverterRuntimePropertiesMixin:
 
     @property
     def generator_voltage(self) -> float | None:
-        """Get generator voltage in volts."""
+        """Get generator voltage in volts (input register 121)."""
         return self._scaled_float("generator_voltage", "genVolt")
 
     @property
     def generator_frequency(self) -> float | None:
-        """Get generator frequency in Hz."""
+        """Get generator frequency in Hz (input register 122)."""
         return self._scaled_float("generator_frequency", "genFreq")
 
     @property
     def generator_power(self) -> int | None:
-        """Get generator power in watts."""
+        """Get generator power in watts (input register 123).
+
+        Returns None on EG4_OFFGRID, where this register is NOT a measurement:
+        it is a free-running 16-bit counter incremented once per second by the
+        ARM comms processor and wrapping at 65536 — seconds since boot, not
+        watts.  Proven from a 12000XP's own firmware (eg4_web_monitor#544): the
+        FC04 handler reads a word of ARM-local RAM that a timer task
+        increments with no bound check, and a whole-image writer audit found no
+        DSP measurement path to it.  The reporting user saw 28,646 W with
+        nothing connected to the GEN port.
+
+        No substitute exists on that family — registers 188/189 are
+        unimplemented and no dedicated generator-power register has been
+        identified.  Generator voltage/frequency (regs 121/122) ARE genuine
+        there and read 0 when nothing is attached.
+        """
+        if self._is_offgrid_family:
+            return None
         return self._raw_int("generator_power", "genPower")
 
     @property
     def is_using_generator(self) -> bool:
-        """Check if generator is currently in use."""
-        if self._transport_runtime is not None:
-            val = self._transport_runtime.generator_power
-            return val is not None and int(val) > 0
-        if self._runtime is None:
+        """Whether the generator input is currently energised.
+
+        Derived from the GEN terminal's own voltage and frequency (regs
+        121/122) — genuine measurements on every family that read 0 with
+        nothing attached.  Deliberately NOT from generator_power, which was the
+        previous implementation and is wrong on both families: on EG4_OFFGRID
+        reg 123 is a 1 Hz counter, so `> 0` latched True until the 16-bit wrap;
+        on EG4_HYBRID reg 123 reports whatever crosses the multiplexed GEN
+        terminal, including AC-coupled PV, so it read True with no generator
+        present (eg4_web_monitor#544).
+
+        Means "GEN input is energised", not "drawing power" — a generator that
+        is running but unloaded still answers True.
+
+        The portal's own ``_12KUsingGenerator`` flag is used only when there is
+        no local transport at all (pure CLOUD, where the measurements are
+        always present anyway since ``genVolt``/``genFreq`` are non-optional
+        ints defaulting to 0).  A transport-backed device whose regs 121/122
+        went missing on a partial read answers False rather than consulting it:
+        in HYBRID the cloud ``_runtime`` is refreshed only for EG4_OFFGRID
+        (see ``_wants_hybrid_supplemental_runtime``), so for other families it
+        is a setup-time snapshot and presenting it as current state would be
+        worse than reporting nothing.
+
+        CAVEAT: regs 121/122 are established as genuine on EG4_HYBRID and read
+        0 with nothing attached on EG4_OFFGRID, but no capture of an ACTIVE
+        generator on the off-grid family exists yet — so the True direction is
+        unverified there.  If they turn out to be stubs on that platform this
+        property would be permanently False for it; eg4_web_monitor#544 has an
+        open request to the reporter for a generator-running capture.
+        """
+        voltage = self.generator_voltage
+        frequency = self.generator_frequency
+        if voltage is not None and frequency is not None:
+            return bool(voltage > 0 and frequency > 0)
+        if self._transport_runtime is not None or self._runtime is None:
             return False
         return self._runtime._12KUsingGenerator
 

--- a/src/pylxpweb/registers/inverter_input.py
+++ b/src/pylxpweb/registers/inverter_input.py
@@ -1110,7 +1110,26 @@ INVERTER_INPUT_REGISTERS: tuple[RegisterDefinition, ...] = (
         ha_sensor_key="generator_power",
         unit="W",
         category=RegisterCategory.GENERATOR,
-        description="Generator power.",
+        models=frozenset({"EG4_HYBRID", "LXP"}),
+        description="Generator power — EXCLUDED from EG4_OFFGRID, where it is not a "
+        "measurement.  On that family (12000XP/6000XP) this register is a "
+        "free-running 16-bit counter incremented once per second by the ARM "
+        "comms processor and wrapping at 65536 (seconds since boot, not "
+        "watts), proven by decoding a 12000XP's own ceaa-0709 firmware in "
+        "eg4_web_monitor#544: the FC04 handler reads a word of ARM-local RAM "
+        "that a timer task increments with no bound check, and a whole-image "
+        "writer audit found no DSP path to it.  Because this definition is "
+        "family-scoped, registers_for_model/sensor_keys_for_model omit it and "
+        "InverterRuntimeData.generator_power decodes to None there; the cloud "
+        "genPower field is gated separately on the generator_power property.  "
+        "On EG4_HYBRID/LXP the register carries real power, but from the "
+        "MULTIPLEXED GEN terminal — generator, AC-coupled PV, or smart load — "
+        "so it is not generator-specific: measured on a FlexBOSS21 + 18kPV "
+        "GridBOSS parallel system with no generator on site, the two "
+        "inverters' values sum to the GridBOSS AC-Couple-1 total within "
+        "0.13%.  That hybrid reading is an empirical correlation — the only "
+        "firmware image decoded is the off-grid one.  Never infer 'generator "
+        "running' from this register; use regs 121/122.",
     ),
     RegisterDefinition(
         address=124,
@@ -1120,14 +1139,21 @@ INVERTER_INPUT_REGISTERS: tuple[RegisterDefinition, ...] = (
         scale=ScaleFactor.DIV_10,
         unit="kWh",
         category=RegisterCategory.ENERGY_DAILY,
-        description="Generator energy today (Egen_day). EG4_OFFGRID caveat: "
-        "the withdrawn eg4_web_monitor PR #220 claimed regs 124-126 hold "
-        "AC-couple energy in raw Wh (DIV_1000) on the 12000XP, but the "
-        "reporter's own earlier sweep (#196) read I124 == holding 179 "
-        "exactly (0x0800, the AC-couple enable bit) and successive captures "
-        "moved by exact powers of two — bit-field behavior, not energy "
-        "accrual. Semantics on the SNA platform are UNVERIFIED; do not "
-        "surface as a sensor for that family without a fresh capture.",
+        models=frozenset({"EG4_HYBRID", "LXP"}),
+        description="Generator energy today (Egen_day).  EXCLUDED from EG4_OFFGRID, where "
+        "it is NOT energy — resolved from firmware in eg4_web_monitor#544.  "
+        "The FC04 handler assembles it from two separate bytes, "
+        "(RAM8[hi] << 8) | RAM8[lo]: the low byte is a locally-maintained "
+        "status bitmask whose bits are set/cleared by ordinary firmware "
+        "logic, and the high byte is copied from a DSP receive-frame "
+        "metadata field.  A reported 179.2 kWh is raw 1792 = 0x0700; the "
+        "0x07 high byte coincides with that firmware's own v1 version "
+        "number, which is suggestive of a version/metadata byte but is a "
+        "single observation, not a proven identity.  This supersedes the "
+        "earlier UNVERIFIED note — the bit-field reading #196's sweep "
+        "suspected, and the withdrawn PR #220 disputed, is confirmed.  "
+        "Family-scoped, so it decodes to None rather than reaching "
+        "InverterEnergyData on that family.",
     ),
     RegisterDefinition(
         address=125,
@@ -1138,9 +1164,17 @@ INVERTER_INPUT_REGISTERS: tuple[RegisterDefinition, ...] = (
         scale=ScaleFactor.DIV_10,
         unit="kWh",
         category=RegisterCategory.ENERGY_LIFETIME,
-        description="Generator cumulative energy (Egen_all, 32-bit). "
-        "EG4_OFFGRID caveat: unverified on the SNA platform — see the "
-        "register-124 note (PR #220 adjudication).",
+        models=frozenset({"EG4_HYBRID", "LXP"}),
+        description="Generator cumulative energy (Egen_all, 32-bit).  EXCLUDED from "
+        "EG4_OFFGRID, where it is NOT energy — resolved from firmware in "
+        "eg4_web_monitor#544.  Registers 125 and 126 are the low and high "
+        "halves of ONE 32-bit status word whose individual bits are set and "
+        "cleared throughout the firmware; there is no accumulator.  A "
+        "reported 'lifetime' of 135,494.5 kWh is the bit pattern 0x0014ACC1 "
+        "— and the same 0xACC1 low word was recorded on a DIFFERENT 12000XP "
+        "in #196 five months earlier, which is what a stable status field "
+        "looks like and what an energy total does not.  Family-scoped, so it "
+        "decodes to None rather than reaching InverterEnergyData there.",
     ),
     # =========================================================================
     # SPLIT-PHASE EPS L1/L2 (regs 127-138) — US models

--- a/tests/unit/devices/inverters/test_issue_544_generator_registers.py
+++ b/tests/unit/devices/inverters/test_issue_544_generator_registers.py
@@ -1,0 +1,232 @@
+"""Input registers 123-126 are not measurements on EG4_OFFGRID (eg4_web_monitor#544).
+
+Proven by decoding the reporting device's own firmware (12000XP, ``ceaa-0709``):
+
+  * Reg 123 — the Modbus FC04 handler returns a word of the ARM comms
+    processor's own RAM that a timer task increments once per second with no
+    bound check, so it wraps at 65536.  It is seconds-since-boot, not watts; a
+    whole-image writer audit found no DSP measurement path to it.  The reporting
+    user saw 28,646 W with nothing connected to the GEN port, and their two
+    samples fit the wrap with zero free parameters
+    (``(5610 - 28646) mod 65536 = 42500 s``, within 33 s of the real interval).
+  * Regs 124/125/126 — ARM-local status words, not accumulators.
+
+On EG4_HYBRID reg 123 IS measurement-derived, but from the MULTIPLEXED GEN
+terminal, so it carries AC-coupled PV too and is still not generator-specific.
+Hence: ``generator_power`` is None only on EG4_OFFGRID, while
+``is_using_generator`` stops using that register on BOTH families.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pylxpweb.devices.inverters._features import InverterFamily, InverterFeatures
+from pylxpweb.devices.inverters.generic import GenericInverter
+from pylxpweb.models import InverterRuntime
+from pylxpweb.registers.inverter_input import sensor_keys_for_model
+from pylxpweb.transports.data import InverterEnergyData, InverterRuntimeData
+
+
+def _inverter(family: InverterFamily) -> GenericInverter:
+    """Inverter with a transport runtime and a positively-resolved family."""
+    inverter = GenericInverter(client=MagicMock(), serial_number="1234567890", model="12000XP")
+    inverter._transport_runtime = InverterRuntimeData()
+    inverter._features = InverterFeatures(model_family=family)
+    return inverter
+
+
+class TestRegisterMapFamilyScoping:
+    """The decode layer — the surface downstream consumers actually read.
+
+    Gating only the ``generator_power`` property would have left
+    ``InverterRuntimeData``/``InverterEnergyData`` publishing the raw counter
+    and status bitfields, which is what the Home Assistant integration reads on
+    its LOCAL and HYBRID paths — i.e. exactly the modes #544 was reported on.
+    """
+
+    def test_offgrid_runtime_decode_drops_the_counter(self) -> None:
+        """Reg 123 must not reach InverterRuntimeData on EG4_OFFGRID."""
+        data = InverterRuntimeData.from_modbus_registers(
+            {121: 0, 122: 0, 123: 28646}, "EG4_OFFGRID"
+        )
+        assert data.generator_power is None
+        # ...while the genuine GEN-terminal measurements still decode.
+        assert data.generator_voltage == 0
+        assert data.generator_frequency == 0
+
+    @pytest.mark.parametrize("family", ["EG4_HYBRID", "LXP"])
+    def test_other_families_still_decode_reg123(self, family: str) -> None:
+        data = InverterRuntimeData.from_modbus_registers({123: 2645}, family)
+        assert data.generator_power == 2645
+
+    def test_offgrid_energy_decode_drops_the_status_words(self) -> None:
+        """Regs 124/125/126 must not reach InverterEnergyData on EG4_OFFGRID.
+
+        These are the worse harm of the two: they would land in Home
+        Assistant's long-term statistics as kWh totals.
+        """
+        data = InverterEnergyData.from_modbus_registers(
+            {124: 1792, 125: 44225, 126: 20}, "EG4_OFFGRID"
+        )
+        assert data.generator_energy_today is None
+        assert data.generator_energy_total is None
+
+    def test_offgrid_sensor_keys_exclude_the_phantom_keys(self) -> None:
+        keys = sensor_keys_for_model("EG4_OFFGRID")
+        assert "generator_power" not in keys
+        # The real measurements keep their keys.
+        assert "generator_voltage" in keys
+        assert "generator_frequency" in keys
+        assert "generator_power" in sensor_keys_for_model("EG4_HYBRID")
+
+
+class TestGeneratorPowerFamilyGate:
+    """Reg 123 is suppressed only where it is proven not to be a measurement."""
+
+    def test_offgrid_returns_none_despite_a_live_register(self) -> None:
+        """The exact #544 reading is withheld rather than reported as watts."""
+        inverter = _inverter(InverterFamily.EG4_OFFGRID)
+        inverter._transport_runtime.generator_power = 28646.0
+        assert inverter.generator_power is None
+
+    @pytest.mark.parametrize(
+        "family",
+        [InverterFamily.EG4_HYBRID, InverterFamily.LXP, InverterFamily.UNKNOWN],
+    )
+    def test_other_families_pass_the_register_through(self, family: InverterFamily) -> None:
+        """Hybrid/LXP keep the value; an UNRESOLVED family keeps it too.
+
+        The gate is deliberately narrow: only positively-identified EG4_OFFGRID
+        is suppressed, so a transient feature-detection failure cannot silently
+        blank a genuine hybrid measurement.
+        """
+        inverter = _inverter(family)
+        inverter._transport_runtime.generator_power = 2645.0
+        assert inverter.generator_power == 2645
+
+
+class TestAcCouplePowerFallbackGate:
+    """The reg-123 fallback must never fire on EG4_OFFGRID."""
+
+    def test_offgrid_partial_read_does_not_republish_the_counter(self) -> None:
+        """Reg 153 missing + reg 123 present must NOT surface as AC couple power.
+
+        This is the residual path #544 left behind: regs 121/122/153 and 123 sit
+        in different read blocks, so a partial local read can lose 153 while
+        keeping 123.  Falling back would report ~28 kW of "AC Couple Power" on
+        the exact hardware the counter lives on.
+        """
+        inverter = _inverter(InverterFamily.EG4_OFFGRID)
+        inverter._transport_runtime.ac_couple_power = None
+        inverter._transport_runtime.generator_power = 28646.0
+        assert inverter.ac_couple_power == 0
+
+    def test_offgrid_still_uses_reg153_when_present(self) -> None:
+        """Reg 153 is confirmed on this family (#196: I153=1409 W) — keep it."""
+        inverter = _inverter(InverterFamily.EG4_OFFGRID)
+        inverter._transport_runtime.ac_couple_power = 1409.0
+        inverter._transport_runtime.generator_power = 28646.0
+        assert inverter.ac_couple_power == 1409
+
+    def test_hybrid_fallback_is_preserved(self) -> None:
+        """Non-off-grid behaviour is unchanged — the fallback still applies."""
+        inverter = _inverter(InverterFamily.EG4_HYBRID)
+        inverter._transport_runtime.ac_couple_power = None
+        inverter._transport_runtime.generator_power = 750.0
+        assert inverter.ac_couple_power == 750
+
+
+class TestIsUsingGenerator:
+    """Derived from GEN terminal V/Hz, never from reg 123."""
+
+    def test_offgrid_counter_no_longer_latches_true(self) -> None:
+        """The #544 symptom: a huge reg 123 with a dead GEN port.
+
+        The previous implementation returned True here (28646 > 0) and stayed
+        True until the 16-bit wrap.
+        """
+        inverter = _inverter(InverterFamily.EG4_OFFGRID)
+        inverter._transport_runtime.generator_power = 28646.0
+        inverter._transport_runtime.generator_voltage = 0.0
+        inverter._transport_runtime.generator_frequency = 0.0
+        assert inverter.is_using_generator is False
+
+    def test_hybrid_ac_coupled_pv_is_not_a_generator(self) -> None:
+        """Real hardware case: 3 kW of AC-coupled PV crossing the GEN terminal.
+
+        Measured on a FlexBOSS21 in a GridBOSS parallel system with no generator
+        anywhere on site — reg 123 read ~3069 W while gen V/Hz read 0.
+        """
+        inverter = _inverter(InverterFamily.EG4_HYBRID)
+        inverter._transport_runtime.generator_power = 3069.0
+        inverter._transport_runtime.generator_voltage = 0.0
+        inverter._transport_runtime.generator_frequency = 0.0
+        assert inverter.is_using_generator is False
+
+    def test_energised_generator_detected(self) -> None:
+        """A live GEN terminal is True even with reg 123 at zero."""
+        inverter = _inverter(InverterFamily.EG4_HYBRID)
+        inverter._transport_runtime.generator_power = 0.0
+        inverter._transport_runtime.generator_voltage = 240.1
+        inverter._transport_runtime.generator_frequency = 59.9
+        assert inverter.is_using_generator is True
+
+    @pytest.mark.parametrize(("volt", "freq"), [(240.0, 0.0), (0.0, 60.0)])
+    def test_requires_both_voltage_and_frequency(self, volt: float, freq: float) -> None:
+        """One live measurement alone is not an energised generator."""
+        inverter = _inverter(InverterFamily.EG4_HYBRID)
+        inverter._transport_runtime.generator_voltage = volt
+        inverter._transport_runtime.generator_frequency = freq
+        assert inverter.is_using_generator is False
+
+    def test_cloud_measurements_win_over_the_portal_flag(self) -> None:
+        """Pure CLOUD: V/Hz decide, because they are always present there.
+
+        ``InverterRuntime.genVolt``/``genFreq`` are non-optional ints defaulting
+        to 0, so the cloud path never has "missing" measurements and the portal
+        flag is not reached.  A dead GEN terminal answers False even if the
+        portal's 12K-specific flag disagrees — that ordering is deliberate,
+        since V/Hz is family-agnostic and the flag is not.
+        """
+        inverter = GenericInverter(client=MagicMock(), serial_number="1234567890", model="12000XP")
+        inverter._features = InverterFeatures(model_family=InverterFamily.EG4_OFFGRID)
+        inverter._runtime = InverterRuntime.model_construct(
+            genVolt=0, genFreq=0, genPower=28646, _12KUsingGenerator=True
+        )
+        assert inverter.is_using_generator is False
+
+    def test_transport_partial_read_does_not_use_the_stale_cloud_flag(self) -> None:
+        """HYBRID partial read: regs 121/122 lost → False, not the portal flag.
+
+        In HYBRID the cloud ``_runtime`` is refreshed only for EG4_OFFGRID
+        (``_wants_hybrid_supplemental_runtime``), so for other families it is a
+        setup-time snapshot.  Presenting a stale boolean as current state would
+        be worse than reporting nothing — and falling back to
+        ``generator_power`` instead would reintroduce #544 outright.
+        """
+        inverter = _inverter(InverterFamily.EG4_HYBRID)
+        inverter._transport_runtime.generator_voltage = None
+        inverter._transport_runtime.generator_frequency = None
+        inverter._transport_runtime.generator_power = 28646.0
+        inverter._runtime = InverterRuntime.model_construct(_12KUsingGenerator=True)
+        assert inverter.is_using_generator is False
+
+    def test_pure_cloud_with_no_measurements_uses_the_portal_flag(self) -> None:
+        """No transport and no V/Hz at all: the portal's own flag is all there is.
+
+        It is the portal's independent determination, NOT a
+        ``generator_power > 0`` comparison — #196 recorded the flag reading
+        false while reg 123 held a large counter value, so the portal does not
+        derive it from that register either.
+        """
+        inverter = GenericInverter(client=MagicMock(), serial_number="1234567890", model="12000XP")
+        inverter._features = InverterFeatures(model_family=InverterFamily.EG4_OFFGRID)
+        runtime = InverterRuntime.model_construct(_12KUsingGenerator=True)
+        # Drop the defaulted fields so the measurements read as genuinely absent.
+        del runtime.genVolt
+        del runtime.genFreq
+        inverter._runtime = runtime
+        assert inverter.is_using_generator is True

--- a/tests/unit/devices/inverters/test_runtime_properties.py
+++ b/tests/unit/devices/inverters/test_runtime_properties.py
@@ -294,8 +294,20 @@ class TestGeneratorProperties:
         assert inverter_with_runtime.generator_power == 0
 
     def test_generator_status(self, inverter_with_runtime):
-        """Verify generator status is boolean."""
-        assert inverter_with_runtime.is_using_generator is False
+        """Verify generator status reflects the GEN terminal's own V/Hz.
+
+        The fixture carries genVolt=240.0 V and genFreq=60.0 Hz, i.e. a live
+        generator input, so this is True.
+
+        It asserted False before eg4_web_monitor#544, when the property was
+        derived from ``generator_power > 0`` (the fixture's genPower is 0) and
+        fell through to the portal's ``_12KUsingGenerator`` flag.  That
+        predicate was wrong on both families — a 1 Hz counter on EG4_OFFGRID
+        and multiplexed GEN-terminal throughput on EG4_HYBRID — so the property
+        now reads the voltage/frequency measurements instead.  The fixture's
+        electrical state did not change; the question the property answers did.
+        """
+        assert inverter_with_runtime.is_using_generator is True
 
 
 class TestStatusProperties:
@@ -414,12 +426,33 @@ class TestACCouplePower:
         inverter._transport_runtime.generator_power = 9999.0  # seconds counter on OFFGRID
         assert inverter.ac_couple_power == 1500
 
-    def test_falls_back_to_transport_generator_power(self, inverter_with_transport):
-        """When transport has no ac_couple_power, fall back to generator_power."""
+    def test_falls_back_to_transport_generator_power_on_hybrid(self, inverter_with_transport):
+        """No ac_couple_power + POSITIVELY EG4_HYBRID → fall back to reg 123."""
+        from pylxpweb.devices.inverters._features import (
+            InverterFamily,
+            InverterFeatures,
+        )
+
         inverter = inverter_with_transport
+        inverter._features = InverterFeatures(model_family=InverterFamily.EG4_HYBRID)
         inverter._transport_runtime.ac_couple_power = None
         inverter._transport_runtime.generator_power = 750.0
         assert inverter.ac_couple_power == 750
+
+    def test_no_fallback_while_family_unresolved(self, inverter_with_transport):
+        """An UNRESOLVED family does NOT fall back to reg 123.
+
+        The gate is positive (EG4_HYBRID only) rather than "not off-grid":
+        register 123 is a 1 Hz counter on EG4_OFFGRID (eg4_web_monitor#544), and
+        an undetected family is not evidence the device isn't one — so a partial
+        read that lost reg 153 must not republish tens of kW of "AC couple
+        power".  This fixture's family is UNKNOWN, which is why it changed
+        behaviour here.
+        """
+        inverter = inverter_with_transport
+        inverter._transport_runtime.ac_couple_power = None
+        inverter._transport_runtime.generator_power = 28646.0
+        assert inverter.ac_couple_power == 0
 
     def test_falls_back_to_cloud_acCouplePower(self, inverter_with_runtime):
         """When no transport, use cloud acCouplePower."""

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.39b9"
+version = "0.9.39b10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## The bug

[eg4_web_monitor#544](https://github.com/joyfulhouse/eg4_web_monitor/issues/544): a 12000XP reported
**28,646 W of generator power** with nothing connected to the GEN port, plus a **135,494.5 kWh**
generator lifetime total and a permanently-true "using generator" flag.

## Root cause

I downloaded the firmware that device actually runs (`ceaa-0709`) from EG4's portal and decoded the
Modbus FC04 dispatcher. Input register 123's handler returns `RAM16[0x2000D70A]` — a word of the ARM
comms processor's own RAM. That exact word is incremented in a timer task:

```
0x08018BDA  LDR   R0,=0x2000D6F0
0x08018BDC  LDRH  R1,[R0,#0x1A]
0x08018BDE  ADDS  R1,R1,#1        ; unconditional, no bound check
0x08018BE0  STRH  R1,[R0,#0x1A]   ; 16-bit store -> wraps at 65536
```

Nominally once per second. **Seconds since boot, not watts.** A whole-image writer audit found only
that increment and the power-on clear — no DSP measurement path. The reporter's two samples confirm
it with zero free parameters: `(5610 − 28646) mod 65536 = 42,500 s`, within **33 seconds** of the
real interval between captures.

Registers 124/125/126 are ARM-local status words; "135,494.5 kWh" is the bit pattern `0x0014ACC1`,
whose low word `0xACC1` also appeared on a *different* 12000XP in
[#196](https://github.com/joyfulhouse/eg4_web_monitor/issues/196) five months earlier.

## What changes

- **Registers 123/124/125 scoped to `EG4_HYBRID`+`LXP`.** This is the important one: gating only the
  property would have left `InverterRuntimeData.generator_power` and
  `InverterEnergyData.generator_energy_today/_total` publishing the raw counter and the status
  bitfields — and that decode layer is what the Home Assistant integration reads on its LOCAL and
  HYBRID paths, i.e. exactly the modes #544 was reported on. The energy ones are the worse harm,
  since they land in long-term statistics.
- **`generator_power` returns `None`** on positively-identified EG4_OFFGRID, covering the cloud
  `genPower` field that the register map doesn't gate.
- **`ac_couple_power`'s reg-123 fallback now requires a positive `EG4_HYBRID` identification**,
  not merely "not off-grid" — an unresolved family isn't evidence, and regs 121/122/153 sit in a
  different read block from 123, so a partial read could otherwise republish the counter as tens of
  kW of "AC couple power".
- **`is_using_generator` derives from the GEN terminal's own voltage and frequency**, not
  `generator_power > 0`. That predicate was wrong on *both* families: a 1 Hz counter off-grid, and
  multiplexed GEN-terminal throughput on hybrid — measured at ~3 kW of AC-coupled PV on a FlexBOSS21
  with no generator anywhere on site. It now means "GEN input is energised". The portal's
  `_12KUsingGenerator` flag is consulted only when there is no transport at all, since in HYBRID the
  cloud runtime is refreshed for EG4_OFFGRID only and would otherwise present a setup-time snapshot
  as current state.

Register descriptions for 123–126 are rewritten to state what the library implements, and the
long-standing UNVERIFIED note on 124/125/126 is resolved.

## Compatibility

`generator_power` is now `int | None` and `is_using_generator` has changed meaning, so
`PROPERTY_REFERENCE.md` and `USAGE_GUIDE.md` are updated — the previously documented
`if inverter.generator_power > 0:` would raise `TypeError` on an off-grid device. Version bumped to
`0.9.39b10` in the same commit so consumers have a boundary to pin against.

## Tests

New `tests/unit/devices/inverters/test_issue_544_generator_registers.py` (20 tests) covering the
decode layer (`from_modbus_registers` returning None on off-grid for 123/124/125, and
`sensor_keys_for_model` dropping the phantom keys), the property gates, the AC-couple fallback in
both directions, and `is_using_generator` including the reporter's exact 28,646 reading and the
measured hybrid AC-coupled-PV case. Full suite **3203 passed**; ruff and `mypy --strict` clean.

Two pre-existing tests changed expected values. Both are genuine semantic updates, not tests bent to
fit: `test_generator_status`'s fixture carries `genVolt=240.0`/`genFreq=60.0`, i.e. a live GEN input,
which is now True; and the AC-couple fallback test's fixture has an unresolved family, which positive
gating deliberately excludes — it is split into hybrid and unresolved cases.

## Review

Tri-vendor adversarial review (Claude code-reviewer + Codex GPT-5.6-sol @ xhigh + Gemini 3.1 Pro).
All three independently found that the original property-only fix left the decode layer publishing
the bogus values — that finding is what produced the register-scoping change above, which is now the
primary fix. Also addressed from review: positive rather than negative gating on the AC-couple
fallback; the stale-cloud-snapshot path in `is_using_generator`; the public API docs; the version
bump; and provenance claims in the register descriptions that overstated what the firmware proves
(the hybrid reading is an empirical correlation — the only image decoded is the off-grid one).

**Known residual, recorded rather than papered over:** regs 121/122 are confirmed genuine on
EG4_HYBRID and read 0 with nothing attached on EG4_OFFGRID, but no capture of an *active* generator
on the off-grid family exists yet, so the True direction is unverified there. If they turn out to be
stubs on that platform, `is_using_generator` would be permanently False for it. #544 has an open
request to the reporter for a generator-running capture.

Pairs with eg4_web_monitor [#545](https://github.com/joyfulhouse/eg4_web_monitor/pull/545).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
