### PR TITLE
Expose public transport capability injection seam

### DIFF
--- a/src/pylxpweb/devices/base.py
+++ b/src/pylxpweb/devices/base.py
@@ -214,6 +214,101 @@ class BaseDevice(ABC):
         return self._local_transport is not None
 
     @property
+    def transport(self) -> InverterTransport | None:
+        """Return the attached local transport capability, if any."""
+        return self._local_transport
+
+    @property
+    def _transport(self) -> InverterTransport | None:
+        """Compatibility alias for internal transport-backed device code."""
+        return self._local_transport
+
+    @_transport.setter
+    def _transport(self, transport: InverterTransport | None) -> None:
+        self._local_transport = transport
+
+    async def _close_transport_capability(self, transport: InverterTransport) -> None:
+        """Close a capability terminally when it exposes that lifecycle."""
+        from pylxpweb.transports.protocol import TerminalTransport
+
+        if isinstance(transport, TerminalTransport):
+            await transport.async_shutdown()
+        else:
+            await transport.disconnect()
+
+    async def attach_local_transport(self, transport: InverterTransport) -> None:
+        """Connect and publicly retain a caller-supplied local capability.
+
+        A replacement is not published until the new capability is connected
+        and the old capability has reached terminal closure. Any failure or
+        cancellation closes the unretained new capability before propagating.
+        Already-connected capabilities are retained without another connect.
+
+        Args:
+            transport: Capability whose serial must match this device.
+
+        Raises:
+            ValueError: If the capability serial does not match this device.
+            BaseExceptionGroup: If attachment and cleanup both fail.
+        """
+        current = self._local_transport
+        if current is transport:
+            if not transport.is_connected:
+                await transport.connect()
+            return
+
+        try:
+            if transport.serial != self.serial_number:
+                raise ValueError(
+                    f"Transport serial {transport.serial!r} does not match "
+                    f"device {self.serial_number!r}"
+                )
+            if not transport.is_connected:
+                await transport.connect()
+            if current is not None:
+                await self._close_transport_capability(current)
+        except BaseException as attach_error:
+            try:
+                await self._close_transport_capability(transport)
+            except BaseException as cleanup_error:
+                raise BaseExceptionGroup(
+                    "Local transport attachment and cleanup both failed",
+                    [attach_error, cleanup_error],
+                ) from attach_error
+            raise
+
+        self._local_transport = transport
+        self._on_local_transport_attached()
+
+    async def detach_local_transport(self) -> InverterTransport | None:
+        """Terminally close and detach the current local capability.
+
+        Capabilities implementing ``TerminalTransport`` receive
+        ``async_shutdown()``; other capabilities receive ``disconnect()``.
+        The capability remains retained if closure raises or is cancelled, so a
+        replacement owner cannot be published ahead of terminal cleanup.
+
+        Returns:
+            The detached capability, or None when no capability was attached.
+        """
+        transport = self._local_transport
+        if transport is None:
+            return None
+        await self._close_transport_capability(transport)
+        if self._local_transport is transport:
+            self._local_transport = None
+            self._on_local_transport_detached()
+        return transport
+
+    def _on_local_transport_attached(self) -> None:
+        """Apply subclass state changes after a capability is published."""
+        return
+
+    def _on_local_transport_detached(self) -> None:
+        """Apply subclass state changes after a capability is detached."""
+        return
+
+    @property
     def is_local_only(self) -> bool:
         """Check if device is local-only (no HTTP client credentials).
 

--- a/src/pylxpweb/devices/base.py
+++ b/src/pylxpweb/devices/base.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
 
     from pylxpweb import LuxpowerClient
-    from pylxpweb.transports.protocol import InverterTransport
+    from pylxpweb.transports.protocol import InverterTransport, TerminalInverterTransport
 
 
 class BaseDevice(ABC):
@@ -117,6 +117,8 @@ class BaseDevice(ABC):
         self._local_transport: InverterTransport | None = None
         self._local_transport_requires_terminal = False
         self._transport_lifecycle_lock = asyncio.Lock()
+        self._transport_lifecycle_owner: asyncio.Task[object] | None = None
+        self._transport_lifecycle_delegate: asyncio.Task[object] | None = None
 
         # Data validation: when True, corrupt transport reads are rejected
         # and the previous cached value is kept instead. Set by coordinator
@@ -236,26 +238,34 @@ class BaseDevice(ABC):
         transport: InverterTransport,
         *,
         require_terminal: bool,
-        propagate_cancellation: bool = True,
     ) -> asyncio.CancelledError | None:
         """Finish one close attempt despite cancellation, then report cancellation."""
         from pylxpweb.transports.protocol import TerminalTransport
 
-        if isinstance(transport, TerminalTransport):
-            close_awaitable = transport.async_shutdown()
-        elif not require_terminal:
-            close_awaitable = transport.disconnect()
-        else:
-            raise TypeError("Caller-owned transport capabilities must implement TerminalTransport")
+        async def close() -> None:
+            task = asyncio.current_task()
+            self._transport_lifecycle_delegate = task
+            try:
+                if isinstance(transport, TerminalTransport):
+                    await transport.async_shutdown()
+                elif not require_terminal:
+                    await transport.disconnect()
+                else:
+                    raise TypeError(
+                        "Caller-owned transport capabilities must implement TerminalTransport"
+                    )
+            finally:
+                if self._transport_lifecycle_delegate is task:
+                    self._transport_lifecycle_delegate = None
 
-        close_task = asyncio.create_task(close_awaitable)
+        close_task = asyncio.create_task(close())
         cancellation: asyncio.CancelledError | None = None
         while True:
             try:
                 await asyncio.shield(close_task)
             except asyncio.CancelledError as error:
                 if close_task.cancelled():
-                    if cancellation is not None and propagate_cancellation:
+                    if cancellation is not None:
                         raise BaseExceptionGroup(
                             "Local transport cleanup was cancelled and failed",
                             [cancellation, error],
@@ -264,7 +274,7 @@ class BaseDevice(ABC):
                 if cancellation is None:
                     cancellation = error
             except BaseException as cleanup_error:
-                if cancellation is not None and propagate_cancellation:
+                if cancellation is not None:
                     raise BaseExceptionGroup(
                         "Local transport cleanup was cancelled and failed",
                         [cancellation, cleanup_error],
@@ -273,11 +283,29 @@ class BaseDevice(ABC):
             else:
                 return cancellation
 
+    def _check_transport_lifecycle_reentry(self) -> None:
+        """Reject nested lifecycle calls made by the active transition."""
+        task = asyncio.current_task()
+        if task in (
+            self._transport_lifecycle_owner,
+            self._transport_lifecycle_delegate,
+        ):
+            raise RuntimeError("Local transport lifecycle re-entry is not supported")
+
+    async def _acquire_transport_lifecycle(self) -> None:
+        """Acquire lifecycle ownership after rejecting same-transition re-entry."""
+        self._check_transport_lifecycle_reentry()
+        await self._transport_lifecycle_lock.acquire()
+        self._transport_lifecycle_owner = asyncio.current_task()
+
+    def _release_transport_lifecycle(self) -> None:
+        """Release lifecycle ownership held by the current task."""
+        self._transport_lifecycle_owner = None
+        self._transport_lifecycle_lock.release()
+
     async def attach_local_transport(
         self,
-        transport: InverterTransport,
-        *,
-        require_terminal: bool = True,
+        transport: TerminalInverterTransport,
     ) -> None:
         """Connect and publicly retain a caller-supplied local capability.
 
@@ -287,33 +315,43 @@ class BaseDevice(ABC):
         Already-connected capabilities are retained without another connect.
 
         Args:
-            transport: Capability whose serial must match this device.
-            require_terminal: Require ``TerminalTransport.async_shutdown()`` for
-                caller-owned injection. Pass False only for pylxpweb's legacy/default
-                transports, which retain reusable ``disconnect()`` compatibility.
+            transport: Terminal capability whose serial must match this device.
 
         Raises:
             ValueError: If the capability serial does not match this device.
             BaseExceptionGroup: If attachment and cleanup both fail.
         """
-        if require_terminal:
-            from pylxpweb.transports.protocol import TerminalTransport
+        from pylxpweb.transports.protocol import TerminalInverterTransport
 
-            if not isinstance(transport, TerminalTransport):
-                raise TypeError(
-                    "Caller-owned transport capabilities must implement TerminalTransport"
-                )
+        if not isinstance(transport, TerminalInverterTransport):
+            raise TypeError(
+                "Caller-owned transport capabilities must implement TerminalInverterTransport"
+            )
+        await self._attach_transport_capability(transport, require_terminal=True)
 
+    async def _attach_legacy_local_transport(self, transport: InverterTransport) -> None:
+        """Attach a pylxpweb-created transport with disconnect compatibility."""
+        await self._attach_transport_capability(transport, require_terminal=False)
+
+    async def _attach_transport_capability(
+        self,
+        transport: InverterTransport,
+        *,
+        require_terminal: bool,
+    ) -> None:
+        """Serialize attachment for public terminal and private legacy paths."""
+
+        self._check_transport_lifecycle_reentry()
         try:
             await self._transport_lifecycle_lock.acquire()
         except BaseException as acquire_error:
-            if self._local_transport is not transport:
-                await self._cleanup_unretained_transport(
-                    transport,
-                    require_terminal=require_terminal,
-                    primary_error=acquire_error,
-                )
-            raise
+            await self._cleanup_cancelled_lifecycle_waiter(
+                transport,
+                require_terminal=require_terminal,
+                primary_error=acquire_error,
+            )
+            raise acquire_error
+        self._transport_lifecycle_owner = asyncio.current_task()
 
         try:
             await self._attach_local_transport_locked(
@@ -321,7 +359,55 @@ class BaseDevice(ABC):
                 require_terminal=require_terminal,
             )
         finally:
-            self._transport_lifecycle_lock.release()
+            self._release_transport_lifecycle()
+
+    async def _cleanup_cancelled_lifecycle_waiter(
+        self,
+        transport: InverterTransport,
+        *,
+        require_terminal: bool,
+        primary_error: BaseException,
+    ) -> None:
+        """Serialize ownership resolution for an input whose waiter was cancelled."""
+
+        async def cleanup() -> None:
+            await self._acquire_transport_lifecycle()
+            try:
+                if self._local_transport is not transport:
+                    cancellation = await self._close_transport_capability(
+                        transport,
+                        require_terminal=require_terminal,
+                    )
+                    if cancellation is not None:
+                        raise cancellation
+            finally:
+                self._release_transport_lifecycle()
+
+        cleanup_task = asyncio.create_task(cleanup())
+        later_cancellations: list[asyncio.CancelledError] = []
+        cleanup_error: BaseException | None = None
+        while True:
+            try:
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError as error:
+                if cleanup_task.cancelled():
+                    cleanup_error = error
+                    break
+                later_cancellations.append(error)
+            except BaseException as error:
+                cleanup_error = error
+                break
+            else:
+                break
+
+        errors = [primary_error, *later_cancellations]
+        if cleanup_error is not None:
+            errors.append(cleanup_error)
+        if len(errors) > 1:
+            raise BaseExceptionGroup(
+                "Local transport lifecycle wait and cleanup failed",
+                errors,
+            ) from primary_error
 
     async def _cleanup_unretained_transport(
         self,
@@ -332,15 +418,19 @@ class BaseDevice(ABC):
     ) -> None:
         """Close an unpublished input and combine a cleanup failure."""
         try:
-            await self._close_transport_capability(
+            cancellation = await self._close_transport_capability(
                 transport,
                 require_terminal=require_terminal,
-                propagate_cancellation=False,
             )
         except BaseException as cleanup_error:
             raise BaseExceptionGroup(
                 "Local transport attachment and cleanup both failed",
                 [primary_error, cleanup_error],
+            ) from primary_error
+        if cancellation is not None:
+            raise BaseExceptionGroup(
+                "Local transport attachment and cleanup were interrupted",
+                [primary_error, cancellation],
             ) from primary_error
 
     async def _attach_local_transport_locked(
@@ -408,7 +498,8 @@ class BaseDevice(ABC):
         Returns:
             The detached capability, or None when no capability was attached.
         """
-        async with self._transport_lifecycle_lock:
+        await self._acquire_transport_lifecycle()
+        try:
             transport = self._local_transport
             if transport is None:
                 return None
@@ -422,6 +513,8 @@ class BaseDevice(ABC):
             if cancellation is not None:
                 raise cancellation
             return transport
+        finally:
+            self._release_transport_lifecycle()
 
     def _on_local_transport_attached(self) -> None:
         """Apply subclass state changes after a capability is published."""

--- a/src/pylxpweb/devices/base.py
+++ b/src/pylxpweb/devices/base.py
@@ -477,6 +477,9 @@ class BaseDevice(ABC):
                 [primary_error, cancellation],
                 cause=primary_error,
             )
+        primary_cancellation = _cancellation_only(primary_error)
+        if primary_cancellation is not None:
+            raise primary_cancellation
 
     async def _attach_local_transport_locked(
         self,

--- a/src/pylxpweb/devices/base.py
+++ b/src/pylxpweb/devices/base.py
@@ -7,6 +7,7 @@ and Home Assistant integration.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from abc import ABC, abstractmethod
@@ -114,6 +115,8 @@ class BaseDevice(ABC):
 
         # Local transport (Modbus/Dongle) - None means HTTP-only mode
         self._local_transport: InverterTransport | None = None
+        self._local_transport_requires_terminal = False
+        self._transport_lifecycle_lock = asyncio.Lock()
 
         # Data validation: when True, corrupt transport reads are rejected
         # and the previous cached value is kept instead. Set by coordinator
@@ -226,17 +229,60 @@ class BaseDevice(ABC):
     @_transport.setter
     def _transport(self, transport: InverterTransport | None) -> None:
         self._local_transport = transport
+        self._local_transport_requires_terminal = False
 
-    async def _close_transport_capability(self, transport: InverterTransport) -> None:
-        """Close a capability terminally when it exposes that lifecycle."""
+    async def _close_transport_capability(
+        self,
+        transport: InverterTransport,
+        *,
+        require_terminal: bool,
+        propagate_cancellation: bool = True,
+    ) -> asyncio.CancelledError | None:
+        """Finish one close attempt despite cancellation, then report cancellation."""
         from pylxpweb.transports.protocol import TerminalTransport
 
         if isinstance(transport, TerminalTransport):
-            await transport.async_shutdown()
+            close_awaitable = transport.async_shutdown()
+        elif not require_terminal:
+            close_awaitable = transport.disconnect()
         else:
-            await transport.disconnect()
+            raise TypeError("Caller-owned transport capabilities must implement TerminalTransport")
 
-    async def attach_local_transport(self, transport: InverterTransport) -> None:
+        close_task = asyncio.create_task(close_awaitable)
+        cancellation: asyncio.CancelledError | None = None
+        while not close_task.done():
+            try:
+                await asyncio.shield(close_task)
+            except asyncio.CancelledError as error:
+                if close_task.cancelled():
+                    break
+                if cancellation is None:
+                    cancellation = error
+            except BaseException as cleanup_error:
+                if cancellation is not None and propagate_cancellation:
+                    raise BaseExceptionGroup(
+                        "Local transport cleanup was cancelled and failed",
+                        [cancellation, cleanup_error],
+                    ) from cleanup_error
+                raise
+
+        try:
+            close_task.result()
+        except BaseException as cleanup_error:
+            if cancellation is not None and propagate_cancellation:
+                raise BaseExceptionGroup(
+                    "Local transport cleanup was cancelled and failed",
+                    [cancellation, cleanup_error],
+                ) from cleanup_error
+            raise
+        return cancellation
+
+    async def attach_local_transport(
+        self,
+        transport: InverterTransport,
+        *,
+        require_terminal: bool = True,
+    ) -> None:
         """Connect and publicly retain a caller-supplied local capability.
 
         A replacement is not published until the new capability is connected
@@ -246,38 +292,112 @@ class BaseDevice(ABC):
 
         Args:
             transport: Capability whose serial must match this device.
+            require_terminal: Require ``TerminalTransport.async_shutdown()`` for
+                caller-owned injection. Pass False only for pylxpweb's legacy/default
+                transports, which retain reusable ``disconnect()`` compatibility.
 
         Raises:
             ValueError: If the capability serial does not match this device.
             BaseExceptionGroup: If attachment and cleanup both fail.
         """
+        if require_terminal:
+            from pylxpweb.transports.protocol import TerminalTransport
+
+            if not isinstance(transport, TerminalTransport):
+                raise TypeError(
+                    "Caller-owned transport capabilities must implement TerminalTransport"
+                )
+
+        try:
+            await self._transport_lifecycle_lock.acquire()
+        except BaseException as acquire_error:
+            if self._local_transport is not transport:
+                await self._cleanup_unretained_transport(
+                    transport,
+                    require_terminal=require_terminal,
+                    primary_error=acquire_error,
+                )
+            raise
+
+        try:
+            await self._attach_local_transport_locked(
+                transport,
+                require_terminal=require_terminal,
+            )
+        finally:
+            self._transport_lifecycle_lock.release()
+
+    async def _cleanup_unretained_transport(
+        self,
+        transport: InverterTransport,
+        *,
+        require_terminal: bool,
+        primary_error: BaseException,
+    ) -> None:
+        """Close an unpublished input and combine a cleanup failure."""
+        try:
+            await self._close_transport_capability(
+                transport,
+                require_terminal=require_terminal,
+                propagate_cancellation=False,
+            )
+        except BaseException as cleanup_error:
+            raise BaseExceptionGroup(
+                "Local transport attachment and cleanup both failed",
+                [primary_error, cleanup_error],
+            ) from primary_error
+
+    async def _attach_local_transport_locked(
+        self,
+        transport: InverterTransport,
+        *,
+        require_terminal: bool,
+    ) -> None:
+        """Perform one attachment transition while holding the lifecycle lock."""
         current = self._local_transport
+        if transport.serial != self.serial_number:
+            serial_error = ValueError(
+                f"Transport serial {transport.serial!r} does not match "
+                f"device {self.serial_number!r}"
+            )
+            if current is transport:
+                raise serial_error
+            await self._cleanup_unretained_transport(
+                transport,
+                require_terminal=require_terminal,
+                primary_error=serial_error,
+            )
+            raise serial_error
         if current is transport:
             if not transport.is_connected:
                 await transport.connect()
+            self._local_transport_requires_terminal = require_terminal
+            self._on_local_transport_attached()
             return
 
         try:
-            if transport.serial != self.serial_number:
-                raise ValueError(
-                    f"Transport serial {transport.serial!r} does not match "
-                    f"device {self.serial_number!r}"
-                )
             if not transport.is_connected:
                 await transport.connect()
             if current is not None:
-                await self._close_transport_capability(current)
+                cancellation = await self._close_transport_capability(
+                    current,
+                    require_terminal=self._local_transport_requires_terminal,
+                )
+                if cancellation is not None:
+                    self._local_transport = None
+                    self._local_transport_requires_terminal = False
+                    self._on_local_transport_detached()
+                    raise cancellation
         except BaseException as attach_error:
-            try:
-                await self._close_transport_capability(transport)
-            except BaseException as cleanup_error:
-                raise BaseExceptionGroup(
-                    "Local transport attachment and cleanup both failed",
-                    [attach_error, cleanup_error],
-                ) from attach_error
+            await self._cleanup_unretained_transport(
+                transport,
+                require_terminal=require_terminal,
+                primary_error=attach_error,
+            )
             raise
 
         self._local_transport = transport
+        self._local_transport_requires_terminal = require_terminal
         self._on_local_transport_attached()
 
     async def detach_local_transport(self) -> InverterTransport | None:
@@ -285,20 +405,27 @@ class BaseDevice(ABC):
 
         Capabilities implementing ``TerminalTransport`` receive
         ``async_shutdown()``; other capabilities receive ``disconnect()``.
-        The capability remains retained if closure raises or is cancelled, so a
-        replacement owner cannot be published ahead of terminal cleanup.
+        The capability remains retained if closure raises. Cancellation is delayed
+        until the close attempt completes; a successful close detaches before the
+        cancellation propagates.
 
         Returns:
             The detached capability, or None when no capability was attached.
         """
-        transport = self._local_transport
-        if transport is None:
-            return None
-        await self._close_transport_capability(transport)
-        if self._local_transport is transport:
+        async with self._transport_lifecycle_lock:
+            transport = self._local_transport
+            if transport is None:
+                return None
+            cancellation = await self._close_transport_capability(
+                transport,
+                require_terminal=self._local_transport_requires_terminal,
+            )
             self._local_transport = None
+            self._local_transport_requires_terminal = False
             self._on_local_transport_detached()
-        return transport
+            if cancellation is not None:
+                raise cancellation
+            return transport
 
     def _on_local_transport_attached(self) -> None:
         """Apply subclass state changes after a capability is published."""

--- a/src/pylxpweb/devices/base.py
+++ b/src/pylxpweb/devices/base.py
@@ -12,7 +12,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Never, TypeVar
 
 from pylxpweb.validation import (
     MAX_ELAPSED_HOURS,
@@ -46,6 +46,40 @@ TRANSPORT_LINK_DOWN_THRESHOLD = 3
 LINK_PROBE_MIN_INTERVAL_SECONDS = 4.0
 
 _T = TypeVar("_T")
+
+
+def _cancellation_only(error: BaseException) -> asyncio.CancelledError | None:
+    """Return one cancellation when every leaf is cancellation-only."""
+    if isinstance(error, asyncio.CancelledError):
+        return error
+    if isinstance(error, BaseExceptionGroup):
+        cancellation: asyncio.CancelledError | None = None
+        for nested_error in error.exceptions:
+            nested_cancellation = _cancellation_only(nested_error)
+            if nested_cancellation is None:
+                return None
+            if cancellation is None:
+                cancellation = nested_cancellation
+        return cancellation
+    return None
+
+
+def _raise_transport_errors(
+    message: str,
+    errors: list[BaseException],
+    *,
+    cause: BaseException,
+) -> Never:
+    """Raise one native cancellation or a group containing mixed failures."""
+    cancellation = _cancellation_only(errors[0])
+    if cancellation is None:
+        raise BaseExceptionGroup(message, errors) from cause
+    for error in errors[1:]:
+        nested_cancellation = _cancellation_only(error)
+        if nested_cancellation is None:
+            raise BaseExceptionGroup(message, errors) from cause
+    raise cancellation
+
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
@@ -266,19 +300,24 @@ class BaseDevice(ABC):
             except asyncio.CancelledError as error:
                 if close_task.cancelled():
                     if cancellation is not None:
-                        raise BaseExceptionGroup(
+                        _raise_transport_errors(
                             "Local transport cleanup was cancelled and failed",
                             [cancellation, error],
-                        ) from error
+                            cause=error,
+                        )
                     raise
                 if cancellation is None:
                     cancellation = error
             except BaseException as cleanup_error:
                 if cancellation is not None:
-                    raise BaseExceptionGroup(
+                    _raise_transport_errors(
                         "Local transport cleanup was cancelled and failed",
                         [cancellation, cleanup_error],
-                    ) from cleanup_error
+                        cause=cleanup_error,
+                    )
+                cleanup_cancellation = _cancellation_only(cleanup_error)
+                if cleanup_cancellation is not None:
+                    raise cleanup_cancellation from cleanup_error
                 raise
             else:
                 return cancellation
@@ -384,7 +423,7 @@ class BaseDevice(ABC):
                 self._release_transport_lifecycle()
 
         cleanup_task = asyncio.create_task(cleanup())
-        later_cancellations: list[asyncio.CancelledError] = []
+        later_cancellation: asyncio.CancelledError | None = None
         cleanup_error: BaseException | None = None
         while True:
             try:
@@ -393,21 +432,25 @@ class BaseDevice(ABC):
                 if cleanup_task.cancelled():
                     cleanup_error = error
                     break
-                later_cancellations.append(error)
+                if later_cancellation is None:
+                    later_cancellation = error
             except BaseException as error:
                 cleanup_error = error
                 break
             else:
                 break
 
-        errors = [primary_error, *later_cancellations]
+        errors = [primary_error]
+        if later_cancellation is not None:
+            errors.append(later_cancellation)
         if cleanup_error is not None:
             errors.append(cleanup_error)
         if len(errors) > 1:
-            raise BaseExceptionGroup(
+            _raise_transport_errors(
                 "Local transport lifecycle wait and cleanup failed",
                 errors,
-            ) from primary_error
+                cause=primary_error,
+            )
 
     async def _cleanup_unretained_transport(
         self,
@@ -423,15 +466,17 @@ class BaseDevice(ABC):
                 require_terminal=require_terminal,
             )
         except BaseException as cleanup_error:
-            raise BaseExceptionGroup(
+            _raise_transport_errors(
                 "Local transport attachment and cleanup both failed",
                 [primary_error, cleanup_error],
-            ) from primary_error
+                cause=primary_error,
+            )
         if cancellation is not None:
-            raise BaseExceptionGroup(
+            _raise_transport_errors(
                 "Local transport attachment and cleanup were interrupted",
                 [primary_error, cancellation],
-            ) from primary_error
+                cause=primary_error,
+            )
 
     async def _attach_local_transport_locked(
         self,

--- a/src/pylxpweb/devices/base.py
+++ b/src/pylxpweb/devices/base.py
@@ -250,12 +250,17 @@ class BaseDevice(ABC):
 
         close_task = asyncio.create_task(close_awaitable)
         cancellation: asyncio.CancelledError | None = None
-        while not close_task.done():
+        while True:
             try:
                 await asyncio.shield(close_task)
             except asyncio.CancelledError as error:
                 if close_task.cancelled():
-                    break
+                    if cancellation is not None and propagate_cancellation:
+                        raise BaseExceptionGroup(
+                            "Local transport cleanup was cancelled and failed",
+                            [cancellation, error],
+                        ) from error
+                    raise
                 if cancellation is None:
                     cancellation = error
             except BaseException as cleanup_error:
@@ -265,17 +270,8 @@ class BaseDevice(ABC):
                         [cancellation, cleanup_error],
                     ) from cleanup_error
                 raise
-
-        try:
-            close_task.result()
-        except BaseException as cleanup_error:
-            if cancellation is not None and propagate_cancellation:
-                raise BaseExceptionGroup(
-                    "Local transport cleanup was cancelled and failed",
-                    [cancellation, cleanup_error],
-                ) from cleanup_error
-            raise
-        return cancellation
+            else:
+                return cancellation
 
     async def attach_local_transport(
         self,

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -115,7 +115,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         super().__init__(client, serial_number, model)
 
         # Optional transport for direct local communication
-        self._transport: InverterTransport | None = transport
+        self._local_transport = transport
 
         # Runtime data (refreshed frequently) - PRIVATE: use properties for access
         # HTTP API returns InverterRuntime, transport returns InverterRuntimeData
@@ -293,11 +293,6 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
     # ============================================================================
 
     @property
-    def transport(self) -> InverterTransport | None:
-        """Attached local transport, or None in cloud-only mode."""
-        return self._transport
-
-    @property
     def transport_runtime(self) -> InverterRuntimeData | None:
         """Runtime data from the local transport, or None when not transport-backed."""
         return self._transport_runtime
@@ -327,6 +322,17 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         self._transport_runtime = None
         self._transport_energy = None
         self._transport_battery = None
+
+    def _on_local_transport_attached(self) -> None:
+        """Apply transport-specific cache TTLs after public attachment."""
+        self.set_transport_cache_ttls()
+
+    def _on_local_transport_detached(self) -> None:
+        """Drop local data and restore cloud cache TTLs after detachment."""
+        self._on_transport_link_down()
+        self._runtime_cache_ttl = timedelta(seconds=30)
+        self._energy_cache_ttl = timedelta(minutes=5)
+        self._battery_cache_ttl = timedelta(seconds=30)
 
     # ============================================================================
     # Factory Methods

--- a/src/pylxpweb/devices/mid_device.py
+++ b/src/pylxpweb/devices/mid_device.py
@@ -79,14 +79,6 @@ class MIDDevice(FirmwareUpdateMixin, MIDRuntimePropertiesMixin, BaseDevice):
         # Initialize firmware update detection (from FirmwareUpdateMixin)
         self._init_firmware_update_cache()
 
-        # Local transport for hybrid/local-only mode (optional)
-        self._transport: InverterTransport | None = None
-
-    @property
-    def transport(self) -> InverterTransport | None:
-        """Attached local transport, or None in cloud-only mode."""
-        return self._transport
-
     @property
     def transport_runtime(self) -> MidboxRuntimeData | None:
         """Runtime data from the local transport, or None when not transport-backed."""
@@ -222,6 +214,11 @@ class MIDDevice(FirmwareUpdateMixin, MIDRuntimePropertiesMixin, BaseDevice):
             new_runtime.daily_energy_values(),
             prev_daily,
         )
+
+    def _on_local_transport_detached(self) -> None:
+        """Drop transport-derived MID data after detachment."""
+        self._transport_runtime = None
+        self._runtime_cache_time = None
 
     async def refresh(self) -> None:
         """Refresh MID device runtime data from API or transport.

--- a/src/pylxpweb/devices/station.py
+++ b/src/pylxpweb/devices/station.py
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pylxpweb import LuxpowerClient
-    from pylxpweb.transports.config import AttachResult, TransportConfig
+    from pylxpweb.transports.config import AttachResult, TransportConfig, TransportFactory
 
     from .battery import Battery
     from .inverters.base import BaseInverter
@@ -1281,9 +1281,14 @@ class Station(BaseDevice):
             >>> station.is_hybrid_mode
             True
         """
-        return any(inverter._transport is not None for inverter in self.all_inverters)
+        return any(inverter.transport is not None for inverter in self.all_inverters)
 
-    async def attach_local_transports(self, configs: list[TransportConfig]) -> AttachResult:
+    async def attach_local_transports(
+        self,
+        configs: list[TransportConfig],
+        *,
+        transport_factory: TransportFactory | None = None,
+    ) -> AttachResult:
         """Attach local transports to HTTP-discovered devices.
 
         This method enables hybrid mode by connecting local transports
@@ -1294,6 +1299,20 @@ class Station(BaseDevice):
         Args:
             configs: List of TransportConfig objects specifying local transports.
                 Each config includes serial, host, port, and transport type.
+            transport_factory: Optional caller-supplied factory invoked only for
+                matched configs. Its returned capability is connected, retained,
+                and cleaned up through the public transport lifecycle.
+
+        Lifecycle:
+            Serial matching precedes factory invocation. For each match, the
+            returned capability is connected only when needed, then retained as
+            ``device.transport``. A connect or replacement failure terminally
+            closes the new capability and is reported in ``AttachResult``;
+            cancellation performs the same cleanup and propagates. Replacement
+            terminally closes the old capability before publishing the new one.
+            Inverter cache TTLs keep the existing transport-type defaults; an
+            injected capability without ``transport_type`` keeps current TTLs,
+            which callers may configure with ``inverter.set_cache_ttls()``.
 
         Returns:
             AttachResult with counts of matched, unmatched, and failed attachments.
@@ -1317,8 +1336,6 @@ class Station(BaseDevice):
             ```
         """
         from pylxpweb.transports import (
-            DongleTransport,
-            ModbusTransport,
             create_dongle_transport,
             create_modbus_transport,
         )
@@ -1352,8 +1369,9 @@ class Station(BaseDevice):
 
             # Create and connect transport
             try:
-                transport: ModbusTransport | DongleTransport
-                if config.transport_type == TransportType.MODBUS_TCP:
+                if transport_factory is not None:
+                    transport = transport_factory(config)
+                elif config.transport_type == TransportType.MODBUS_TCP:
                     transport = create_modbus_transport(
                         host=config.host,
                         port=config.port,
@@ -1381,19 +1399,10 @@ class Station(BaseDevice):
                     result.failed_serials.append(serial)
                     continue
 
-                # Connect the transport
-                await transport.connect()
-
-                # Attach to device (inverter or MID device)
-                device._transport = transport
+                # Connect and retain through the public device lifecycle.
+                await device.attach_local_transport(transport)
                 result.matched += 1
                 device_type = "MID device" if isinstance(device, MIDDevice) else "inverter"
-
-                # Adjust cache TTLs for local transport speed
-                from .inverters.base import BaseInverter
-
-                if isinstance(device, BaseInverter):
-                    device.set_transport_cache_ttls()
 
                 _LOGGER.info(
                     "Attached %s transport to %s %s (%s:%d)",

--- a/src/pylxpweb/devices/station.py
+++ b/src/pylxpweb/devices/station.py
@@ -1314,6 +1314,9 @@ class Station(BaseDevice):
             closes the new capability and is reported in ``AttachResult``;
             cancellation performs the same cleanup and propagates. Replacement
             terminally closes the old capability before publishing the new one.
+            Terminal shutdown runs under the matched device's lifecycle lock; an
+            implementation that exceeds its documented finite shutdown bound
+            blocks later lifecycle operations on that device.
             Inverter cache TTLs keep the existing transport-type defaults; an
             injected capability without ``transport_type`` keeps current TTLs,
             which callers may configure with ``inverter.set_cache_ttls()``.

--- a/src/pylxpweb/devices/station.py
+++ b/src/pylxpweb/devices/station.py
@@ -1300,8 +1300,10 @@ class Station(BaseDevice):
             configs: List of TransportConfig objects specifying local transports.
                 Each config includes serial, host, port, and transport type.
             transport_factory: Optional caller-supplied factory invoked only for
-                matched configs. Its returned capability is connected, retained,
-                and cleaned up through the public transport lifecycle.
+                matched configs. Its returned capability must implement
+                ``TerminalTransport``; it is connected, retained, and terminally
+                closed through the public transport lifecycle. Pylxpweb-created
+                default transports retain legacy ``disconnect()`` compatibility.
 
         Lifecycle:
             Serial matching precedes factory invocation. For each match, the
@@ -1400,7 +1402,10 @@ class Station(BaseDevice):
                     continue
 
                 # Connect and retain through the public device lifecycle.
-                await device.attach_local_transport(transport)
+                await device.attach_local_transport(
+                    transport,
+                    require_terminal=transport_factory is not None,
+                )
                 result.matched += 1
                 device_type = "MID device" if isinstance(device, MIDDevice) else "inverter"
 

--- a/src/pylxpweb/devices/station.py
+++ b/src/pylxpweb/devices/station.py
@@ -29,6 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from pylxpweb import LuxpowerClient
     from pylxpweb.transports.config import AttachResult, TransportConfig, TransportFactory
+    from pylxpweb.transports.protocol import InverterTransport
 
     from .battery import Battery
     from .inverters.base import BaseInverter
@@ -1301,9 +1302,10 @@ class Station(BaseDevice):
                 Each config includes serial, host, port, and transport type.
             transport_factory: Optional caller-supplied factory invoked only for
                 matched configs. Its returned capability must implement
-                ``TerminalTransport``; it is connected, retained, and terminally
-                closed through the public transport lifecycle. Pylxpweb-created
-                default transports retain legacy ``disconnect()`` compatibility.
+                ``TerminalInverterTransport``; it is connected, retained, and
+                terminally closed through the public transport lifecycle.
+                Pylxpweb-created default transports retain legacy ``disconnect()``
+                compatibility.
 
         Lifecycle:
             Serial matching precedes factory invocation. For each match, the
@@ -1371,8 +1373,11 @@ class Station(BaseDevice):
 
             # Create and connect transport
             try:
+                transport: InverterTransport
                 if transport_factory is not None:
-                    transport = transport_factory(config)
+                    injected_transport = transport_factory(config)
+                    await device.attach_local_transport(injected_transport)
+                    transport = injected_transport
                 elif config.transport_type == TransportType.MODBUS_TCP:
                     transport = create_modbus_transport(
                         host=config.host,
@@ -1401,11 +1406,8 @@ class Station(BaseDevice):
                     result.failed_serials.append(serial)
                     continue
 
-                # Connect and retain through the public device lifecycle.
-                await device.attach_local_transport(
-                    transport,
-                    require_terminal=transport_factory is not None,
-                )
+                if transport_factory is None:
+                    await device._attach_legacy_local_transport(transport)
                 result.matched += 1
                 device_type = "MID device" if isinstance(device, MIDDevice) else "inverter"
 

--- a/src/pylxpweb/transports/__init__.py
+++ b/src/pylxpweb/transports/__init__.py
@@ -47,6 +47,7 @@ from .capabilities import (
 from .config import (
     AttachResult,
     TransportConfig,
+    TransportFactory,
     TransportType,
 )
 from .data import (
@@ -90,7 +91,7 @@ from .http import HTTPTransport
 from .hybrid import HybridTransport
 from .modbus import ModbusTransport
 from .modbus_serial import ModbusSerialTransport
-from .protocol import BaseTransport, InverterTransport
+from .protocol import BaseTransport, InverterTransport, TerminalTransport
 
 if TYPE_CHECKING:
     from .battery_modbus import BatteryModbusTransport
@@ -121,10 +122,12 @@ __all__ = [
     "create_transport_from_config",
     # Configuration
     "TransportConfig",
+    "TransportFactory",
     "TransportType",
     "AttachResult",
     # Protocol
     "InverterTransport",
+    "TerminalTransport",
     "BaseTransport",
     # Transport implementations
     "HTTPTransport",

--- a/src/pylxpweb/transports/__init__.py
+++ b/src/pylxpweb/transports/__init__.py
@@ -91,7 +91,12 @@ from .http import HTTPTransport
 from .hybrid import HybridTransport
 from .modbus import ModbusTransport
 from .modbus_serial import ModbusSerialTransport
-from .protocol import BaseTransport, InverterTransport, TerminalTransport
+from .protocol import (
+    BaseTransport,
+    InverterTransport,
+    TerminalInverterTransport,
+    TerminalTransport,
+)
 
 if TYPE_CHECKING:
     from .battery_modbus import BatteryModbusTransport
@@ -127,6 +132,7 @@ __all__ = [
     "AttachResult",
     # Protocol
     "InverterTransport",
+    "TerminalInverterTransport",
     "TerminalTransport",
     "BaseTransport",
     # Transport implementations

--- a/src/pylxpweb/transports/config.py
+++ b/src/pylxpweb/transports/config.py
@@ -30,10 +30,9 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from pylxpweb.transports.protocol import InverterTransport
-
 if TYPE_CHECKING:
     from pylxpweb.devices.inverters._features import InverterFamily
+    from pylxpweb.transports.protocol import InverterTransport
 
 
 class TransportType(StrEnum):
@@ -277,7 +276,7 @@ class TransportConfig:
         return instance
 
 
-type TransportFactory = Callable[[TransportConfig], InverterTransport]
+type TransportFactory = Callable[[TransportConfig], "InverterTransport"]
 """Factory supplying a transport capability for a matched attachment config."""
 
 

--- a/src/pylxpweb/transports/config.py
+++ b/src/pylxpweb/transports/config.py
@@ -25,26 +25,15 @@ Example:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
+
+from pylxpweb.transports.protocol import InverterTransport
 
 if TYPE_CHECKING:
     from pylxpweb.devices.inverters._features import InverterFamily
-    from pylxpweb.transports.protocol import InverterTransport
-
-
-class TransportFactory(Protocol):
-    """Callable that supplies a transport capability for an attachment config.
-
-    The factory is invoked only after a station device has matched the config's
-    serial number. It may return an ordinary pylxpweb transport or a caller-owned
-    capability that serializes access to a raw transport behind its public API.
-    """
-
-    def __call__(self, config: TransportConfig) -> InverterTransport:
-        """Return the transport capability associated with ``config``."""
-        ...
 
 
 class TransportType(StrEnum):
@@ -286,6 +275,10 @@ class TransportConfig:
         # Validate the restored config
         instance.validate()
         return instance
+
+
+type TransportFactory = Callable[[TransportConfig], InverterTransport]
+"""Factory supplying a transport capability for a matched attachment config."""
 
 
 @dataclass

--- a/src/pylxpweb/transports/config.py
+++ b/src/pylxpweb/transports/config.py
@@ -27,10 +27,24 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from pylxpweb.devices.inverters._features import InverterFamily
+    from pylxpweb.transports.protocol import InverterTransport
+
+
+class TransportFactory(Protocol):
+    """Callable that supplies a transport capability for an attachment config.
+
+    The factory is invoked only after a station device has matched the config's
+    serial number. It may return an ordinary pylxpweb transport or a caller-owned
+    capability that serializes access to a raw transport behind its public API.
+    """
+
+    def __call__(self, config: TransportConfig) -> InverterTransport:
+        """Return the transport capability associated with ``config``."""
+        ...
 
 
 class TransportType(StrEnum):
@@ -280,7 +294,8 @@ class AttachResult:
 
     This class reports the outcome of Station.attach_local_transports(),
     indicating which transports were successfully connected, which had
-    no matching device, and which failed to connect.
+    no matching device, and which failed during creation, connection,
+    cleanup, or replacement.
 
     Attributes:
         matched: Number of transports successfully attached to devices.
@@ -320,5 +335,6 @@ class AttachResult:
 __all__ = [
     "TransportType",
     "TransportConfig",
+    "TransportFactory",
     "AttachResult",
 ]

--- a/src/pylxpweb/transports/config.py
+++ b/src/pylxpweb/transports/config.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pylxpweb.devices.inverters._features import InverterFamily
-    from pylxpweb.transports.protocol import InverterTransport
+    from pylxpweb.transports.protocol import TerminalInverterTransport
 
 
 class TransportType(StrEnum):
@@ -276,7 +276,7 @@ class TransportConfig:
         return instance
 
 
-type TransportFactory = Callable[[TransportConfig], "InverterTransport"]
+type TransportFactory = Callable[[TransportConfig], "TerminalInverterTransport"]
 """Factory supplying a transport capability for a matched attachment config."""
 
 

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -238,6 +238,20 @@ class InverterTransport(Protocol):
         ...
 
 
+@runtime_checkable
+class TerminalTransport(Protocol):
+    """Optional capability for terminal transport shutdown.
+
+    Terminal shutdown must drain or interrupt in-flight work and make the
+    capability unusable. Device detach and replacement prefer this operation
+    over reusable :meth:`InverterTransport.disconnect` when it is available.
+    """
+
+    async def async_shutdown(self) -> None:
+        """Terminally close the transport capability."""
+        ...
+
+
 class BaseTransport:
     """Base class providing common transport functionality.
 

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -245,7 +245,9 @@ class TerminalTransport(Protocol):
     Terminal shutdown must drain or interrupt in-flight work and make the
     capability unusable. Its implementation must be cancellation-safe and
     complete within the implementation's documented finite upper bound. Device
-    detach and replacement wait for completion and may defer caller cancellation.
+    detach and replacement invoke it while holding the per-device lifecycle lock,
+    wait for completion, and may defer caller cancellation. Exceeding the bound
+    therefore blocks subsequent lifecycle operations on that device.
     """
 
     async def async_shutdown(self) -> None:
@@ -259,7 +261,9 @@ class TerminalInverterTransport(InverterTransport, TerminalTransport, Protocol):
 
     ``async_shutdown()`` is the ownership boundary: it must remain safe under
     cancellation, make the capability permanently unusable, and finish within
-    the implementation's documented finite upper bound.
+    the implementation's documented finite upper bound. Pylxpweb invokes it while
+    holding the device lifecycle lock, so exceeding that bound blocks later
+    attachment, replacement, and detachment on the same device.
     """
 
 

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -243,13 +243,24 @@ class TerminalTransport(Protocol):
     """Optional capability for terminal transport shutdown.
 
     Terminal shutdown must drain or interrupt in-flight work and make the
-    capability unusable. Device detach and replacement prefer this operation
-    over reusable :meth:`InverterTransport.disconnect` when it is available.
+    capability unusable. Its implementation must be cancellation-safe and
+    complete within the implementation's documented finite upper bound. Device
+    detach and replacement wait for completion and may defer caller cancellation.
     """
 
     async def async_shutdown(self) -> None:
-        """Terminally close the transport capability."""
+        """Terminally close within the implementation's documented finite bound."""
         ...
+
+
+@runtime_checkable
+class TerminalInverterTransport(InverterTransport, TerminalTransport, Protocol):
+    """Public caller-owned inverter capability with terminal shutdown.
+
+    ``async_shutdown()`` is the ownership boundary: it must remain safe under
+    cancellation, make the capability permanently unusable, and finish within
+    the implementation's documented finite upper bound.
+    """
 
 
 class BaseTransport:

--- a/tests/unit/devices/test_station_hybrid.py
+++ b/tests/unit/devices/test_station_hybrid.py
@@ -75,9 +75,18 @@ class TestIsHybridMode:
         self, station_with_inverter: Station, mock_inverter: BaseInverter
     ) -> None:
         """Test is_hybrid_mode is True when transport is attached."""
-        await mock_inverter.attach_local_transport(
-            make_transport("CE12345678"), require_terminal=False
+        transport = make_transport("CE12345678")
+        config = TransportConfig(
+            host="example.invalid",
+            port=502,
+            serial="CE12345678",
+            transport_type=TransportType.MODBUS_TCP,
         )
+        with patch(
+            "pylxpweb.transports.create_modbus_transport",
+            return_value=transport,
+        ):
+            await station_with_inverter.attach_local_transports([config])
         assert station_with_inverter.is_hybrid_mode is True
 
     def test_empty_station(self, mock_client: MagicMock) -> None:

--- a/tests/unit/devices/test_station_hybrid.py
+++ b/tests/unit/devices/test_station_hybrid.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from pylxpweb.devices.inverters.base import BaseInverter
 from pylxpweb.devices.station import Station
 from pylxpweb.transports.config import TransportConfig, TransportType
 
@@ -18,17 +19,31 @@ def mock_client() -> MagicMock:
     return client
 
 
-@pytest.fixture
-def mock_inverter() -> MagicMock:
-    """Create a mock inverter."""
-    inverter = MagicMock()
-    inverter.serial_number = "CE12345678"
-    inverter._transport = None
-    return inverter
+def make_inverter(client: MagicMock, serial: str) -> BaseInverter:
+    """Create a real inverter so tests exercise its public transport lifecycle."""
+    from pylxpweb.devices.inverters.generic import GenericInverter
+
+    return GenericInverter(client, serial, "Test Inverter")
+
+
+def make_transport(serial: str) -> MagicMock:
+    """Create a transport capability with explicit public lifecycle state."""
+    transport = MagicMock()
+    transport.serial = serial
+    transport.is_connected = False
+    transport.connect = AsyncMock()
+    transport.disconnect = AsyncMock()
+    return transport
 
 
 @pytest.fixture
-def station_with_inverter(mock_client: MagicMock, mock_inverter: MagicMock) -> Station:
+def mock_inverter(mock_client: MagicMock) -> BaseInverter:
+    """Create an inverter backed by the public device implementation."""
+    return make_inverter(mock_client, "CE12345678")
+
+
+@pytest.fixture
+def station_with_inverter(mock_client: MagicMock, mock_inverter: BaseInverter) -> Station:
     """Create a Station with one inverter."""
     from datetime import datetime
 
@@ -50,17 +65,17 @@ class TestIsHybridMode:
     """Tests for Station.is_hybrid_mode property."""
 
     def test_no_transports_attached(
-        self, station_with_inverter: Station, mock_inverter: MagicMock
+        self, station_with_inverter: Station, mock_inverter: BaseInverter
     ) -> None:
         """Test is_hybrid_mode is False when no transports attached."""
-        mock_inverter._transport = None
         assert station_with_inverter.is_hybrid_mode is False
 
-    def test_with_transport_attached(
-        self, station_with_inverter: Station, mock_inverter: MagicMock
+    @pytest.mark.asyncio
+    async def test_with_transport_attached(
+        self, station_with_inverter: Station, mock_inverter: BaseInverter
     ) -> None:
         """Test is_hybrid_mode is True when transport is attached."""
-        mock_inverter._transport = MagicMock()
+        await mock_inverter.attach_local_transport(make_transport("CE12345678"))
         assert station_with_inverter.is_hybrid_mode is True
 
     def test_empty_station(self, mock_client: MagicMock) -> None:
@@ -85,11 +100,10 @@ class TestAttachLocalTransports:
 
     @pytest.mark.asyncio
     async def test_attach_modbus_transport_success(
-        self, station_with_inverter: Station, mock_inverter: MagicMock
+        self, station_with_inverter: Station, mock_inverter: BaseInverter
     ) -> None:
         """Test successfully attaching a Modbus transport."""
-        mock_transport = AsyncMock()
-        mock_transport.connect = AsyncMock()
+        mock_transport = make_transport("CE12345678")
 
         config = TransportConfig(
             host="192.168.1.100",
@@ -110,15 +124,14 @@ class TestAttachLocalTransports:
         assert result.failed == 0
         mock_create.assert_called_once()
         mock_transport.connect.assert_called_once()
-        assert mock_inverter._transport == mock_transport
+        assert mock_inverter.transport == mock_transport
 
     @pytest.mark.asyncio
     async def test_attach_dongle_transport_success(
-        self, station_with_inverter: Station, mock_inverter: MagicMock
+        self, station_with_inverter: Station, mock_inverter: BaseInverter
     ) -> None:
         """Test successfully attaching a WiFi dongle transport."""
-        mock_transport = AsyncMock()
-        mock_transport.connect = AsyncMock()
+        mock_transport = make_transport("CE12345678")
 
         config = TransportConfig(
             host="192.168.1.100",
@@ -139,7 +152,7 @@ class TestAttachLocalTransports:
         assert result.failed == 0
         mock_create.assert_called_once()
         mock_transport.connect.assert_called_once()
-        assert mock_inverter._transport == mock_transport
+        assert mock_inverter.transport == mock_transport
 
     @pytest.mark.asyncio
     async def test_attach_unmatched_serial(self, station_with_inverter: Station) -> None:
@@ -160,11 +173,11 @@ class TestAttachLocalTransports:
 
     @pytest.mark.asyncio
     async def test_attach_connection_failure(
-        self, station_with_inverter: Station, mock_inverter: MagicMock
+        self, station_with_inverter: Station, mock_inverter: BaseInverter
     ) -> None:
         """Test attaching transport that fails to connect."""
-        mock_transport = AsyncMock()
-        mock_transport.connect = AsyncMock(side_effect=Exception("Connection refused"))
+        mock_transport = make_transport("CE12345678")
+        mock_transport.connect.side_effect = Exception("Connection refused")
 
         config = TransportConfig(
             host="192.168.1.100",
@@ -183,7 +196,7 @@ class TestAttachLocalTransports:
         assert result.unmatched == 0
         assert result.failed == 1
         assert "CE12345678" in result.failed_serials
-        assert mock_inverter._transport is None
+        assert mock_inverter.transport is None
 
     @pytest.mark.asyncio
     async def test_attach_multiple_configs(self, mock_client: MagicMock) -> None:
@@ -193,13 +206,8 @@ class TestAttachLocalTransports:
         from pylxpweb.devices.station import Location
 
         # Create two inverters
-        inv1 = MagicMock()
-        inv1.serial_number = "CE11111111"
-        inv1._transport = None
-
-        inv2 = MagicMock()
-        inv2.serial_number = "CE22222222"
-        inv2._transport = None
+        inv1 = make_inverter(mock_client, "CE11111111")
+        inv2 = make_inverter(mock_client, "CE22222222")
 
         station = Station(
             client=mock_client,
@@ -226,10 +234,8 @@ class TestAttachLocalTransports:
             ),
         ]
 
-        mock_transport1 = AsyncMock()
-        mock_transport1.connect = AsyncMock()
-        mock_transport2 = AsyncMock()
-        mock_transport2.connect = AsyncMock()
+        mock_transport1 = make_transport("CE11111111")
+        mock_transport2 = make_transport("CE22222222")
 
         with patch(
             "pylxpweb.transports.create_modbus_transport",
@@ -240,8 +246,8 @@ class TestAttachLocalTransports:
         assert result.matched == 2
         assert result.unmatched == 0
         assert result.failed == 0
-        assert inv1._transport == mock_transport1
-        assert inv2._transport == mock_transport2
+        assert inv1.transport == mock_transport1
+        assert inv2.transport == mock_transport2
 
     @pytest.mark.asyncio
     async def test_attach_mixed_results(self, mock_client: MagicMock) -> None:
@@ -250,9 +256,7 @@ class TestAttachLocalTransports:
 
         from pylxpweb.devices.station import Location
 
-        inv1 = MagicMock()
-        inv1.serial_number = "CE11111111"
-        inv1._transport = None
+        inv1 = make_inverter(mock_client, "CE11111111")
 
         station = Station(
             client=mock_client,
@@ -279,8 +283,7 @@ class TestAttachLocalTransports:
             ),
         ]
 
-        mock_transport = AsyncMock()
-        mock_transport.connect = AsyncMock()
+        mock_transport = make_transport("CE11111111")
 
         with patch(
             "pylxpweb.transports.create_modbus_transport",
@@ -304,13 +307,12 @@ class TestAttachLocalTransports:
 
     @pytest.mark.asyncio
     async def test_attach_with_inverter_family(
-        self, station_with_inverter: Station, mock_inverter: MagicMock
+        self, station_with_inverter: Station, mock_inverter: BaseInverter
     ) -> None:
         """Test attaching transport with inverter family specified."""
         from pylxpweb.devices.inverters._features import InverterFamily
 
-        mock_transport = AsyncMock()
-        mock_transport.connect = AsyncMock()
+        mock_transport = make_transport("CE12345678")
 
         config = TransportConfig(
             host="192.168.1.100",

--- a/tests/unit/devices/test_station_hybrid.py
+++ b/tests/unit/devices/test_station_hybrid.py
@@ -28,7 +28,7 @@ def make_inverter(client: MagicMock, serial: str) -> BaseInverter:
 
 def make_transport(serial: str) -> MagicMock:
     """Create a transport capability with explicit public lifecycle state."""
-    transport = MagicMock()
+    transport = MagicMock(spec=["serial", "is_connected", "connect", "disconnect"])
     transport.serial = serial
     transport.is_connected = False
     transport.connect = AsyncMock()
@@ -75,7 +75,9 @@ class TestIsHybridMode:
         self, station_with_inverter: Station, mock_inverter: BaseInverter
     ) -> None:
         """Test is_hybrid_mode is True when transport is attached."""
-        await mock_inverter.attach_local_transport(make_transport("CE12345678"))
+        await mock_inverter.attach_local_transport(
+            make_transport("CE12345678"), require_terminal=False
+        )
         assert station_with_inverter.is_hybrid_mode is True
 
     def test_empty_station(self, mock_client: MagicMock) -> None:
@@ -197,6 +199,7 @@ class TestAttachLocalTransports:
         assert result.failed == 1
         assert "CE12345678" in result.failed_serials
         assert mock_inverter.transport is None
+        mock_transport.disconnect.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_attach_multiple_configs(self, mock_client: MagicMock) -> None:

--- a/tests/unit/devices/test_station_transport_injection.py
+++ b/tests/unit/devices/test_station_transport_injection.py
@@ -31,8 +31,8 @@ class RecordingTransport:
         events: list[str],
         *,
         label: str = "",
-        connect_error: Exception | None = None,
-        close_error: Exception | None = None,
+        connect_error: BaseException | None = None,
+        close_error: BaseException | None = None,
     ) -> None:
         self.serial = serial
         self.transport_type = "modbus_tcp"
@@ -171,6 +171,13 @@ def exception_leaves(error: BaseException) -> list[BaseException]:
     if isinstance(error, BaseExceptionGroup):
         return [leaf for child in error.exceptions for leaf in exception_leaves(child)]
     return [error]
+
+
+async def cancel_repeatedly(task: asyncio.Task[Any], count: int = 100) -> None:
+    """Deliver repeated cancellation at distinct event-loop opportunities."""
+    for _ in range(count):
+        task.cancel()
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
@@ -443,8 +450,10 @@ async def test_cancellation_and_cleanup_failure_are_combined(station: Station) -
 
 
 @pytest.mark.asyncio
-async def test_repeated_cancellation_waits_for_terminal_cleanup(station: Station) -> None:
-    """Repeated cancellation cannot interrupt terminal cleanup or leak capability."""
+async def test_many_repeated_cancellations_coalesce_to_native_cancellation(
+    station: Station,
+) -> None:
+    """Unretained cleanup keeps constant cancellation state and native semantics."""
     events: list[str] = []
     capability = RecordingTransport("INV0000001", events)
     capability.connect_started = asyncio.Event()
@@ -456,17 +465,124 @@ async def test_repeated_cancellation_waits_for_terminal_cleanup(station: Station
 
     task.cancel()
     await capability.close_started.wait()
-    task.cancel()
-    await asyncio.sleep(0)
+    await cancel_repeatedly(task)
     assert not task.done()
 
     capability.close_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task.cancelled()
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_wait_for_preserves_native_timeout_when_terminal_cleanup_cancels(
+    station: Station,
+) -> None:
+    """Cancellation-only cleanup remains a timeout through asyncio.wait_for()."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events, close_error=asyncio.CancelledError())
+    capability.connect_release = asyncio.Event()
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(
+            station.all_inverters[0].attach_local_transport(capability),
+            timeout=0.05,
+        )
+
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_timeout_context_preserves_native_timeout_when_cleanup_cancels(
+    station: Station,
+) -> None:
+    """Cancellation-only cleanup remains a timeout through asyncio.timeout()."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events, close_error=asyncio.CancelledError())
+    capability.connect_release = asyncio.Event()
+
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(0.05):
+            await station.all_inverters[0].attach_local_transport(capability)
+
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_task_group_treats_cancellation_only_cleanup_as_cancelled(
+    station: Station,
+) -> None:
+    """A child with cancellation-only cleanup remains cancelled to TaskGroup."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events, close_error=asyncio.CancelledError())
+    capability.connect_started = asyncio.Event()
+    capability.connect_release = asyncio.Event()
+
+    async with asyncio.TaskGroup() as group:
+        task = group.create_task(station.all_inverters[0].attach_local_transport(capability))
+        await capability.connect_started.wait()
+        task.cancel()
+
+    assert task.cancelled()
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_nested_cancellation_only_cleanup_preserves_native_cancellation(
+    station: Station,
+) -> None:
+    """Nested cancellation-only cleanup errors collapse to one cancellation."""
+    events: list[str] = []
+    cleanup_error = BaseExceptionGroup(
+        "nested cancellation",
+        [
+            asyncio.CancelledError(),
+            BaseExceptionGroup("deeper cancellation", [asyncio.CancelledError()]),
+        ],
+    )
+    capability = RecordingTransport("INV0000001", events, close_error=cleanup_error)
+    capability.connect_started = asyncio.Event()
+    capability.connect_release = asyncio.Event()
+    task = asyncio.create_task(station.all_inverters[0].attach_local_transport(capability))
+    await capability.connect_started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task.cancelled()
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_nested_mixed_cleanup_preserves_every_failure(station: Station) -> None:
+    """A nested non-cancellation leaf keeps the complete mixed failure group."""
+    events: list[str] = []
+    cleanup_error = BaseExceptionGroup(
+        "nested mixed cleanup",
+        [asyncio.CancelledError(), RuntimeError("cleanup failed")],
+    )
+    capability = RecordingTransport("INV0000001", events, close_error=cleanup_error)
+    capability.connect_started = asyncio.Event()
+    capability.connect_release = asyncio.Event()
+    task = asyncio.create_task(station.all_inverters[0].attach_local_transport(capability))
+    await capability.connect_started.wait()
+
+    task.cancel()
     with pytest.raises(BaseExceptionGroup) as raised:
         await task
 
     assert [type(error) for error in exception_leaves(raised.value)] == [
         asyncio.CancelledError,
         asyncio.CancelledError,
+        RuntimeError,
     ]
     assert events == ["connect", "shutdown"]
     assert station.all_inverters[0].transport is None
@@ -646,8 +762,7 @@ async def test_cancelled_same_capability_waiter_cannot_close_holder_input(
     await capability.connect_started.wait()
     waiter = asyncio.create_task(inverter.attach_local_transport(capability))
     await asyncio.sleep(0)
-    waiter.cancel()
-    await asyncio.sleep(0)
+    await cancel_repeatedly(waiter)
 
     assert not waiter.done()
     assert events == ["connect"]
@@ -656,8 +771,47 @@ async def test_cancelled_same_capability_waiter_cannot_close_holder_input(
     with pytest.raises(asyncio.CancelledError):
         await waiter
 
+    assert waiter.cancelled()
     assert events == ["connect"]
     assert inverter.transport is capability
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_coalesces_repeats_with_cleanup_failure(
+    station: Station,
+) -> None:
+    """A mixed waiter outcome keeps one primary and one later cancellation marker."""
+    events: list[str] = []
+    holder_capability = RecordingTransport("INV0000001", events, label="holder")
+    waiting_capability = RecordingTransport(
+        "INV0000001",
+        events,
+        label="waiting",
+        close_error=RuntimeError("cleanup failed"),
+    )
+    holder_capability.connect_started = asyncio.Event()
+    holder_capability.connect_release = asyncio.Event()
+    inverter = station.all_inverters[0]
+
+    holder = asyncio.create_task(inverter.attach_local_transport(holder_capability))
+    await holder_capability.connect_started.wait()
+    waiter = asyncio.create_task(inverter.attach_local_transport(waiting_capability))
+    await asyncio.sleep(0)
+    await cancel_repeatedly(waiter)
+    assert not waiter.done()
+
+    holder_capability.connect_release.set()
+    await holder
+    with pytest.raises(BaseExceptionGroup) as raised:
+        await waiter
+
+    assert [type(error) for error in exception_leaves(raised.value)] == [
+        asyncio.CancelledError,
+        asyncio.CancelledError,
+        RuntimeError,
+    ]
+    assert events == ["holder:connect", "waiting:shutdown"]
+    assert inverter.transport is holder_capability
 
 
 @pytest.mark.asyncio

--- a/tests/unit/devices/test_station_transport_injection.py
+++ b/tests/unit/devices/test_station_transport_injection.py
@@ -426,6 +426,30 @@ async def test_connect_and_cleanup_failures_are_combined(station: Station) -> No
 
 
 @pytest.mark.asyncio
+async def test_nested_cancellation_only_connect_preserves_native_cancellation(
+    station: Station,
+) -> None:
+    """A cancellation-only connect group becomes native after successful cleanup."""
+    events: list[str] = []
+    connect_error = BaseExceptionGroup(
+        "nested connect cancellation",
+        [
+            asyncio.CancelledError(),
+            BaseExceptionGroup("deeper cancellation", [asyncio.CancelledError()]),
+        ],
+    )
+    capability = RecordingTransport("INV0000001", events, connect_error=connect_error)
+    task = asyncio.create_task(station.all_inverters[0].attach_local_transport(capability))
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1)
+
+    assert task.cancelled()
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
 async def test_cancellation_and_cleanup_failure_are_combined(station: Station) -> None:
     """Cancellation and terminal-cleanup failure are reported deterministically."""
     events: list[str] = []

--- a/tests/unit/devices/test_station_transport_injection.py
+++ b/tests/unit/devices/test_station_transport_injection.py
@@ -1,0 +1,320 @@
+"""Public transport-capability injection and lifecycle tests."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pylxpweb.devices.inverters.generic import GenericInverter
+from pylxpweb.devices.mid_device import MIDDevice
+from pylxpweb.devices.station import Location, Station
+from pylxpweb.transports import TransportConfig, TransportFactory, TransportType
+
+
+class RecordingTransport:
+    """Minimal caller-owned capability that records attachment-boundary calls."""
+
+    def __init__(
+        self,
+        serial: str,
+        events: list[str],
+        *,
+        connect_error: Exception | None = None,
+        close_error: Exception | None = None,
+    ) -> None:
+        self.serial = serial
+        self.transport_type = "modbus_tcp"
+        self.is_connected = False
+        self.events = events
+        self.connect_error = connect_error
+        self.close_error = close_error
+        self.connect_started: asyncio.Event | None = None
+        self.connect_release: asyncio.Event | None = None
+
+    async def connect(self) -> None:
+        self.events.append("connect")
+        await asyncio.sleep(0)
+        if self.connect_started is not None:
+            self.connect_started.set()
+        if self.connect_release is not None:
+            await self.connect_release.wait()
+        if self.connect_error is not None:
+            raise self.connect_error
+        self.is_connected = True
+
+    async def disconnect(self) -> None:
+        self.events.append("disconnect")
+        self.is_connected = False
+
+    async def async_shutdown(self) -> None:
+        self.events.append("shutdown")
+        if self.close_error is not None:
+            raise self.close_error
+        self.is_connected = False
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith(("read", "write", "reconnect")):
+            raise AssertionError(f"attachment invoked forbidden operation {name}")
+        raise AttributeError(name)
+
+
+class DisconnectOnlyTransport:
+    """Capability that supports the required reusable disconnect lifecycle only."""
+
+    def __init__(self, serial: str, events: list[str]) -> None:
+        self.serial = serial
+        self.is_connected = False
+        self.events = events
+
+    async def connect(self) -> None:
+        self.events.append("connect")
+        self.is_connected = True
+
+    async def disconnect(self) -> None:
+        self.events.append("disconnect")
+        self.is_connected = False
+
+
+@pytest.fixture
+def station() -> Station:
+    """Create a cloud-discovered station with one inverter and one MID."""
+    client = MagicMock()
+    client.username = "test-user"
+    result = Station(
+        client=client,
+        plant_id=12345,
+        name="Test Station",
+        location=Location(address="", country="US"),
+        timezone="UTC",
+        created_date=datetime.now(),
+    )
+    result.standalone_inverters = [GenericInverter(client, "INV0000001", "Test Inverter")]
+    result.standalone_mid_devices = [MIDDevice(client, "MID0000001")]
+    return result
+
+
+def config(serial: str) -> TransportConfig:
+    """Build a sanitized local transport configuration."""
+    return TransportConfig(
+        host="example.invalid",
+        port=502,
+        serial=serial,
+        transport_type=TransportType.MODBUS_TCP,
+    )
+
+
+@pytest.mark.asyncio
+async def test_injected_factory_is_the_only_attachment_boundary(station: Station) -> None:
+    """Injection constructs/connects only the supplied capability, with no I/O probe."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+
+    def factory(item: TransportConfig) -> RecordingTransport:
+        events.append(f"factory:{item.serial}")
+        return capability
+
+    typed_factory: TransportFactory = factory
+    with (
+        patch("pylxpweb.transports.create_modbus_transport") as default_modbus,
+        patch("pylxpweb.transports.create_dongle_transport") as default_dongle,
+    ):
+        result = await station.attach_local_transports(
+            [config("INV0000001")], transport_factory=typed_factory
+        )
+
+    assert events == ["factory:INV0000001", "connect"]
+    assert result.matched == 1
+    assert station.all_inverters[0].transport is capability
+    default_modbus.assert_not_called()
+    default_dongle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_injected_factory_attaches_mid_capability(station: Station) -> None:
+    """The public seam retains a supplied capability on a matched MID."""
+    events: list[str] = []
+    capability = RecordingTransport("MID0000001", events)
+
+    result = await station.attach_local_transports(
+        [config("MID0000001")], transport_factory=lambda _: capability
+    )
+
+    assert result.matched == 1
+    assert station.all_mid_devices[0].transport is capability
+    assert events == ["connect"]
+
+
+@pytest.mark.asyncio
+async def test_mid_public_detach_uses_terminal_close(station: Station) -> None:
+    """A MID capability has the same public terminal detach lifecycle."""
+    events: list[str] = []
+    capability = RecordingTransport("MID0000001", events)
+    mid = station.all_mid_devices[0]
+    await mid.attach_local_transport(capability)
+
+    detached = await mid.detach_local_transport()
+
+    assert detached is capability
+    assert mid.transport is None
+    assert events == ["connect", "shutdown"]
+
+
+@pytest.mark.asyncio
+async def test_partial_match_does_not_construct_unmatched_capability(station: Station) -> None:
+    """Serial matching happens before the caller-owned factory is invoked."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    requested: list[str] = []
+
+    def factory(item: TransportConfig) -> RecordingTransport:
+        requested.append(item.serial)
+        return capability
+
+    result = await station.attach_local_transports(
+        [config("MISSING001"), config("INV0000001")], transport_factory=factory
+    )
+
+    assert requested == ["INV0000001"]
+    assert (result.matched, result.unmatched, result.failed) == (1, 1, 0)
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_closes_capability_without_retaining_it(station: Station) -> None:
+    """A failed injected connect is closed and reported through AttachResult."""
+    events: list[str] = []
+    capability = RecordingTransport(
+        "INV0000001", events, connect_error=ConnectionError("unavailable")
+    )
+
+    result = await station.attach_local_transports(
+        [config("INV0000001")], transport_factory=lambda _: capability
+    )
+
+    assert events == ["connect", "shutdown"]
+    assert (result.matched, result.unmatched, result.failed) == (0, 0, 1)
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_factory_capability_serial_mismatch_is_closed_and_failed(station: Station) -> None:
+    """A factory cannot attach a capability to the wrong matched device."""
+    events: list[str] = []
+    capability = RecordingTransport("OTHER00001", events)
+
+    result = await station.attach_local_transports(
+        [config("INV0000001")], transport_factory=lambda _: capability
+    )
+
+    assert events == ["shutdown"]
+    assert (result.matched, result.unmatched, result.failed) == (0, 0, 1)
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_connect_closes_capability_and_propagates(station: Station) -> None:
+    """Cancellation during connect terminally closes without retaining the capability."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    capability.connect_started = asyncio.Event()
+    capability.connect_release = asyncio.Event()
+    task = asyncio.create_task(
+        station.attach_local_transports(
+            [config("INV0000001")], transport_factory=lambda _: capability
+        )
+    )
+    await capability.connect_started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_precancelled_attachment_cleans_up_before_propagating(station: Station) -> None:
+    """Cancellation already pending at connect still terminally closes the capability."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+
+    async def run_cancelled() -> None:
+        task = asyncio.current_task()
+        assert task is not None
+        task.cancel()
+        await station.attach_local_transports(
+            [config("INV0000001")], transport_factory=lambda _: capability
+        )
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_cancelled()
+
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_public_detach_uses_terminal_close(station: Station) -> None:
+    """Callers can terminally close and detach without private device access."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(capability)
+
+    detached = await inverter.detach_local_transport()
+
+    assert detached is capability
+    assert inverter.transport is None
+    assert events == ["connect", "shutdown"]
+
+
+@pytest.mark.asyncio
+async def test_public_detach_falls_back_to_disconnect(station: Station) -> None:
+    """Capabilities without terminal shutdown retain protocol-compatible cleanup."""
+    events: list[str] = []
+    capability = DisconnectOnlyTransport("INV0000001", events)
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(capability)
+
+    detached = await inverter.detach_local_transport()
+
+    assert detached is capability
+    assert inverter.transport is None
+    assert events == ["connect", "disconnect"]
+
+
+@pytest.mark.asyncio
+async def test_replacement_closes_old_before_retaining_new(station: Station) -> None:
+    """Replacement connects new, drains old, then atomically publishes new."""
+    events: list[str] = []
+    old = RecordingTransport("INV0000001", events)
+    new = RecordingTransport("INV0000001", events)
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(old)
+    events.clear()
+
+    await inverter.attach_local_transport(new)
+
+    assert events == ["connect", "shutdown"]
+    assert inverter.transport is new
+
+
+@pytest.mark.asyncio
+async def test_failed_replacement_keeps_old_and_closes_new(station: Station) -> None:
+    """A close failure cannot publish a replacement or leak its capability."""
+    events: list[str] = []
+    old = RecordingTransport("INV0000001", events, close_error=RuntimeError("close failed"))
+    new = RecordingTransport("INV0000001", events)
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(old)
+    events.clear()
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        await inverter.attach_local_transport(new)
+
+    assert events == ["connect", "shutdown", "shutdown"]
+    assert inverter.transport is old

--- a/tests/unit/devices/test_station_transport_injection.py
+++ b/tests/unit/devices/test_station_transport_injection.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -23,6 +23,7 @@ class RecordingTransport:
         serial: str,
         events: list[str],
         *,
+        label: str = "",
         connect_error: Exception | None = None,
         close_error: Exception | None = None,
     ) -> None:
@@ -30,13 +31,20 @@ class RecordingTransport:
         self.transport_type = "modbus_tcp"
         self.is_connected = False
         self.events = events
+        self.label = label
         self.connect_error = connect_error
         self.close_error = close_error
         self.connect_started: asyncio.Event | None = None
         self.connect_release: asyncio.Event | None = None
+        self.close_started: asyncio.Event | None = None
+        self.close_release: asyncio.Event | None = None
+
+    def _event(self, name: str) -> str:
+        """Prefix an event when a test needs to distinguish capabilities."""
+        return f"{self.label}:{name}" if self.label else name
 
     async def connect(self) -> None:
-        self.events.append("connect")
+        self.events.append(self._event("connect"))
         await asyncio.sleep(0)
         if self.connect_started is not None:
             self.connect_started.set()
@@ -47,11 +55,15 @@ class RecordingTransport:
         self.is_connected = True
 
     async def disconnect(self) -> None:
-        self.events.append("disconnect")
+        self.events.append(self._event("disconnect"))
         self.is_connected = False
 
     async def async_shutdown(self) -> None:
-        self.events.append("shutdown")
+        self.events.append(self._event("shutdown"))
+        if self.close_started is not None:
+            self.close_started.set()
+        if self.close_release is not None:
+            await self.close_release.wait()
         if self.close_error is not None:
             raise self.close_error
         self.is_connected = False
@@ -278,13 +290,290 @@ async def test_public_detach_falls_back_to_disconnect(station: Station) -> None:
     events: list[str] = []
     capability = DisconnectOnlyTransport("INV0000001", events)
     inverter = station.all_inverters[0]
-    await inverter.attach_local_transport(capability)
+    await inverter.attach_local_transport(capability, require_terminal=False)
 
     detached = await inverter.detach_local_transport()
 
     assert detached is capability
     assert inverter.transport is None
     assert events == ["connect", "disconnect"]
+
+
+@pytest.mark.asyncio
+async def test_injected_factory_rejects_disconnect_only_capability(station: Station) -> None:
+    """Caller-owned injection requires an explicit terminal-close capability."""
+    events: list[str] = []
+    capability = DisconnectOnlyTransport("INV0000001", events)
+
+    result = await station.attach_local_transports(
+        [config("INV0000001")], transport_factory=lambda _: capability
+    )
+
+    assert (result.matched, result.failed) == (0, 1)
+    assert station.all_inverters[0].transport is None
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_connect_and_cleanup_failures_are_combined(station: Station) -> None:
+    """Both failures remain visible when a failed connect cannot be cleaned up."""
+    events: list[str] = []
+    capability = RecordingTransport(
+        "INV0000001",
+        events,
+        connect_error=ConnectionError("connect failed"),
+        close_error=RuntimeError("cleanup failed"),
+    )
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        await station.all_inverters[0].attach_local_transport(capability)
+
+    assert [type(error) for error in raised.value.exceptions] == [
+        ConnectionError,
+        RuntimeError,
+    ]
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_cancellation_and_cleanup_failure_are_combined(station: Station) -> None:
+    """Cancellation and terminal-cleanup failure are reported deterministically."""
+    events: list[str] = []
+    capability = RecordingTransport(
+        "INV0000001", events, close_error=RuntimeError("cleanup failed")
+    )
+    capability.connect_started = asyncio.Event()
+    capability.connect_release = asyncio.Event()
+    task = asyncio.create_task(station.all_inverters[0].attach_local_transport(capability))
+    await capability.connect_started.wait()
+
+    task.cancel()
+    with pytest.raises(BaseExceptionGroup) as raised:
+        await task
+
+    assert [type(error) for error in raised.value.exceptions] == [
+        asyncio.CancelledError,
+        RuntimeError,
+    ]
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_waits_for_terminal_cleanup(station: Station) -> None:
+    """Repeated cancellation cannot interrupt terminal cleanup or leak capability."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    capability.connect_started = asyncio.Event()
+    capability.connect_release = asyncio.Event()
+    capability.close_started = asyncio.Event()
+    capability.close_release = asyncio.Event()
+    task = asyncio.create_task(station.all_inverters[0].attach_local_transport(capability))
+    await capability.connect_started.wait()
+
+    task.cancel()
+    await capability.close_started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    capability.close_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events == ["connect", "shutdown"]
+    assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_detach_failure_retains_current_capability(station: Station) -> None:
+    """A failed terminal detach retains the current owner for a later retry."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events, close_error=RuntimeError("close failed"))
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(capability)
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        await inverter.detach_local_transport()
+
+    assert inverter.transport is capability
+    assert events == ["connect", "shutdown"]
+
+
+@pytest.mark.asyncio
+async def test_detach_cancellation_and_cleanup_failure_are_combined(
+    station: Station,
+) -> None:
+    """Detach preserves cancellation when the completed close attempt also fails."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(capability)
+    capability.close_error = RuntimeError("close failed")
+    capability.close_started = asyncio.Event()
+    capability.close_release = asyncio.Event()
+    task = asyncio.create_task(inverter.detach_local_transport())
+    await capability.close_started.wait()
+
+    task.cancel()
+    capability.close_release.set()
+    with pytest.raises(BaseExceptionGroup) as raised:
+        await task
+
+    assert [type(error) for error in raised.value.exceptions] == [
+        asyncio.CancelledError,
+        RuntimeError,
+    ]
+    assert inverter.transport is capability
+
+
+@pytest.mark.asyncio
+async def test_concurrent_attachments_are_serialized(station: Station) -> None:
+    """A second attachment cannot connect or publish during the first transition."""
+    events: list[str] = []
+    first = RecordingTransport("INV0000001", events, label="first")
+    second = RecordingTransport("INV0000001", events, label="second")
+    first.connect_started = asyncio.Event()
+    first.connect_release = asyncio.Event()
+    second.connect_started = asyncio.Event()
+    second.connect_release = asyncio.Event()
+    inverter = station.all_inverters[0]
+
+    first_task = asyncio.create_task(inverter.attach_local_transport(first))
+    await first.connect_started.wait()
+    second_task = asyncio.create_task(inverter.attach_local_transport(second))
+    await asyncio.sleep(0)
+    assert not second.connect_started.is_set()
+
+    first.connect_release.set()
+    await first_task
+    await second.connect_started.wait()
+    second.connect_release.set()
+    await second_task
+
+    assert events == ["first:connect", "second:connect", "first:shutdown"]
+    assert inverter.transport is second
+
+
+@pytest.mark.asyncio
+async def test_cancellation_while_waiting_for_lifecycle_closes_new_capability(
+    station: Station,
+) -> None:
+    """Cancellation while waiting for another transition cleans the unpublished input."""
+    events: list[str] = []
+    first = RecordingTransport("INV0000001", events, label="first")
+    waiting = RecordingTransport("INV0000001", events, label="waiting")
+    first.connect_started = asyncio.Event()
+    first.connect_release = asyncio.Event()
+    inverter = station.all_inverters[0]
+
+    first_task = asyncio.create_task(inverter.attach_local_transport(first))
+    await first.connect_started.wait()
+    waiting_task = asyncio.create_task(inverter.attach_local_transport(waiting))
+    await asyncio.sleep(0)
+    waiting_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiting_task
+
+    first.connect_release.set()
+    await first_task
+
+    assert events == ["first:connect", "waiting:shutdown"]
+    assert inverter.transport is first
+
+
+@pytest.mark.asyncio
+async def test_concurrent_detach_and_replacement_close_once(station: Station) -> None:
+    """Detach owns the old close while a replacement waits for the transition."""
+    events: list[str] = []
+    old = RecordingTransport("INV0000001", events, label="old")
+    replacement = RecordingTransport("INV0000001", events, label="new")
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(old)
+    events.clear()
+    old.close_started = asyncio.Event()
+    old.close_release = asyncio.Event()
+    replacement.connect_started = asyncio.Event()
+
+    detach_task = asyncio.create_task(inverter.detach_local_transport())
+    await old.close_started.wait()
+    replacement_task = asyncio.create_task(inverter.attach_local_transport(replacement))
+    await asyncio.sleep(0)
+    assert not replacement.connect_started.is_set()
+
+    old.close_release.set()
+    await detach_task
+    await replacement_task
+
+    assert events == ["old:shutdown", "new:connect"]
+    assert inverter.transport is replacement
+
+
+@pytest.mark.asyncio
+async def test_cancelled_replacement_closes_both_without_publishing_new(
+    station: Station,
+) -> None:
+    """Cancellation during old-owner close cannot publish or leak the replacement."""
+    events: list[str] = []
+    old = RecordingTransport("INV0000001", events, label="old")
+    replacement = RecordingTransport("INV0000001", events, label="new")
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(old)
+    events.clear()
+    old.close_started = asyncio.Event()
+    old.close_release = asyncio.Event()
+
+    task = asyncio.create_task(inverter.attach_local_transport(replacement))
+    await old.close_started.wait()
+    task.cancel()
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    old.close_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events == ["new:connect", "old:shutdown", "new:shutdown"]
+    assert inverter.transport is None
+
+
+@pytest.mark.asyncio
+async def test_same_object_attachment_validates_serial_first(station: Station) -> None:
+    """Identity cannot bypass serial validation on an already-owned capability."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(capability)
+    capability.serial = "OTHER00001"
+
+    with pytest.raises(ValueError, match="does not match"):
+        await inverter.attach_local_transport(capability)
+
+    assert inverter.transport is capability
+
+
+@pytest.mark.asyncio
+async def test_same_object_attachment_applies_cache_ttl_hook(station: Station) -> None:
+    """Idempotent public attachment establishes transport cache invariants."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    capability.is_connected = True
+    client = MagicMock()
+    client.username = "test-user"
+    inverter = GenericInverter(
+        client,
+        "INV0000001",
+        "Test Inverter",
+        transport=capability,
+    )
+
+    await inverter.attach_local_transport(capability)
+
+    assert inverter._runtime_cache_ttl == timedelta(seconds=5)
+    assert inverter._energy_cache_ttl == timedelta(seconds=5)
+    assert inverter._battery_cache_ttl == timedelta(seconds=5)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/devices/test_station_transport_injection.py
+++ b/tests/unit/devices/test_station_transport_injection.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -12,7 +14,12 @@ import pytest
 from pylxpweb.devices.inverters.generic import GenericInverter
 from pylxpweb.devices.mid_device import MIDDevice
 from pylxpweb.devices.station import Location, Station
-from pylxpweb.transports import TransportConfig, TransportFactory, TransportType
+from pylxpweb.transports import (
+    TerminalInverterTransport,
+    TransportConfig,
+    TransportFactory,
+    TransportType,
+)
 
 
 class RecordingTransport:
@@ -38,10 +45,17 @@ class RecordingTransport:
         self.connect_release: asyncio.Event | None = None
         self.close_started: asyncio.Event | None = None
         self.close_release: asyncio.Event | None = None
+        self.connect_callback: Callable[[], Awaitable[None]] | None = None
+        self.close_callback: Callable[[], Awaitable[None]] | None = None
 
     def _event(self, name: str) -> str:
         """Prefix an event when a test needs to distinguish capabilities."""
         return f"{self.label}:{name}" if self.label else name
+
+    @property
+    def capabilities(self) -> Any:
+        """Expose the typed capability member without invoking protocol I/O."""
+        return None
 
     async def connect(self) -> None:
         self.events.append(self._event("connect"))
@@ -50,6 +64,8 @@ class RecordingTransport:
             self.connect_started.set()
         if self.connect_release is not None:
             await self.connect_release.wait()
+        if self.connect_callback is not None:
+            await self.connect_callback()
         if self.connect_error is not None:
             raise self.connect_error
         self.is_connected = True
@@ -64,9 +80,32 @@ class RecordingTransport:
             self.close_started.set()
         if self.close_release is not None:
             await self.close_release.wait()
+        if self.close_callback is not None:
+            await self.close_callback()
         if self.close_error is not None:
             raise self.close_error
         self.is_connected = False
+
+    async def read_runtime(self) -> Any:
+        raise AssertionError("attachment invoked forbidden operation read_runtime")
+
+    async def read_energy(self) -> Any:
+        raise AssertionError("attachment invoked forbidden operation read_energy")
+
+    async def read_battery(self) -> Any:
+        raise AssertionError("attachment invoked forbidden operation read_battery")
+
+    async def read_parameters(self, start_address: int, count: int) -> dict[int, int]:
+        raise AssertionError("attachment invoked forbidden operation read_parameters")
+
+    async def write_parameters(self, parameters: dict[int, int]) -> bool:
+        raise AssertionError("attachment invoked forbidden operation write_parameters")
+
+    async def read_named_parameters(self, start_address: int, count: int) -> dict[str, Any]:
+        raise AssertionError("attachment invoked forbidden operation read_named_parameters")
+
+    async def write_named_parameters(self, parameters: dict[str, Any]) -> bool:
+        raise AssertionError("attachment invoked forbidden operation write_named_parameters")
 
     def __getattr__(self, name: str) -> Any:
         if name.startswith(("read", "write", "reconnect")):
@@ -88,6 +127,14 @@ class DisconnectOnlyTransport:
 
     async def disconnect(self) -> None:
         self.events.append("disconnect")
+        self.is_connected = False
+
+
+class ShutdownOnlyTransport(DisconnectOnlyTransport):
+    """Terminal lifecycle without the required inverter-operation capability."""
+
+    async def async_shutdown(self) -> None:
+        self.events.append("shutdown")
         self.is_connected = False
 
 
@@ -117,6 +164,13 @@ def config(serial: str) -> TransportConfig:
         serial=serial,
         transport_type=TransportType.MODBUS_TCP,
     )
+
+
+def exception_leaves(error: BaseException) -> list[BaseException]:
+    """Return exception-group leaves in deterministic traversal order."""
+    if isinstance(error, BaseExceptionGroup):
+        return [leaf for child in error.exceptions for leaf in exception_leaves(child)]
+    return [error]
 
 
 @pytest.mark.asyncio
@@ -286,17 +340,45 @@ async def test_public_detach_uses_terminal_close(station: Station) -> None:
 
 @pytest.mark.asyncio
 async def test_public_detach_falls_back_to_disconnect(station: Station) -> None:
-    """Capabilities without terminal shutdown retain protocol-compatible cleanup."""
+    """The config-only Station path retains legacy disconnect compatibility."""
     events: list[str] = []
     capability = DisconnectOnlyTransport("INV0000001", events)
     inverter = station.all_inverters[0]
-    await inverter.attach_local_transport(capability, require_terminal=False)
+    with patch(
+        "pylxpweb.transports.create_modbus_transport",
+        return_value=capability,
+    ):
+        result = await station.attach_local_transports([config("INV0000001")])
 
     detached = await inverter.detach_local_transport()
 
+    assert result.matched == 1
     assert detached is capability
     assert inverter.transport is None
     assert events == ["connect", "disconnect"]
+
+
+def test_public_attachment_has_no_terminal_contract_downgrade() -> None:
+    """Caller-owned attachment exposes only the terminal capability contract."""
+    signature = inspect.signature(GenericInverter.attach_local_transport)
+    capability = RecordingTransport("INV0000001", [])
+
+    assert list(signature.parameters) == ["self", "transport"]
+    assert "TerminalInverterTransport" in str(signature.parameters["transport"].annotation)
+    assert isinstance(capability, TerminalInverterTransport)
+
+
+@pytest.mark.asyncio
+async def test_public_attachment_rejects_shutdown_only_capability(station: Station) -> None:
+    """Terminal shutdown alone cannot satisfy the inverter capability contract."""
+    events: list[str] = []
+    capability = ShutdownOnlyTransport("INV0000001", events)
+
+    with pytest.raises(TypeError, match="TerminalInverterTransport"):
+        await station.all_inverters[0].attach_local_transport(capability)
+
+    assert events == []
+    assert station.all_inverters[0].transport is None
 
 
 @pytest.mark.asyncio
@@ -379,11 +461,75 @@ async def test_repeated_cancellation_waits_for_terminal_cleanup(station: Station
     assert not task.done()
 
     capability.close_release.set()
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(BaseExceptionGroup) as raised:
         await task
 
+    assert [type(error) for error in exception_leaves(raised.value)] == [
+        asyncio.CancelledError,
+        asyncio.CancelledError,
+    ]
     assert events == ["connect", "shutdown"]
     assert station.all_inverters[0].transport is None
+
+
+@pytest.mark.asyncio
+async def test_later_cleanup_cancellation_is_combined_with_connect_failure(
+    station: Station,
+) -> None:
+    """Cancellation reported during cleanup remains visible with the primary failure."""
+    events: list[str] = []
+    capability = RecordingTransport(
+        "INV0000001", events, connect_error=ConnectionError("connect failed")
+    )
+    capability.close_started = asyncio.Event()
+    capability.close_release = asyncio.Event()
+    task = asyncio.create_task(station.all_inverters[0].attach_local_transport(capability))
+    await capability.close_started.wait()
+
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+    capability.close_release.set()
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        await task
+
+    assert [type(error) for error in exception_leaves(raised.value)] == [
+        ConnectionError,
+        asyncio.CancelledError,
+    ]
+    assert events == ["connect", "shutdown"]
+
+
+@pytest.mark.asyncio
+async def test_primary_cleanup_failure_and_later_cancellation_are_all_preserved(
+    station: Station,
+) -> None:
+    """Primary failure, cleanup failure, and later cancellation all remain visible."""
+    events: list[str] = []
+    capability = RecordingTransport(
+        "INV0000001",
+        events,
+        connect_error=ConnectionError("connect failed"),
+        close_error=RuntimeError("cleanup failed"),
+    )
+    capability.close_started = asyncio.Event()
+    capability.close_release = asyncio.Event()
+    task = asyncio.create_task(station.all_inverters[0].attach_local_transport(capability))
+    await capability.close_started.wait()
+
+    task.cancel()
+    capability.close_release.set()
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        await task
+
+    assert [type(error) for error in exception_leaves(raised.value)] == [
+        ConnectionError,
+        asyncio.CancelledError,
+        RuntimeError,
+    ]
+    assert events == ["connect", "shutdown"]
 
 
 @pytest.mark.asyncio
@@ -473,14 +619,96 @@ async def test_cancellation_while_waiting_for_lifecycle_closes_new_capability(
     waiting_task = asyncio.create_task(inverter.attach_local_transport(waiting))
     await asyncio.sleep(0)
     waiting_task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await waiting_task
+    await asyncio.sleep(0)
+    assert not waiting_task.done()
 
     first.connect_release.set()
     await first_task
+    with pytest.raises(asyncio.CancelledError):
+        await waiting_task
 
     assert events == ["first:connect", "waiting:shutdown"]
     assert inverter.transport is first
+
+
+@pytest.mark.asyncio
+async def test_cancelled_same_capability_waiter_cannot_close_holder_input(
+    station: Station,
+) -> None:
+    """A cancelled waiter defers ownership cleanup until the holder publishes."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    capability.connect_started = asyncio.Event()
+    capability.connect_release = asyncio.Event()
+    inverter = station.all_inverters[0]
+
+    holder = asyncio.create_task(inverter.attach_local_transport(capability))
+    await capability.connect_started.wait()
+    waiter = asyncio.create_task(inverter.attach_local_transport(capability))
+    await asyncio.sleep(0)
+    waiter.cancel()
+    await asyncio.sleep(0)
+
+    assert not waiter.done()
+    assert events == ["connect"]
+    capability.connect_release.set()
+    await holder
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert events == ["connect"]
+    assert inverter.transport is capability
+
+
+@pytest.mark.asyncio
+async def test_connect_callback_lifecycle_reentry_fails_fast(station: Station) -> None:
+    """A connect callback cannot deadlock by nesting a lifecycle transition."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    inverter = station.all_inverters[0]
+    nested_errors: list[BaseException] = []
+
+    async def nested_detach() -> None:
+        try:
+            async with asyncio.timeout(0.1):
+                await inverter.detach_local_transport()
+        except BaseException as error:
+            nested_errors.append(error)
+
+    capability.connect_callback = nested_detach
+    await inverter.attach_local_transport(capability)
+
+    assert len(nested_errors) == 1
+    assert isinstance(nested_errors[0], RuntimeError)
+    assert "re-entry" in str(nested_errors[0])
+    assert inverter.transport is capability
+
+
+@pytest.mark.asyncio
+async def test_shutdown_callback_lifecycle_reentry_fails_fast(station: Station) -> None:
+    """A shutdown callback cannot deadlock by nesting a lifecycle transition."""
+    events: list[str] = []
+    capability = RecordingTransport("INV0000001", events)
+    replacement = RecordingTransport("INV0000001", events, label="nested")
+    inverter = station.all_inverters[0]
+    await inverter.attach_local_transport(capability)
+    nested_errors: list[BaseException] = []
+
+    async def nested_attach() -> None:
+        try:
+            async with asyncio.timeout(0.1):
+                await inverter.attach_local_transport(replacement)
+        except BaseException as error:
+            nested_errors.append(error)
+
+    capability.close_callback = nested_attach
+    detached = await inverter.detach_local_transport()
+
+    assert detached is capability
+    assert len(nested_errors) == 1
+    assert isinstance(nested_errors[0], RuntimeError)
+    assert "re-entry" in str(nested_errors[0])
+    assert inverter.transport is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/transports/test_config.py
+++ b/tests/unit/transports/test_config.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import pytest
 
 from pylxpweb.devices.inverters._features import InverterFamily
-from pylxpweb.transports.config import AttachResult, TransportConfig, TransportType
+from pylxpweb.transports.config import (
+    AttachResult,
+    TransportConfig,
+    TransportFactory,
+    TransportType,
+)
 
 
 def test_transport_factory_alias_does_not_eagerly_bind_protocol() -> None:
@@ -13,6 +18,8 @@ def test_transport_factory_alias_does_not_eagerly_bind_protocol() -> None:
     from pylxpweb.transports import config as config_module
 
     assert "InverterTransport" not in vars(config_module)
+    assert "TerminalInverterTransport" not in vars(config_module)
+    assert "TerminalInverterTransport" in str(TransportFactory.__value__)
 
 
 class TestTransportType:

--- a/tests/unit/transports/test_config.py
+++ b/tests/unit/transports/test_config.py
@@ -8,6 +8,13 @@ from pylxpweb.devices.inverters._features import InverterFamily
 from pylxpweb.transports.config import AttachResult, TransportConfig, TransportType
 
 
+def test_transport_factory_alias_does_not_eagerly_bind_protocol() -> None:
+    """The typing-only factory alias does not bind its return protocol eagerly."""
+    from pylxpweb.transports import config as config_module
+
+    assert "InverterTransport" not in vars(config_module)
+
+
 class TestTransportType:
     """Tests for TransportType enum."""
 


### PR DESCRIPTION
## Summary

- add the public `TransportFactory` injection seam to `Station.attach_local_transports`
- retain supplied transport capabilities through public inverter/MID lifecycle APIs
- make connection, terminal detach, replacement ordering, cancellation, failure cleanup, and cache-TTL behavior explicit
- preserve the existing config-only attachment path and `AttachResult` behavior

The injected factory is called only after serial matching. It may return a caller-owned task-reentrant serializer that remains the exclusive holder of its raw transport; pylxpweb retains and drives only the returned `InverterTransport` capability.

## Lifecycle contract

- matched, disconnected capabilities are connected and published as `device.transport`
- unmatched configs never invoke the factory
- failed or cancelled attachment terminally closes the unretained capability
- replacement connects the new capability, terminally closes/drains the old one, then publishes the new one
- failed replacement retains the old capability and closes the new one
- public detach prefers `TerminalTransport.async_shutdown()` and falls back to `disconnect()`
- inverter transport-type cache TTL defaults remain unchanged; wrapper capabilities without `transport_type` retain current TTLs and callers can use `set_cache_ttls()`
- attachment performs no reads, writes, reconnects, or extra disconnects

## TDD and mutation evidence

Initial RED: the focused file failed collection because `TransportFactory` did not exist.

Mutation RED runs after implementation:

- bypass injected factory: 1/1 failed
- invoke factory before matching: 1/1 failed
- disable failure/cancellation cleanup: 4/4 failed
- bypass terminal shutdown: 4/4 failed
- remove MID matching: 1/1 failed
- revert capability publication: 2/2 failed
- remove disconnect fallback: 1/1 failed

Restored GREEN: 23/23 focused tests passed.

## Validation

- `uv run pytest tests/unit/devices/test_station_transport_injection.py tests/unit/devices/test_station_hybrid.py -q`: 23 passed
- `uv run pytest tests/unit/ -q`: 3,179 passed, 19 existing deprecation warnings
- CI-equivalent unit coverage command: 3,178 passed at the time of that run, 88.98% coverage (the subsequent added disconnect-fallback test is included in the 3,179-test full run)
- `uv run ruff check src/ tests/`: passed
- `uv run ruff format --check src/ tests/`: 218 files already formatted
- `uv run mypy --strict src/pylxpweb/`: success, 94 source files
- `uv build` and `uv run twine check dist/*`: wheel and sdist passed
- added-line privacy scan and `git diff --check`: passed

Closes #275
