### PR TITLE
chore(release): prepare 0.10.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2641,7 +2641,8 @@ ac_power = inverter.ac_charge_power_limit  # Property access (uses 1-hour cache)
 - **v0.1.1** (2025-11-15): Bug fixes and improvements
 - **v0.1.0** (2025-11-14): Initial release with core functionality
 
-[Unreleased]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.32...HEAD
+[Unreleased]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b1...HEAD
+[0.10.0b1]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.39b11...v0.10.0b1
 [0.9.32]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.29...v0.9.32
 [0.9.29]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.26...v0.9.29
 [0.9.26]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.17...v0.9.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caller-supplied `TransportFactory` for matched inverter and MID-device
   configurations. The public lifecycle retains only the returned
   `TerminalInverterTransport` capability, connects it after serial matching,
-  and terminally drains it during detach, replacement, cancellation, and
+  and terminally closes it during detach, replacement, cancellation, and
   failure cleanup. The existing config-only API and `AttachResult` behavior
   remain compatible, while callers can keep exclusive ownership of the raw
   transport behind their injected capability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0b1] - 2026-08-14
+
+### Added
+
+- **Public transport-capability injection for local and hybrid attachment**
+  ([#275](https://github.com/joyfulhouse/pylxpweb/issues/275), PR
+  [#276](https://github.com/joyfulhouse/pylxpweb/pull/276), release issue
+  [#277](https://github.com/joyfulhouse/pylxpweb/issues/277)):
+  `Station.attach_local_transports(..., transport_factory=...)` now accepts a
+  caller-supplied `TransportFactory` for matched inverter and MID-device
+  configurations. The public lifecycle retains only the returned
+  `TerminalInverterTransport` capability, connects it after serial matching,
+  and terminally drains it during detach, replacement, cancellation, and
+  failure cleanup. The existing config-only API and `AttachResult` behavior
+  remain compatible, while callers can keep exclusive ownership of the raw
+  transport behind their injected capability.
+
 ## [0.9.39b11] - 2026-08-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.9.39b11"
+version = "0.10.0b1"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.9.39b11"
+version = "0.10.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- bump the project and lockfile self-version from `0.9.39b11` to `0.10.0b1`
- add the dated `0.10.0b1` Keep a Changelog entry for the public transport-capability injection API merged in #276
- describe terminal lifecycle behavior as closing capabilities, matching the `TerminalTransport` drain-or-interrupt contract without overclaiming
- add the `0.10.0b1` compare-link definition and advance the `Unreleased` comparison base
- keep the release-preparation diff limited to `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`

## Why

PR #276 closed #275 by adding a public `TransportFactory` injection seam for matched inverter and MID-device configurations. The API lets callers retain exclusive ownership of raw transports behind a `TerminalInverterTransport` capability while pylxpweb manages public connection, attachment, terminal cleanup, cancellation, and replacement behavior. This PR prepares the first beta on the 0.10 line that carries that public API.

The release note now uses “terminally closes” because `TerminalTransport.async_shutdown()` permits an implementation to drain or interrupt in-flight work; the broader close wording matches both permitted implementations. The changelog also uses bracketed version headings backed by compare-link definitions at the file footer, so the release entry now defines `v0.9.39b11...v0.10.0b1` and `Unreleased` starts from `v0.10.0b1`.

## User impact

Consumers can install the eventual `0.10.0b1` release to use the public transport-capability injection seam without private transport or lock-field access. Existing config-only `attach_local_transports(configs)` calls and `AttachResult` behavior remain compatible.

## Validation

- [x] `uv lock --check` — resolved 70 packages with no lockfile changes
- [x] `uv sync --all-extras --frozen` — installed pylxpweb `0.10.0b1`
- [x] version consistency script — `pyproject.toml`, `uv.lock`, and installed metadata all report `0.10.0b1`
- [x] changelog footer check — `0.10.0b1` resolves to `v0.9.39b11...v0.10.0b1`; `Unreleased` resolves to `v0.10.0b1...HEAD`
- [x] `uv run ruff check src/ tests/` — passed
- [x] `uv run ruff format --check src/ tests/` — 218 files already formatted
- [x] `uv run mypy --strict src/pylxpweb/` — passed for 94 source files
- [x] focused transport tests — 76 passed
- [x] full unit suite with coverage — 3,206 passed, 89.11% coverage
- [x] `uv build` — wheel and sdist built successfully
- [x] `uv run twine check dist/*` — both distributions passed
- [x] wheel `METADATA` and sdist `PKG-INFO` — both report `Version: 0.10.0b1`
- [x] `git diff --check` — passed

No tests were added or changed, so mutation testing is not applicable.

## Release safety

- [x] confirmed immediately before committing that no `0.10.0b1` tag, GitHub release, or PyPI release exists
- [x] confirmed `release.yml` is triggered only by a published GitHub release or manual dispatch, not by a normal PR merge
- [x] no tag or GitHub release created
- [x] no TestPyPI/PyPI upload performed
- [x] no release workflow manually triggered
- [x] no source, test, or workflow files changed

Closes #277

## Tribunal

### Round 1 — findings

- Blocking Codex `gpt-5.6-sol`: FINDINGS (4 evidence gaps).
- Blocking Claude `claude-opus-4-8`: FINDINGS (changelog accuracy/link convention plus evidence gaps).
- Advisory seat: unseated.
- Outcome: corrected lifecycle wording and added required compare links; attached commit/PR/build/scope/publication evidence.

### Round 2 — partial convergence

- Blocking Codex `gpt-5.6-sol`: CLEAN on `e4d5c28f`.
- Blocking Claude `claude-opus-4-8`: FINDING (verify `v0.9.39b11` compare-base tag).
- Advisory seat: unseated.

### Round 3 — CLEAN

- Blocking Claude `claude-opus-4-8`: CLEAN on `e4d5c28f` after primary tag/release evidence.
- Blocking Codex CLEAN from round 2 remains current because the artifact bytes did not change.
- Advisory seat: unseated.
- Tribunal result: dual blocking-engine CLEAN on `e4d5c28f`.
