### PR TITLE
Fix AC charge power and start SOC register ranges

### DIFF
--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -524,7 +524,7 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
     # only the CLOUD named-write path divides by 10 to reach engineering units,
     # and that ÷10 is recorded once in constants.registers.CLOUD_WRITE_DIV10_
     # REGISTERS (keyed by address). min_value/max_value are the post-scaling
-    # engineering bounds (0-15000 W here). Do NOT fold the ÷10 into `scale` — it
+    # engineering bounds (0-10000 W here). Do NOT fold the ÷10 into `scale` — it
     # would wrongly divide local reads too.
     HoldingRegisterDefinition(
         address=66,
@@ -533,9 +533,9 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         ha_entity_key="ac_charge_power",
         unit="W",
         min_value=0,
-        max_value=15000,
+        max_value=10000,
         category=HoldingCategory.POWER,
-        description="AC charge power. Raw value in 100W units (0-150 = 0-15kW).",
+        description="AC charge power. Raw value in 100W units (0-100 = 0-10kW).",
     ),
     HoldingRegisterDefinition(
         address=67,
@@ -1204,7 +1204,7 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         canonical_name="ac_charge_start_soc",
         api_param_key="HOLD_AC_CHARGE_START_BATTERY_SOC",  # verified
         unit="%",
-        min_value=0,
+        min_value=1,
         max_value=90,
         category=HoldingCategory.BATTERY,
         description="Battery SOC to start AC charging.",

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -524,8 +524,8 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
     # only the CLOUD named-write path divides by 10 to reach engineering units,
     # and that ÷10 is recorded once in constants.registers.CLOUD_WRITE_DIV10_
     # REGISTERS (keyed by address). min_value/max_value are the post-scaling
-    # engineering bounds (0-10000 W here). Do NOT fold the ÷10 into `scale` — it
-    # would wrongly divide local reads too.
+    # engineering bounds (0-10000 W for reg 66; other family members differ).
+    # Do NOT fold the ÷10 into `scale` — it would wrongly divide local reads too.
     HoldingRegisterDefinition(
         address=66,
         canonical_name="ac_charge_power",
@@ -623,7 +623,8 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         category=HoldingCategory.SCHEDULE,
         description=(
             "Forced/PV charge (ChgFirst) power command. Raw value in 100W units "
-            "(0-150 = 0-15kW), same encoding as AC charge power (reg 66)."
+            "(0-150 = 0-15kW); encoding matches AC charge power (reg 66), but "
+            "the valid ranges differ."
         ),
     ),
     HoldingRegisterDefinition(

--- a/tests/unit/test_inverter_holding_ranges.py
+++ b/tests/unit/test_inverter_holding_ranges.py
@@ -4,7 +4,7 @@ from pylxpweb.registers.inverter_holding import BY_NAME
 
 
 def test_h66_firmware_range() -> None:
-    """Issue #271: firmware rejects H66 raw >=101 with exception 03."""
+    """Issue #272: firmware rejects H66 raw >=101 with exception 03."""
     register = BY_NAME["ac_charge_power"]
 
     assert register.min_value == 0
@@ -12,7 +12,7 @@ def test_h66_firmware_range() -> None:
 
 
 def test_h160_firmware_range() -> None:
-    """Issue #272: firmware rejects H160 raw 0 and >=91 with exception 03."""
+    """Issue #271: firmware rejects H160 raw 0 and >=91 with exception 03."""
     register = BY_NAME["ac_charge_start_soc"]
 
     assert register.min_value == 1

--- a/tests/unit/test_inverter_holding_ranges.py
+++ b/tests/unit/test_inverter_holding_ranges.py
@@ -4,6 +4,7 @@ from pylxpweb.registers.inverter_holding import BY_NAME
 
 
 def test_h66_firmware_range() -> None:
+    """Issue #271: firmware rejects H66 raw >=101 with exception 03."""
     register = BY_NAME["ac_charge_power"]
 
     assert register.min_value == 0
@@ -11,6 +12,7 @@ def test_h66_firmware_range() -> None:
 
 
 def test_h160_firmware_range() -> None:
+    """Issue #272: firmware rejects H160 raw 0 and >=91 with exception 03."""
     register = BY_NAME["ac_charge_start_soc"]
 
     assert register.min_value == 1

--- a/tests/unit/test_inverter_holding_ranges.py
+++ b/tests/unit/test_inverter_holding_ranges.py
@@ -1,0 +1,28 @@
+"""Firmware-verified boundary tests for inverter holding registers."""
+
+from pylxpweb.registers.inverter_holding import BY_NAME, HoldingRegisterDefinition
+
+
+def _accepts_value(register: HoldingRegisterDefinition, value: int) -> bool:
+    """Return whether an engineering-unit value is within the register bounds."""
+    assert register.min_value is not None
+    assert register.max_value is not None
+    return register.min_value <= value <= register.max_value
+
+
+def test_h66_accepts_raw_100_and_rejects_raw_101() -> None:
+    """H66 firmware accepts 100 W units from raw 0 through raw 100 only."""
+    register = BY_NAME["ac_charge_power"]
+
+    assert _accepts_value(register, 100 * 100)
+    assert not _accepts_value(register, 101 * 100)
+
+
+def test_h160_accepts_raw_1_through_90_only() -> None:
+    """H160 firmware rejects zero and values at or above 91."""
+    register = BY_NAME["ac_charge_start_soc"]
+
+    assert not _accepts_value(register, 0)
+    assert _accepts_value(register, 1)
+    assert _accepts_value(register, 90)
+    assert not _accepts_value(register, 91)

--- a/tests/unit/test_inverter_holding_ranges.py
+++ b/tests/unit/test_inverter_holding_ranges.py
@@ -1,28 +1,17 @@
-"""Firmware-verified boundary tests for inverter holding registers."""
+"""Firmware-verified ranges for inverter holding registers."""
 
-from pylxpweb.registers.inverter_holding import BY_NAME, HoldingRegisterDefinition
-
-
-def _accepts_value(register: HoldingRegisterDefinition, value: int) -> bool:
-    """Return whether an engineering-unit value is within the register bounds."""
-    assert register.min_value is not None
-    assert register.max_value is not None
-    return register.min_value <= value <= register.max_value
+from pylxpweb.registers.inverter_holding import BY_NAME
 
 
-def test_h66_accepts_raw_100_and_rejects_raw_101() -> None:
-    """H66 firmware accepts 100 W units from raw 0 through raw 100 only."""
+def test_h66_firmware_range() -> None:
     register = BY_NAME["ac_charge_power"]
 
-    assert _accepts_value(register, 100 * 100)
-    assert not _accepts_value(register, 101 * 100)
+    assert register.min_value == 0
+    assert register.max_value == 10000
 
 
-def test_h160_accepts_raw_1_through_90_only() -> None:
-    """H160 firmware rejects zero and values at or above 91."""
+def test_h160_firmware_range() -> None:
     register = BY_NAME["ac_charge_start_soc"]
 
-    assert not _accepts_value(register, 0)
-    assert _accepts_value(register, 1)
-    assert _accepts_value(register, 90)
-    assert not _accepts_value(register, 91)
+    assert register.min_value == 1
+    assert register.max_value == 90


### PR DESCRIPTION
## Summary

- cap H66 AC charge power at firmware raw value 100 (10 kW)
- require H160 AC charge start SOC to be within 1–90%
- add unit coverage for both firmware-verified boundaries

## Root cause

The canonical holding-register metadata allowed values outside the ranges enforced by CEAA/CCAA ARM firmware: H66 permitted the equivalent of raw 101–150, and H160 permitted zero.

## Impact

Consumers of the canonical register definitions now expose only values accepted by inverter firmware, avoiding Modbus exception 03 at these boundaries. The existing portal-correlation grade is unchanged.

## Validation

- `uv run ruff check && uv run ruff format --check`
- `uv run mypy src/pylxpweb/ --strict`
- `uv run pytest tests/unit/` (3167 passed)
- boundary tests verified RED before the register fixes and GREEN afterward

Closes #271
Closes #272