### PR TITLE
Expose terminal raw-register observations

### DIFF
--- a/src/pylxpweb/transports/__init__.py
+++ b/src/pylxpweb/transports/__init__.py
@@ -91,6 +91,7 @@ from .http import HTTPTransport
 from .hybrid import HybridTransport
 from .modbus import ModbusTransport
 from .modbus_serial import ModbusSerialTransport
+from .observation import RegisterObservation, RegisterObserver, RegisterSegment, RegisterSpace
 from .protocol import (
     BaseTransport,
     InverterTransport,
@@ -135,6 +136,11 @@ __all__ = [
     "TerminalInverterTransport",
     "TerminalTransport",
     "BaseTransport",
+    # Raw-register observation API
+    "RegisterObservation",
+    "RegisterObserver",
+    "RegisterSegment",
+    "RegisterSpace",
     # Transport implementations
     "HTTPTransport",
     "ModbusTransport",

--- a/src/pylxpweb/transports/_modbus_base.py
+++ b/src/pylxpweb/transports/_modbus_base.py
@@ -34,6 +34,7 @@ from .exceptions import (
     TransportTimeoutError,
     TransportWriteError,
 )
+from .observation import RegisterObserver, RegisterSegment
 from .protocol import BaseTransport
 
 if TYPE_CHECKING:
@@ -74,6 +75,7 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
         inter_register_delay: float = 0.05,
         pymodbus_retries: int = 3,
         max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
+        register_observer: RegisterObserver | None = None,
     ) -> None:
         """Initialize base Modbus transport.
 
@@ -96,8 +98,9 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
                 groups into fewer reads for faster polling; hardware that
                 rejects large reads automatically falls back to the plain
                 grouped reads (eg4_web_monitor#254).
+            register_observer: Optional callback for terminal raw-register segments.
         """
-        super().__init__(serial)
+        super().__init__(serial, register_observer=register_observer)
         self._unit_id = unit_id
         self._timeout = timeout
         self._inverter_family = inverter_family
@@ -421,6 +424,7 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
     async def _read_register_groups(
         self,
         group_names: list[str] | None = None,
+        segments: list[RegisterSegment] | None = None,
     ) -> dict[int, int]:
         """Read register groups with adaptive delay and auto-reconnect.
 
@@ -432,7 +436,7 @@ class BaseModbusTransport(RegisterDataMixin, BaseTransport):
         if self._consecutive_errors >= self._max_consecutive_errors:
             await self._reconnect()
 
-        return await super()._read_register_groups(group_names)
+        return await super()._read_register_groups(group_names, segments)
 
     # ------------------------------------------------------------------
     # Overrides: combined read + read_battery with reconnect check

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Coroutine, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -236,6 +236,22 @@ def _append_observed_segment(
     retained.append(new_segment)
     retained.sort(key=lambda segment: segment.start_address)
     segments[:] = retained
+
+
+def _capture_register_reads(
+    reader: Callable[[int, int], Coroutine[None, None, list[int]]],
+    segments: list[RegisterSegment] | None,
+) -> Callable[[int, int], Coroutine[None, None, list[int]]]:
+    """Wrap a register reader only when observation capture is enabled."""
+    if segments is None:
+        return reader
+
+    async def observed_reader(start: int, count: int) -> list[int]:
+        values = await reader(start, count)
+        _append_observed_segment(segments, start, values)
+        return values
+
+    return observed_reader
 
 
 def coalesce_register_groups(
@@ -1764,16 +1780,8 @@ class RegisterDataMixin(_DataMixinBase):
     async def read_serial_number(self) -> str:
         """Read inverter serial number from input registers 115-119."""
         segments = self._new_observed_segments()
-
-        if segments is None:
-            return await read_serial_number_async(self._read_input_registers, self._serial)
-
-        async def read_input(start: int, count: int) -> list[int]:
-            values = await self._read_input_registers(start, count)
-            _append_observed_segment(segments, start, values)
-            return values
-
-        result = await read_serial_number_async(read_input, self._serial)
+        reader = _capture_register_reads(self._read_input_registers, segments)
+        result = await read_serial_number_async(reader, self._serial)
         if segments:
             await self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
@@ -1781,16 +1789,8 @@ class RegisterDataMixin(_DataMixinBase):
     async def read_firmware_version(self) -> str:
         """Read firmware version from holding registers 7-10."""
         segments = self._new_observed_segments()
-
-        if segments is None:
-            return await read_firmware_version_async(self._read_holding_registers)
-
-        async def read_holding(start: int, count: int) -> list[int]:
-            values = await self._read_holding_registers(start, count)
-            _append_observed_segment(segments, start, values)
-            return values
-
-        result = await read_firmware_version_async(read_holding)
+        reader = _capture_register_reads(self._read_holding_registers, segments)
+        result = await read_firmware_version_async(reader)
         if segments:
             await self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
@@ -1798,16 +1798,8 @@ class RegisterDataMixin(_DataMixinBase):
     async def read_device_type(self) -> int:
         """Read device type code from holding register 19."""
         segments = self._new_observed_segments()
-
-        if segments is None:
-            return await read_device_type_async(self._read_holding_registers)
-
-        async def read_holding(start: int, count: int) -> list[int]:
-            values = await self._read_holding_registers(start, count)
-            _append_observed_segment(segments, start, values)
-            return values
-
-        result = await read_device_type_async(read_holding)
+        reader = _capture_register_reads(self._read_holding_registers, segments)
+        result = await read_device_type_async(reader)
         if segments:
             await self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
@@ -1819,16 +1811,8 @@ class RegisterDataMixin(_DataMixinBase):
     async def read_parallel_config(self) -> int:
         """Read parallel configuration from input register 113."""
         segments = self._new_observed_segments()
-
-        if segments is None:
-            return await read_parallel_config_async(self._read_input_registers, self._serial)
-
-        async def read_input(start: int, count: int) -> list[int]:
-            values = await self._read_input_registers(start, count)
-            _append_observed_segment(segments, start, values)
-            return values
-
-        result = await read_parallel_config_async(read_input, self._serial)
+        reader = _capture_register_reads(self._read_input_registers, segments)
+        result = await read_parallel_config_async(reader, self._serial)
         if segments:
             await self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -300,7 +300,7 @@ if TYPE_CHECKING:
 
         async def _write_holding_registers(self, start: int, values: list[int]) -> bool: ...
 
-        def _notify_register_observer(
+        async def _notify_register_observer(
             self,
             observations: tuple[RegisterObservation, ...],
         ) -> None: ...
@@ -363,7 +363,7 @@ class RegisterDataMixin(_DataMixinBase):
             return " (shared-battery secondary — reg96=0 expected)"
         return ""
 
-    def _notify_observed_segments(
+    async def _notify_observed_segments(
         self,
         *observed: tuple[RegisterSpace, Sequence[RegisterSegment] | None],
     ) -> None:
@@ -373,7 +373,7 @@ class RegisterDataMixin(_DataMixinBase):
         observations = tuple(
             RegisterObservation(space, tuple(segments)) for space, segments in observed if segments
         )
-        self._notify_register_observer(observations)
+        await self._notify_register_observer(observations)
 
     def _new_observed_segments(self) -> list[RegisterSegment] | None:
         """Allocate capture state only when an observer was configured."""
@@ -1269,7 +1269,7 @@ class RegisterDataMixin(_DataMixinBase):
         if segments is not None:
             _append_observed_segment(segments, 210, values)
         if segments:
-            self._notify_observed_segments((RegisterSpace.INPUT, segments))
+            await self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return seconds if seconds > 0 else None
 
     # ------------------------------------------------------------------
@@ -1296,7 +1296,7 @@ class RegisterDataMixin(_DataMixinBase):
             pv_string_count=self._pv_string_count,
         )
         if segments:
-            self._notify_observed_segments((RegisterSpace.INPUT, segments))
+            await self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def read_energy(self) -> InverterEnergyData:
@@ -1335,7 +1335,7 @@ class RegisterDataMixin(_DataMixinBase):
             pv_string_count=self._pv_string_count,
         )
         if segments:
-            self._notify_observed_segments((RegisterSpace.INPUT, segments))
+            await self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def read_battery(
@@ -1450,7 +1450,7 @@ class RegisterDataMixin(_DataMixinBase):
             )
 
         if segments:
-            self._notify_observed_segments((RegisterSpace.INPUT, segments))
+            await self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def _read_all_input_groups(
@@ -1572,7 +1572,7 @@ class RegisterDataMixin(_DataMixinBase):
         # genuine reg 96 = 0 is unaffected and still builds a bank.
         if not bms_ok:
             if winning_segments:
-                self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
+                await self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
             return runtime, energy, None
 
         # Read individual battery registers (5000+) if present
@@ -1611,7 +1611,7 @@ class RegisterDataMixin(_DataMixinBase):
         self._stamp_battery_last_seen(battery)
 
         if winning_segments:
-            self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
+            await self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
         return runtime, energy, battery
 
     async def read_midbox_runtime(self) -> MidboxRuntimeData:
@@ -1664,7 +1664,7 @@ class RegisterDataMixin(_DataMixinBase):
             input_registers, smart_port_mode_reg=smart_port_mode_reg
         )
         if input_segments:
-            self._notify_observed_segments(
+            await self._notify_observed_segments(
                 (RegisterSpace.INPUT, input_segments),
                 (RegisterSpace.HOLDING, holding_segments),
             )
@@ -1706,7 +1706,7 @@ class RegisterDataMixin(_DataMixinBase):
             self._last_hold_110 = result[110]
 
         if segments:
-            self._notify_observed_segments((RegisterSpace.HOLDING, segments))
+            await self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
 
     async def write_parameters(
@@ -1775,7 +1775,7 @@ class RegisterDataMixin(_DataMixinBase):
 
         result = await read_serial_number_async(read_input, self._serial)
         if segments:
-            self._notify_observed_segments((RegisterSpace.INPUT, segments))
+            await self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def read_firmware_version(self) -> str:
@@ -1792,7 +1792,7 @@ class RegisterDataMixin(_DataMixinBase):
 
         result = await read_firmware_version_async(read_holding)
         if segments:
-            self._notify_observed_segments((RegisterSpace.HOLDING, segments))
+            await self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
 
     async def read_device_type(self) -> int:
@@ -1809,7 +1809,7 @@ class RegisterDataMixin(_DataMixinBase):
 
         result = await read_device_type_async(read_holding)
         if segments:
-            self._notify_observed_segments((RegisterSpace.HOLDING, segments))
+            await self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
 
     def is_midbox_device(self, device_type_code: int) -> bool:
@@ -1830,7 +1830,7 @@ class RegisterDataMixin(_DataMixinBase):
 
         result = await read_parallel_config_async(read_input, self._serial)
         if segments:
-            self._notify_observed_segments((RegisterSpace.INPUT, segments))
+            await self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def validate_serial(self, expected_serial: str) -> bool:

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -210,6 +210,16 @@ def _append_observed_segment(
     if not values:
         return
 
+    new_segment = RegisterSegment(start, tuple(values))
+    if not segments:
+        segments.append(new_segment)
+        return
+
+    last_segment = segments[-1]
+    if start >= last_segment.start_address + len(last_segment.words):
+        segments.append(new_segment)
+        return
+
     end = start + len(values)
     retained: list[RegisterSegment] = []
     for segment in segments:
@@ -223,7 +233,7 @@ def _append_observed_segment(
         if segment_end > end:
             retained.append(RegisterSegment(end, segment.words[end - segment_start :]))
 
-    retained.append(RegisterSegment(start, tuple(values)))
+    retained.append(new_segment)
     retained.sort(key=lambda segment: segment.start_address)
     segments[:] = retained
 
@@ -282,6 +292,9 @@ if TYPE_CHECKING:
         _pv_string_count: int
         _max_input_block_size: int
         _input_coalescing_latched_off: bool
+
+        @property
+        def _register_observer_enabled(self) -> bool: ...
 
         async def _read_input_registers(self, start: int, count: int) -> list[int]: ...
 
@@ -354,13 +367,19 @@ class RegisterDataMixin(_DataMixinBase):
 
     def _notify_observed_segments(
         self,
-        *observed: tuple[RegisterSpace, Sequence[RegisterSegment]],
+        *observed: tuple[RegisterSpace, Sequence[RegisterSegment] | None],
     ) -> None:
         """Publish one method-level callback containing each non-empty space."""
+        if not self._register_observer_enabled:
+            return
         observations = tuple(
             RegisterObservation(space, tuple(segments)) for space, segments in observed if segments
         )
         self._notify_register_observer(observations)
+
+    def _new_observed_segments(self) -> list[RegisterSegment] | None:
+        """Allocate capture state only when an observer was configured."""
+        return [] if self._register_observer_enabled else None
 
     async def _read_individual_battery_registers(
         self,
@@ -1109,7 +1128,7 @@ class RegisterDataMixin(_DataMixinBase):
         """
         groups = self._resolve_input_groups(group_names)
         try:
-            winning_segments: list[RegisterSegment] = []
+            winning_segments: list[RegisterSegment] | None = [] if segments is not None else None
             registers = await self._read_group_plan(
                 self._plan_input_reads(groups), winning_segments
             )
@@ -1118,12 +1137,16 @@ class RegisterDataMixin(_DataMixinBase):
             # or it was a misrouted frame that intentionally did not (#320).
             # Re-read with an explicit plain plan so the retry is one
             # read/group regardless of whether the latch fired.
-            winning_segments = []
+            winning_segments = [] if segments is not None else None
             registers = await self._read_group_plan(
                 self._plain_input_plan(groups), winning_segments
             )
-        if segments is not None:
-            segments.extend(winning_segments)
+        if segments is not None and winning_segments is not None:
+            if not segments:
+                segments.extend(winning_segments)
+            else:
+                for segment in winning_segments:
+                    _append_observed_segment(segments, segment.start_address, segment.words)
         return registers
 
     async def _read_group_plan(
@@ -1244,9 +1267,11 @@ class RegisterDataMixin(_DataMixinBase):
             )
             return None
         seconds = int(values[0]) if values else 0
-        segments: list[RegisterSegment] = []
-        _append_observed_segment(segments, 210, values)
-        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        segments = self._new_observed_segments()
+        if segments is not None:
+            _append_observed_segment(segments, 210, values)
+        if segments:
+            self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return seconds if seconds > 0 else None
 
     # ------------------------------------------------------------------
@@ -1262,7 +1287,7 @@ class RegisterDataMixin(_DataMixinBase):
         Raises:
             TransportReadError: If read operation fails.
         """
-        segments: list[RegisterSegment] = []
+        segments = self._new_observed_segments()
         input_registers = await self._read_register_groups(segments=segments)
         input_registers.update(await self._read_pv4_6_registers(segments))
         family = self._inverter_family.value if self._inverter_family else "EG4_HYBRID"
@@ -1272,7 +1297,8 @@ class RegisterDataMixin(_DataMixinBase):
             split_phase=self._split_phase,
             pv_string_count=self._pv_string_count,
         )
-        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        if segments:
+            self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def read_energy(self) -> InverterEnergyData:
@@ -1284,7 +1310,7 @@ class RegisterDataMixin(_DataMixinBase):
         Raises:
             TransportReadError: If read operation fails.
         """
-        segments: list[RegisterSegment] = []
+        segments = self._new_observed_segments()
         input_registers = await self._read_register_groups(
             ["power_energy", "status_energy", "output_power"], segments
         )
@@ -1310,7 +1336,8 @@ class RegisterDataMixin(_DataMixinBase):
             family,
             pv_string_count=self._pv_string_count,
         )
-        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        if segments:
+            self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def read_battery(
@@ -1330,14 +1357,15 @@ class RegisterDataMixin(_DataMixinBase):
             TransportReadError: If read operation fails.
         """
         all_registers: dict[int, int] = {}
-        segments: list[RegisterSegment] = []
+        segments = self._new_observed_segments()
 
         # Read core battery registers (power + BMS).
         # Registers 0-31 contain power/voltage/SOC; 80-112 contain BMS data.
         try:
             power_regs = await self._read_input_registers(0, 32)
             all_registers.update(self._registers_from_values(0, power_regs))
-            _append_observed_segment(segments, 0, power_regs)
+            if segments is not None:
+                _append_observed_segment(segments, 0, power_regs)
         except Exception as e:
             _LOGGER.warning("Failed to read power registers 0-31: %s", e)
 
@@ -1355,7 +1383,8 @@ class RegisterDataMixin(_DataMixinBase):
                 bms_ok = False
             else:
                 all_registers.update(self._registers_from_values(80, bms_regs))
-                _append_observed_segment(segments, 80, bms_regs)
+                if segments is not None:
+                    _append_observed_segment(segments, 80, bms_regs)
         except Exception as e:
             _LOGGER.warning("Failed to read BMS registers 80-112: %s", e)
             bms_ok = False
@@ -1422,7 +1451,8 @@ class RegisterDataMixin(_DataMixinBase):
                 battery_count,
             )
 
-        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        if segments:
+            self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def _read_all_input_groups(
@@ -1498,8 +1528,8 @@ class RegisterDataMixin(_DataMixinBase):
             Tuple of (runtime_data, energy_data, battery_data_or_none).
         """
         groups = self._resolve_input_groups(None)
+        winning_segments = self._new_observed_segments()
         try:
-            winning_segments: list[RegisterSegment] = []
             input_registers, bms_ok = await self._read_all_input_groups(
                 self._plan_input_reads(groups), winning_segments
             )
@@ -1509,7 +1539,7 @@ class RegisterDataMixin(_DataMixinBase):
             # an explicit plain plan (one read/group) so the retry never
             # coalesces again, restoring the exact per-group (bms non-fatal)
             # semantics regardless of whether the latch fired.
-            winning_segments = []
+            winning_segments = self._new_observed_segments()
             input_registers, bms_ok = await self._read_all_input_groups(
                 self._plain_input_plan(groups), winning_segments
             )
@@ -1543,7 +1573,8 @@ class RegisterDataMixin(_DataMixinBase):
         # runtime + energy still update.  A SUCCESSFUL bms_data read with a
         # genuine reg 96 = 0 is unaffected and still builds a bank.
         if not bms_ok:
-            self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
+            if winning_segments:
+                self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
             return runtime, energy, None
 
         # Read individual battery registers (5000+) if present
@@ -1581,7 +1612,8 @@ class RegisterDataMixin(_DataMixinBase):
         )
         self._stamp_battery_last_seen(battery)
 
-        self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
+        if winning_segments:
+            self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
         return runtime, energy, battery
 
     async def read_midbox_runtime(self) -> MidboxRuntimeData:
@@ -1594,13 +1626,14 @@ class RegisterDataMixin(_DataMixinBase):
             TransportReadError: If read operation fails.
         """
         input_registers: dict[int, int] = {}
-        input_segments: list[RegisterSegment] = []
+        input_segments = self._new_observed_segments()
 
         try:
             for i, (start, count) in enumerate(MIDBOX_REGISTER_GROUPS):
                 values = await self._read_input_registers(start, count)
                 input_registers.update(self._registers_from_values(start, values))
-                _append_observed_segment(input_segments, start, values)
+                if input_segments is not None:
+                    _append_observed_segment(input_segments, start, values)
 
                 if i < len(MIDBOX_REGISTER_GROUPS) - 1:
                     await asyncio.sleep(self._inter_register_delay)
@@ -1620,21 +1653,23 @@ class RegisterDataMixin(_DataMixinBase):
         # WiFi dongles need time between function code changes to avoid corrupt reads.
         await asyncio.sleep(self._inter_register_delay)
         smart_port_mode_reg: int | None = None
-        holding_segments: list[RegisterSegment] = []
+        holding_segments = self._new_observed_segments()
         try:
             holding_vals = await self._read_holding_registers(20, 1)
             smart_port_mode_reg = holding_vals[0]
-            _append_observed_segment(holding_segments, 20, holding_vals)
+            if holding_segments is not None:
+                _append_observed_segment(holding_segments, 20, holding_vals)
         except Exception:
             _LOGGER.debug("Failed to read smart port mode register 20")
 
         result = MidboxRuntimeData.from_modbus_registers(
             input_registers, smart_port_mode_reg=smart_port_mode_reg
         )
-        self._notify_observed_segments(
-            (RegisterSpace.INPUT, input_segments),
-            (RegisterSpace.HOLDING, holding_segments),
-        )
+        if input_segments:
+            self._notify_observed_segments(
+                (RegisterSpace.INPUT, input_segments),
+                (RegisterSpace.HOLDING, holding_segments),
+            )
         return result
 
     async def read_parameters(
@@ -1655,7 +1690,7 @@ class RegisterDataMixin(_DataMixinBase):
             TransportReadError: If read operation fails.
         """
         result: dict[int, int] = {}
-        segments: list[RegisterSegment] = []
+        segments = self._new_observed_segments()
         remaining = count
         current_address = start_address
 
@@ -1663,7 +1698,8 @@ class RegisterDataMixin(_DataMixinBase):
             chunk_size = min(remaining, 40)
             values = await self._read_holding_registers(current_address, chunk_size)
             result.update(self._registers_from_values(current_address, values))
-            _append_observed_segment(segments, current_address, values)
+            if segments is not None:
+                _append_observed_segment(segments, current_address, values)
             current_address += chunk_size
             remaining -= chunk_size
 
@@ -1671,7 +1707,8 @@ class RegisterDataMixin(_DataMixinBase):
         if 110 in result:
             self._last_hold_110 = result[110]
 
-        self._notify_observed_segments((RegisterSpace.HOLDING, segments))
+        if segments:
+            self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
 
     async def write_parameters(
@@ -1728,7 +1765,10 @@ class RegisterDataMixin(_DataMixinBase):
 
     async def read_serial_number(self) -> str:
         """Read inverter serial number from input registers 115-119."""
-        segments: list[RegisterSegment] = []
+        segments = self._new_observed_segments()
+
+        if segments is None:
+            return await read_serial_number_async(self._read_input_registers, self._serial)
 
         async def read_input(start: int, count: int) -> list[int]:
             values = await self._read_input_registers(start, count)
@@ -1736,12 +1776,16 @@ class RegisterDataMixin(_DataMixinBase):
             return values
 
         result = await read_serial_number_async(read_input, self._serial)
-        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        if segments:
+            self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def read_firmware_version(self) -> str:
         """Read firmware version from holding registers 7-10."""
-        segments: list[RegisterSegment] = []
+        segments = self._new_observed_segments()
+
+        if segments is None:
+            return await read_firmware_version_async(self._read_holding_registers)
 
         async def read_holding(start: int, count: int) -> list[int]:
             values = await self._read_holding_registers(start, count)
@@ -1749,12 +1793,16 @@ class RegisterDataMixin(_DataMixinBase):
             return values
 
         result = await read_firmware_version_async(read_holding)
-        self._notify_observed_segments((RegisterSpace.HOLDING, segments))
+        if segments:
+            self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
 
     async def read_device_type(self) -> int:
         """Read device type code from holding register 19."""
-        segments: list[RegisterSegment] = []
+        segments = self._new_observed_segments()
+
+        if segments is None:
+            return await read_device_type_async(self._read_holding_registers)
 
         async def read_holding(start: int, count: int) -> list[int]:
             values = await self._read_holding_registers(start, count)
@@ -1762,7 +1810,8 @@ class RegisterDataMixin(_DataMixinBase):
             return values
 
         result = await read_device_type_async(read_holding)
-        self._notify_observed_segments((RegisterSpace.HOLDING, segments))
+        if segments:
+            self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
 
     def is_midbox_device(self, device_type_code: int) -> bool:
@@ -1771,7 +1820,10 @@ class RegisterDataMixin(_DataMixinBase):
 
     async def read_parallel_config(self) -> int:
         """Read parallel configuration from input register 113."""
-        segments: list[RegisterSegment] = []
+        segments = self._new_observed_segments()
+
+        if segments is None:
+            return await read_parallel_config_async(self._read_input_registers, self._serial)
 
         async def read_input(start: int, count: int) -> list[int]:
             values = await self._read_input_registers(start, count)
@@ -1779,7 +1831,8 @@ class RegisterDataMixin(_DataMixinBase):
             return values
 
         result = await read_parallel_config_async(read_input, self._serial)
-        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        if segments:
+            self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def validate_serial(self, expected_serial: str) -> bool:

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -52,7 +52,7 @@ from .exceptions import (
     TransportResponseMismatchError,
     TransportTimeoutError,
 )
-from .observation import RegisterObservation, RegisterSegment, RegisterSpace
+from .observation import RegisterObservation, RegisterObserver, RegisterSegment, RegisterSpace
 
 if TYPE_CHECKING:
     from pylxpweb.devices.inverters._features import InverterFamily
@@ -292,9 +292,7 @@ if TYPE_CHECKING:
         _pv_string_count: int
         _max_input_block_size: int
         _input_coalescing_latched_off: bool
-
-        @property
-        def _register_observer_enabled(self) -> bool: ...
+        _register_observer: RegisterObserver | None
 
         async def _read_input_registers(self, start: int, count: int) -> list[int]: ...
 
@@ -370,7 +368,7 @@ class RegisterDataMixin(_DataMixinBase):
         *observed: tuple[RegisterSpace, Sequence[RegisterSegment] | None],
     ) -> None:
         """Publish one method-level callback containing each non-empty space."""
-        if not self._register_observer_enabled:
+        if self._register_observer is None:
             return
         observations = tuple(
             RegisterObservation(space, tuple(segments)) for space, segments in observed if segments
@@ -379,7 +377,7 @@ class RegisterDataMixin(_DataMixinBase):
 
     def _new_observed_segments(self) -> list[RegisterSegment] | None:
         """Allocate capture state only when an observer was configured."""
-        return [] if self._register_observer_enabled else None
+        return [] if self._register_observer is not None else None
 
     async def _read_individual_battery_registers(
         self,

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -52,6 +52,7 @@ from .exceptions import (
     TransportResponseMismatchError,
     TransportTimeoutError,
 )
+from .observation import RegisterObservation, RegisterSegment, RegisterSpace
 
 if TYPE_CHECKING:
     from pylxpweb.devices.inverters._features import InverterFamily
@@ -200,6 +201,33 @@ class _CoalescedReadFallback(Exception):
     """Internal: a coalesced block read failed; retry with plain group reads."""
 
 
+def _append_observed_segment(
+    segments: list[RegisterSegment],
+    start: int,
+    values: Sequence[int],
+) -> None:
+    """Merge a terminal segment, making later overlapping reads authoritative."""
+    if not values:
+        return
+
+    end = start + len(values)
+    retained: list[RegisterSegment] = []
+    for segment in segments:
+        segment_start = segment.start_address
+        segment_end = segment_start + len(segment.words)
+        if segment_end <= start or segment_start >= end:
+            retained.append(segment)
+            continue
+        if segment_start < start:
+            retained.append(RegisterSegment(segment_start, segment.words[: start - segment_start]))
+        if segment_end > end:
+            retained.append(RegisterSegment(end, segment.words[end - segment_start :]))
+
+    retained.append(RegisterSegment(start, tuple(values)))
+    retained.sort(key=lambda segment: segment.start_address)
+    segments[:] = retained
+
+
 def coalesce_register_groups(
     groups: Sequence[tuple[str, tuple[int, int]]],
     max_block_size: int,
@@ -261,6 +289,11 @@ if TYPE_CHECKING:
 
         async def _write_holding_registers(self, start: int, values: list[int]) -> bool: ...
 
+        def _notify_register_observer(
+            self,
+            observations: tuple[RegisterObservation, ...],
+        ) -> None: ...
+
 else:
     _DataMixinBase = object
 
@@ -319,9 +352,20 @@ class RegisterDataMixin(_DataMixinBase):
             return " (shared-battery secondary — reg96=0 expected)"
         return ""
 
+    def _notify_observed_segments(
+        self,
+        *observed: tuple[RegisterSpace, Sequence[RegisterSegment]],
+    ) -> None:
+        """Publish one method-level callback containing each non-empty space."""
+        observations = tuple(
+            RegisterObservation(space, tuple(segments)) for space, segments in observed if segments
+        )
+        self._notify_register_observer(observations)
+
     async def _read_individual_battery_registers(
         self,
         battery_count: int,
+        segments: list[RegisterSegment] | None = None,
     ) -> dict[int, int] | None:
         """Read battery slots atomically and accumulate across round-robin cycles.
 
@@ -401,6 +445,8 @@ class RegisterDataMixin(_DataMixinBase):
             )
             return cached
 
+        if segments is not None:
+            _append_observed_segment(segments, BATTERY_BASE_ADDRESS, values)
         raw_registers = self._registers_from_values(BATTERY_BASE_ADDRESS, values)
 
         # --- Serial-keyed round-robin accumulation (#170, #258) ---
@@ -796,7 +842,10 @@ class RegisterDataMixin(_DataMixinBase):
                 reserved_24,
             )
 
-    async def _read_battery_header_registers(self) -> None:
+    async def _read_battery_header_registers(
+        self,
+        segments: list[RegisterSegment] | None = None,
+    ) -> None:
         """Read registers 5000-5001 for round-robin rotation debugging (#165).
 
         These two registers sit before the per-battery blocks at 5002+.
@@ -809,6 +858,8 @@ class RegisterDataMixin(_DataMixinBase):
         """
         try:
             values = await self._read_input_registers(5000, 2)
+            if segments is not None:
+                _append_observed_segment(segments, 5000, values)
             self._battery_header_registers: dict[int, int] = {
                 5000: values[0],
                 5001: values[1],
@@ -1034,6 +1085,7 @@ class RegisterDataMixin(_DataMixinBase):
     async def _read_register_groups(
         self,
         group_names: list[str] | None = None,
+        segments: list[RegisterSegment] | None = None,
     ) -> dict[int, int]:
         """Read multiple register groups sequentially with inter-group delays.
 
@@ -1057,15 +1109,28 @@ class RegisterDataMixin(_DataMixinBase):
         """
         groups = self._resolve_input_groups(group_names)
         try:
-            return await self._read_group_plan(self._plan_input_reads(groups))
+            winning_segments: list[RegisterSegment] = []
+            registers = await self._read_group_plan(
+                self._plan_input_reads(groups), winning_segments
+            )
         except _CoalescedReadFallback:
             # A coalesced block fell back — either it latched coalescing off,
             # or it was a misrouted frame that intentionally did not (#320).
             # Re-read with an explicit plain plan so the retry is one
             # read/group regardless of whether the latch fired.
-            return await self._read_group_plan(self._plain_input_plan(groups))
+            winning_segments = []
+            registers = await self._read_group_plan(
+                self._plain_input_plan(groups), winning_segments
+            )
+        if segments is not None:
+            segments.extend(winning_segments)
+        return registers
 
-    async def _read_group_plan(self, plan: list[_ReadBlock]) -> dict[int, int]:
+    async def _read_group_plan(
+        self,
+        plan: list[_ReadBlock],
+        segments: list[RegisterSegment] | None = None,
+    ) -> dict[int, int]:
         """Execute a read plan sequentially with inter-read delays.
 
         The adaptive-delay backoff only applies to transports that track
@@ -1097,6 +1162,8 @@ class RegisterDataMixin(_DataMixinBase):
 
             for offset, value in enumerate(values):
                 registers[block.start + offset] = value
+            if segments is not None:
+                _append_observed_segment(segments, block.start, values)
 
             # Increase delay when retries occurred to give the device breathing room
             if getattr(self, "_last_read_retried", False):
@@ -1111,7 +1178,10 @@ class RegisterDataMixin(_DataMixinBase):
 
         return registers
 
-    async def _read_pv4_6_registers(self) -> dict[int, int]:
+    async def _read_pv4_6_registers(
+        self,
+        segments: list[RegisterSegment] | None = None,
+    ) -> dict[int, int]:
         """Read the V23-extended PV4-6 input registers if applicable.
 
         Covers both the voltage/power group (217-222) and the daily/lifetime
@@ -1146,6 +1216,8 @@ class RegisterDataMixin(_DataMixinBase):
                 )
                 continue
             registers.update(self._registers_from_values(start, values))
+            if segments is not None:
+                _append_observed_segment(segments, start, values)
         return registers
 
     async def read_quick_charge_remaining_seconds(self) -> int | None:
@@ -1172,6 +1244,9 @@ class RegisterDataMixin(_DataMixinBase):
             )
             return None
         seconds = int(values[0]) if values else 0
+        segments: list[RegisterSegment] = []
+        _append_observed_segment(segments, 210, values)
+        self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return seconds if seconds > 0 else None
 
     # ------------------------------------------------------------------
@@ -1187,15 +1262,18 @@ class RegisterDataMixin(_DataMixinBase):
         Raises:
             TransportReadError: If read operation fails.
         """
-        input_registers = await self._read_register_groups()
-        input_registers.update(await self._read_pv4_6_registers())
+        segments: list[RegisterSegment] = []
+        input_registers = await self._read_register_groups(segments=segments)
+        input_registers.update(await self._read_pv4_6_registers(segments))
         family = self._inverter_family.value if self._inverter_family else "EG4_HYBRID"
-        return InverterRuntimeData.from_modbus_registers(
+        result = InverterRuntimeData.from_modbus_registers(
             input_registers,
             family,
             split_phase=self._split_phase,
             pv_string_count=self._pv_string_count,
         )
+        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        return result
 
     async def read_energy(self) -> InverterEnergyData:
         """Read energy statistics via input registers.
@@ -1206,14 +1284,15 @@ class RegisterDataMixin(_DataMixinBase):
         Raises:
             TransportReadError: If read operation fails.
         """
+        segments: list[RegisterSegment] = []
         input_registers = await self._read_register_groups(
-            ["power_energy", "status_energy", "output_power"]
+            ["power_energy", "status_energy", "output_power"], segments
         )
 
         # bms_data is supplementary — don't fail the entire energy read
         # if these registers time out
         try:
-            bms_registers = await self._read_register_groups(["bms_data"])
+            bms_registers = await self._read_register_groups(["bms_data"], segments)
             input_registers.update(bms_registers)
         except (TransportReadError, TransportTimeoutError):
             _LOGGER.debug(
@@ -1223,14 +1302,16 @@ class RegisterDataMixin(_DataMixinBase):
 
         # V23-extended PV4-6 energy registers (only read for models with >=4
         # strings); gated identically to the runtime path.
-        input_registers.update(await self._read_pv4_6_registers())
+        input_registers.update(await self._read_pv4_6_registers(segments))
 
         family = self._inverter_family.value if self._inverter_family else "EG4_HYBRID"
-        return InverterEnergyData.from_modbus_registers(
+        result = InverterEnergyData.from_modbus_registers(
             input_registers,
             family,
             pv_string_count=self._pv_string_count,
         )
+        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        return result
 
     async def read_battery(
         self,
@@ -1249,12 +1330,14 @@ class RegisterDataMixin(_DataMixinBase):
             TransportReadError: If read operation fails.
         """
         all_registers: dict[int, int] = {}
+        segments: list[RegisterSegment] = []
 
         # Read core battery registers (power + BMS).
         # Registers 0-31 contain power/voltage/SOC; 80-112 contain BMS data.
         try:
             power_regs = await self._read_input_registers(0, 32)
             all_registers.update(self._registers_from_values(0, power_regs))
+            _append_observed_segment(segments, 0, power_regs)
         except Exception as e:
             _LOGGER.warning("Failed to read power registers 0-31: %s", e)
 
@@ -1272,6 +1355,7 @@ class RegisterDataMixin(_DataMixinBase):
                 bms_ok = False
             else:
                 all_registers.update(self._registers_from_values(80, bms_regs))
+                _append_observed_segment(segments, 80, bms_regs)
         except Exception as e:
             _LOGGER.warning("Failed to read BMS registers 80-112: %s", e)
             bms_ok = False
@@ -1312,9 +1396,10 @@ class RegisterDataMixin(_DataMixinBase):
         if include_individual and (
             battery_count > 0 or getattr(self, "_battery_accumulator", None)
         ):
-            await self._read_battery_header_registers()
+            await self._read_battery_header_registers(segments)
             individual_registers = await self._read_individual_battery_registers(
                 battery_count,
+                segments,
             )
 
         if individual_registers:
@@ -1337,11 +1422,13 @@ class RegisterDataMixin(_DataMixinBase):
                 battery_count,
             )
 
+        self._notify_observed_segments((RegisterSpace.INPUT, segments))
         return result
 
     async def _read_all_input_groups(
         self,
         plan: list[_ReadBlock],
+        segments: list[RegisterSegment] | None = None,
     ) -> tuple[dict[int, int], bool]:
         """Execute the combined-read plan, tracking bms_data availability.
 
@@ -1378,6 +1465,8 @@ class RegisterDataMixin(_DataMixinBase):
                     continue
                 for offset, value in enumerate(values):
                     input_registers[block.start + offset] = value
+                if segments is not None:
+                    _append_observed_segment(segments, block.start, values)
             except _CoalescedReadFallback:
                 raise
             except Exception:
@@ -1410,8 +1499,9 @@ class RegisterDataMixin(_DataMixinBase):
         """
         groups = self._resolve_input_groups(None)
         try:
+            winning_segments: list[RegisterSegment] = []
             input_registers, bms_ok = await self._read_all_input_groups(
-                self._plan_input_reads(groups)
+                self._plan_input_reads(groups), winning_segments
             )
         except _CoalescedReadFallback:
             # A coalesced block fell back — either it latched coalescing off,
@@ -1419,12 +1509,13 @@ class RegisterDataMixin(_DataMixinBase):
             # an explicit plain plan (one read/group) so the retry never
             # coalesces again, restoring the exact per-group (bms non-fatal)
             # semantics regardless of whether the latch fired.
+            winning_segments = []
             input_registers, bms_ok = await self._read_all_input_groups(
-                self._plain_input_plan(groups)
+                self._plain_input_plan(groups), winning_segments
             )
 
         # V23-extended PV4-6 registers (only read for models with >=4 strings)
-        input_registers.update(await self._read_pv4_6_registers())
+        input_registers.update(await self._read_pv4_6_registers(winning_segments))
 
         family = self._inverter_family.value if self._inverter_family else "EG4_HYBRID"
 
@@ -1440,7 +1531,6 @@ class RegisterDataMixin(_DataMixinBase):
             family,
             pv_string_count=self._pv_string_count,
         )
-
         # The battery bank lives entirely in the bms_data group (reg 96 +
         # voltage/SOC/current/cell/BMS-limit fields).  If that group's read
         # dropped — common on a flaky dongle link, where single requests time
@@ -1453,6 +1543,7 @@ class RegisterDataMixin(_DataMixinBase):
         # runtime + energy still update.  A SUCCESSFUL bms_data read with a
         # genuine reg 96 = 0 is unaffected and still builds a bank.
         if not bms_ok:
+            self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
             return runtime, energy, None
 
         # Read individual battery registers (5000+) if present
@@ -1475,9 +1566,10 @@ class RegisterDataMixin(_DataMixinBase):
         # accumulated, read the block regardless of reg 96; a unit that never
         # accumulated anything (genuinely battery-less) still skips the read.
         if battery_count > 0 or getattr(self, "_battery_accumulator", None):
-            await self._read_battery_header_registers()
+            await self._read_battery_header_registers(winning_segments)
             individual_registers = await self._read_individual_battery_registers(
                 battery_count,
+                winning_segments,
             )
 
         if individual_registers:
@@ -1489,6 +1581,7 @@ class RegisterDataMixin(_DataMixinBase):
         )
         self._stamp_battery_last_seen(battery)
 
+        self._notify_observed_segments((RegisterSpace.INPUT, winning_segments))
         return runtime, energy, battery
 
     async def read_midbox_runtime(self) -> MidboxRuntimeData:
@@ -1501,11 +1594,13 @@ class RegisterDataMixin(_DataMixinBase):
             TransportReadError: If read operation fails.
         """
         input_registers: dict[int, int] = {}
+        input_segments: list[RegisterSegment] = []
 
         try:
             for i, (start, count) in enumerate(MIDBOX_REGISTER_GROUPS):
                 values = await self._read_input_registers(start, count)
                 input_registers.update(self._registers_from_values(start, values))
+                _append_observed_segment(input_segments, start, values)
 
                 if i < len(MIDBOX_REGISTER_GROUPS) - 1:
                     await asyncio.sleep(self._inter_register_delay)
@@ -1525,15 +1620,22 @@ class RegisterDataMixin(_DataMixinBase):
         # WiFi dongles need time between function code changes to avoid corrupt reads.
         await asyncio.sleep(self._inter_register_delay)
         smart_port_mode_reg: int | None = None
+        holding_segments: list[RegisterSegment] = []
         try:
             holding_vals = await self._read_holding_registers(20, 1)
             smart_port_mode_reg = holding_vals[0]
+            _append_observed_segment(holding_segments, 20, holding_vals)
         except Exception:
             _LOGGER.debug("Failed to read smart port mode register 20")
 
-        return MidboxRuntimeData.from_modbus_registers(
+        result = MidboxRuntimeData.from_modbus_registers(
             input_registers, smart_port_mode_reg=smart_port_mode_reg
         )
+        self._notify_observed_segments(
+            (RegisterSpace.INPUT, input_segments),
+            (RegisterSpace.HOLDING, holding_segments),
+        )
+        return result
 
     async def read_parameters(
         self,
@@ -1553,6 +1655,7 @@ class RegisterDataMixin(_DataMixinBase):
             TransportReadError: If read operation fails.
         """
         result: dict[int, int] = {}
+        segments: list[RegisterSegment] = []
         remaining = count
         current_address = start_address
 
@@ -1560,6 +1663,7 @@ class RegisterDataMixin(_DataMixinBase):
             chunk_size = min(remaining, 40)
             values = await self._read_holding_registers(current_address, chunk_size)
             result.update(self._registers_from_values(current_address, values))
+            _append_observed_segment(segments, current_address, values)
             current_address += chunk_size
             remaining -= chunk_size
 
@@ -1567,6 +1671,7 @@ class RegisterDataMixin(_DataMixinBase):
         if 110 in result:
             self._last_hold_110 = result[110]
 
+        self._notify_observed_segments((RegisterSpace.HOLDING, segments))
         return result
 
     async def write_parameters(
@@ -1623,15 +1728,42 @@ class RegisterDataMixin(_DataMixinBase):
 
     async def read_serial_number(self) -> str:
         """Read inverter serial number from input registers 115-119."""
-        return await read_serial_number_async(self._read_input_registers, self._serial)
+        segments: list[RegisterSegment] = []
+
+        async def read_input(start: int, count: int) -> list[int]:
+            values = await self._read_input_registers(start, count)
+            _append_observed_segment(segments, start, values)
+            return values
+
+        result = await read_serial_number_async(read_input, self._serial)
+        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        return result
 
     async def read_firmware_version(self) -> str:
         """Read firmware version from holding registers 7-10."""
-        return await read_firmware_version_async(self._read_holding_registers)
+        segments: list[RegisterSegment] = []
+
+        async def read_holding(start: int, count: int) -> list[int]:
+            values = await self._read_holding_registers(start, count)
+            _append_observed_segment(segments, start, values)
+            return values
+
+        result = await read_firmware_version_async(read_holding)
+        self._notify_observed_segments((RegisterSpace.HOLDING, segments))
+        return result
 
     async def read_device_type(self) -> int:
         """Read device type code from holding register 19."""
-        return await read_device_type_async(self._read_holding_registers)
+        segments: list[RegisterSegment] = []
+
+        async def read_holding(start: int, count: int) -> list[int]:
+            values = await self._read_holding_registers(start, count)
+            _append_observed_segment(segments, start, values)
+            return values
+
+        result = await read_device_type_async(read_holding)
+        self._notify_observed_segments((RegisterSpace.HOLDING, segments))
+        return result
 
     def is_midbox_device(self, device_type_code: int) -> bool:
         """Check if device type code indicates a MID/GridBOSS device."""
@@ -1639,7 +1771,16 @@ class RegisterDataMixin(_DataMixinBase):
 
     async def read_parallel_config(self) -> int:
         """Read parallel configuration from input register 113."""
-        return await read_parallel_config_async(self._read_input_registers, self._serial)
+        segments: list[RegisterSegment] = []
+
+        async def read_input(start: int, count: int) -> list[int]:
+            values = await self._read_input_registers(start, count)
+            _append_observed_segment(segments, start, values)
+            return values
+
+        result = await read_parallel_config_async(read_input, self._serial)
+        self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        return result
 
     async def validate_serial(self, expected_serial: str) -> bool:
         """Validate that the connected inverter matches the expected serial."""

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -44,6 +44,7 @@ from .exceptions import (
     TransportTimeoutError,
     TransportWriteError,
 )
+from .observation import RegisterObserver
 from .protocol import BaseTransport
 
 if TYPE_CHECKING:
@@ -198,6 +199,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         write_step_delay: float = DEFAULT_WRITE_STEP_DELAY,
         verify_writes: bool = True,
         max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
+        register_observer: RegisterObserver | None = None,
     ) -> None:
         """Initialize WiFi Dongle transport.
 
@@ -226,8 +228,9 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                 adjacent register groups into fewer reads; dongles that reject
                 large reads automatically fall back to the plain grouped reads
                 (eg4_web_monitor#254).
+            register_observer: Optional callback for terminal raw-register segments.
         """
-        super().__init__(inverter_serial)
+        super().__init__(inverter_serial, register_observer=register_observer)
         self._host = host
         self._port = port
         self._dongle_serial = dongle_serial

--- a/src/pylxpweb/transports/factory.py
+++ b/src/pylxpweb/transports/factory.py
@@ -45,6 +45,7 @@ from .http import HTTPTransport
 from .hybrid import HybridTransport
 from .modbus import ModbusTransport
 from .modbus_serial import ModbusSerialTransport
+from .observation import RegisterObserver
 from .protocol import BaseTransport, InverterTransport
 
 if TYPE_CHECKING:
@@ -80,6 +81,7 @@ def create_transport(
     timeout: float = ...,
     inverter_family: InverterFamily | None = ...,
     max_input_block_size: int = ...,
+    register_observer: RegisterObserver | None = ...,
 ) -> ModbusTransport: ...
 
 
@@ -96,6 +98,7 @@ def create_transport(
     timeout: float = ...,
     inverter_family: InverterFamily | None = ...,
     max_input_block_size: int = ...,
+    register_observer: RegisterObserver | None = ...,
 ) -> ModbusSerialTransport: ...
 
 
@@ -110,6 +113,7 @@ def create_transport(
     timeout: float = ...,
     inverter_family: InverterFamily | None = ...,
     max_input_block_size: int = ...,
+    register_observer: RegisterObserver | None = ...,
 ) -> DongleTransport: ...
 
 
@@ -128,6 +132,7 @@ def create_transport(
     inverter_family: InverterFamily | None = ...,
     local_retry_interval: float = ...,
     max_input_block_size: int = ...,
+    register_observer: RegisterObserver | None = ...,
 ) -> HybridTransport: ...
 
 
@@ -224,6 +229,7 @@ def create_transport(
             timeout=config.get("timeout", 10.0),
             inverter_family=config.get("inverter_family"),
             max_input_block_size=config.get("max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE),
+            register_observer=config.get("register_observer"),
         )
 
     if connection_type == "serial":
@@ -243,6 +249,7 @@ def create_transport(
             timeout=config.get("timeout", 10.0),
             inverter_family=config.get("inverter_family"),
             max_input_block_size=config.get("max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE),
+            register_observer=config.get("register_observer"),
         )
 
     if connection_type == "dongle":
@@ -263,6 +270,7 @@ def create_transport(
             timeout=config.get("timeout", 10.0),
             inverter_family=config.get("inverter_family"),
             max_input_block_size=config.get("max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE),
+            register_observer=config.get("register_observer"),
         )
 
     if connection_type == "hybrid":
@@ -281,6 +289,7 @@ def create_transport(
         timeout = config.get("timeout", 10.0)
         local_retry_interval = config.get("local_retry_interval", 60.0)
         max_input_block_size = config.get("max_input_block_size", DEFAULT_INPUT_BLOCK_SIZE)
+        register_observer = config.get("register_observer")
 
         # Create HTTP transport
         http_transport = HTTPTransport(client, serial)
@@ -295,6 +304,7 @@ def create_transport(
                 timeout=timeout,
                 inverter_family=inverter_family,
                 max_input_block_size=max_input_block_size,
+                register_observer=register_observer,
             )
         elif local_type == "dongle":
             dongle_serial = config.get("dongle_serial")
@@ -308,6 +318,7 @@ def create_transport(
                 timeout=timeout,
                 inverter_family=inverter_family,
                 max_input_block_size=max_input_block_size,
+                register_observer=register_observer,
             )
         else:
             raise ValueError(f"Invalid local_type: {local_type}")
@@ -363,6 +374,7 @@ def create_modbus_transport(
     timeout: float = 10.0,
     inverter_family: InverterFamily | None = None,
     max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
+    register_observer: RegisterObserver | None = None,
 ) -> ModbusTransport:
     """Create a Modbus TCP transport for local network communication.
 
@@ -389,6 +401,7 @@ def create_modbus_transport(
             If None, defaults to EG4_HYBRID (18kPV, FlexBOSS) for backward
             compatibility. Use InverterFamily.LXP for Luxpower models
             (LXP-EU, LXP-LB-BR, LXP-LV) which have different register layouts.
+        register_observer: Optional callback for terminal raw-register segments.
 
     Returns:
         ModbusTransport instance ready for use
@@ -430,6 +443,7 @@ def create_modbus_transport(
         timeout=timeout,
         inverter_family=inverter_family,
         max_input_block_size=max_input_block_size,
+        register_observer=register_observer,
     )
 
 
@@ -442,6 +456,7 @@ def create_dongle_transport(
     timeout: float = 10.0,
     inverter_family: InverterFamily | None = None,
     max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
+    register_observer: RegisterObserver | None = None,
 ) -> DongleTransport:
     """Create a WiFi dongle transport for local network communication.
 
@@ -475,6 +490,7 @@ def create_dongle_transport(
         inverter_family: Inverter model family for correct register mapping.
             If None, defaults to PV_SERIES (EG4-18KPV) for backward
             compatibility.
+        register_observer: Optional callback for terminal raw-register segments.
 
     Returns:
         DongleTransport instance ready for use
@@ -505,6 +521,7 @@ def create_dongle_transport(
         timeout=timeout,
         inverter_family=inverter_family,
         max_input_block_size=max_input_block_size,
+        register_observer=register_observer,
     )
 
 
@@ -519,6 +536,7 @@ def create_serial_transport(
     timeout: float = 10.0,
     inverter_family: InverterFamily | None = None,
     max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
+    register_observer: RegisterObserver | None = None,
 ) -> ModbusSerialTransport:
     """Create a Modbus RTU serial transport for local communication.
 
@@ -544,6 +562,7 @@ def create_serial_transport(
         inverter_family: Inverter model family for correct register mapping.
             If None, defaults to PV_SERIES (EG4-18KPV) for backward
             compatibility.
+        register_observer: Optional callback for terminal raw-register segments.
 
     Returns:
         ModbusSerialTransport instance ready for use
@@ -575,10 +594,15 @@ def create_serial_transport(
         timeout=timeout,
         inverter_family=inverter_family,
         max_input_block_size=max_input_block_size,
+        register_observer=register_observer,
     )
 
 
-def create_transport_from_config(config: TransportConfig) -> BaseTransport:
+def create_transport_from_config(
+    config: TransportConfig,
+    *,
+    register_observer: RegisterObserver | None = None,
+) -> BaseTransport:
     """Create transport instance from configuration object.
 
     This factory function creates the appropriate transport instance based
@@ -586,7 +610,8 @@ def create_transport_from_config(config: TransportConfig) -> BaseTransport:
     before creating the transport.
 
     Args:
-        config: Transport configuration specifying connection parameters
+        config: Transport configuration specifying connection parameters.
+        register_observer: Optional callback for terminal raw-register segments.
 
     Returns:
         Configured transport instance (ModbusTransport or DongleTransport)
@@ -622,6 +647,7 @@ def create_transport_from_config(config: TransportConfig) -> BaseTransport:
             retry_delay=config.retry_delay,
             inter_register_delay=config.inter_register_delay,
             max_input_block_size=config.max_input_block_size,
+            register_observer=register_observer,
         )
     elif config.transport_type == TransportType.MODBUS_SERIAL:
         # serial_port is guaranteed to be set after validate() for MODBUS_SERIAL
@@ -639,6 +665,7 @@ def create_transport_from_config(config: TransportConfig) -> BaseTransport:
             retry_delay=config.retry_delay,
             inter_register_delay=config.inter_register_delay,
             max_input_block_size=config.max_input_block_size,
+            register_observer=register_observer,
         )
     elif config.transport_type == TransportType.WIFI_DONGLE:
         # dongle_serial is guaranteed to be set after validate() for WIFI_DONGLE
@@ -651,6 +678,7 @@ def create_transport_from_config(config: TransportConfig) -> BaseTransport:
             timeout=config.timeout,
             inverter_family=config.inverter_family,
             max_input_block_size=config.max_input_block_size,
+            register_observer=register_observer,
         )
     elif config.transport_type == TransportType.HTTP:
         raise ValueError(

--- a/src/pylxpweb/transports/hybrid.py
+++ b/src/pylxpweb/transports/hybrid.py
@@ -119,6 +119,11 @@ class HybridTransport(BaseTransport):
         """Get the underlying HTTP transport."""
         return self._http
 
+    @property
+    def register_observation_error_count(self) -> int:
+        """Return the local transport's redacted observer-error count."""
+        return self._local.register_observation_error_count
+
     def _mark_local_failed(self) -> None:
         """Mark local transport as failed, enabling HTTP fallback."""
         self._local_failed_at = time.monotonic()

--- a/src/pylxpweb/transports/modbus.py
+++ b/src/pylxpweb/transports/modbus.py
@@ -25,6 +25,7 @@ from ._modbus_base import INPUT_REGISTER_GROUPS, BaseModbusTransport
 from ._register_data import DEFAULT_INPUT_BLOCK_SIZE
 from .capabilities import MODBUS_CAPABILITIES, TransportCapabilities
 from .exceptions import TransportConnectionError
+from .observation import RegisterObserver
 
 if TYPE_CHECKING:
     from pymodbus.client import AsyncModbusTcpClient
@@ -85,6 +86,7 @@ class ModbusTransport(BaseModbusTransport):
         inter_register_delay: float = 0.05,
         pymodbus_retries: int = 3,
         max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
+        register_observer: RegisterObserver | None = None,
     ) -> None:
         """Initialize Modbus transport.
 
@@ -110,6 +112,7 @@ class ModbusTransport(BaseModbusTransport):
                 field-proven) consolidate adjacent register groups into fewer
                 reads; hardware that rejects large reads automatically falls
                 back to the plain grouped reads (eg4_web_monitor#254).
+            register_observer: Optional callback for terminal raw-register segments.
         """
         super().__init__(
             serial,
@@ -121,6 +124,7 @@ class ModbusTransport(BaseModbusTransport):
             inter_register_delay=inter_register_delay,
             pymodbus_retries=pymodbus_retries,
             max_input_block_size=max_input_block_size,
+            register_observer=register_observer,
         )
         self._host = host
         self._port = port

--- a/src/pylxpweb/transports/modbus_serial.py
+++ b/src/pylxpweb/transports/modbus_serial.py
@@ -32,6 +32,7 @@ from ._modbus_base import BaseModbusTransport
 from ._register_data import DEFAULT_INPUT_BLOCK_SIZE
 from .capabilities import MODBUS_CAPABILITIES, TransportCapabilities
 from .exceptions import TransportConnectionError
+from .observation import RegisterObserver
 
 if TYPE_CHECKING:
     from pymodbus.client import AsyncModbusSerialClient
@@ -101,6 +102,7 @@ class ModbusSerialTransport(BaseModbusTransport):
         inter_register_delay: float = 0.05,
         pymodbus_retries: int = 3,
         max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
+        register_observer: RegisterObserver | None = None,
     ) -> None:
         """Initialize Modbus serial transport.
 
@@ -134,6 +136,7 @@ class ModbusSerialTransport(BaseModbusTransport):
                 field-proven) consolidate adjacent register groups into fewer
                 reads; hardware that rejects large reads automatically falls
                 back to the plain grouped reads (eg4_web_monitor#254).
+            register_observer: Optional callback for terminal raw-register segments.
         """
         super().__init__(
             serial,
@@ -145,6 +148,7 @@ class ModbusSerialTransport(BaseModbusTransport):
             inter_register_delay=inter_register_delay,
             pymodbus_retries=pymodbus_retries,
             max_input_block_size=max_input_block_size,
+            register_observer=register_observer,
         )
         self._port = port
         self._baudrate = baudrate

--- a/src/pylxpweb/transports/observation.py
+++ b/src/pylxpweb/transports/observation.py
@@ -32,7 +32,7 @@ class RegisterSegment:
         )
 
 
-@dataclass(frozen=True, slots=True, repr=False)
+@dataclass(frozen=True, slots=True)
 class RegisterObservation:
     """Observed raw-register segments for one register space."""
 
@@ -41,13 +41,6 @@ class RegisterObservation:
 
     segments: tuple[RegisterSegment, ...]
     """Ordered, immutable, non-overlapping raw-register segments."""
-
-    def __repr__(self) -> str:
-        """Return register-space and redacted segment provenance."""
-        return (
-            f"{type(self).__name__}(register_space={self.register_space!r}, "
-            f"segments={self.segments!r})"
-        )
 
 
 type RegisterObserver = Callable[[tuple[RegisterObservation, ...]], None]

--- a/src/pylxpweb/transports/observation.py
+++ b/src/pylxpweb/transports/observation.py
@@ -1,0 +1,48 @@
+"""Public raw-register observation types for local transport reads."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class RegisterSpace(StrEnum):
+    """Modbus register space for an observed raw-register read."""
+
+    INPUT = "input"
+    HOLDING = "holding"
+
+
+@dataclass(frozen=True, slots=True)
+class RegisterSegment:
+    """One immutable raw-register segment from a successful public read."""
+
+    start_address: int
+    """First register address covered by ``words``."""
+
+    words: tuple[int, ...]
+    """Exact raw 16-bit register words in observation order."""
+
+
+@dataclass(frozen=True, slots=True)
+class RegisterObservation:
+    """Observed raw-register segments for one register space."""
+
+    register_space: RegisterSpace
+    """Register space shared by every segment in ``segments``."""
+
+    segments: tuple[RegisterSegment, ...]
+    """Ordered, immutable, non-overlapping raw-register segments."""
+
+
+type RegisterObserver = Callable[[tuple[RegisterObservation, ...]], None]
+"""Observer callback for successful local raw-register reads."""
+
+
+__all__ = [
+    "RegisterObservation",
+    "RegisterObserver",
+    "RegisterSegment",
+    "RegisterSpace",
+]

--- a/src/pylxpweb/transports/observation.py
+++ b/src/pylxpweb/transports/observation.py
@@ -14,7 +14,7 @@ class RegisterSpace(StrEnum):
     HOLDING = "holding"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, repr=False)
 class RegisterSegment:
     """One immutable raw-register segment from a successful public read."""
 
@@ -24,8 +24,15 @@ class RegisterSegment:
     words: tuple[int, ...]
     """Exact raw 16-bit register words in observation order."""
 
+    def __repr__(self) -> str:
+        """Return provenance without exposing raw register words."""
+        return (
+            f"{type(self).__name__}(start_address={self.start_address!r}, "
+            f"word_count={len(self.words)}, words=<redacted>)"
+        )
 
-@dataclass(frozen=True, slots=True)
+
+@dataclass(frozen=True, slots=True, repr=False)
 class RegisterObservation:
     """Observed raw-register segments for one register space."""
 
@@ -34,6 +41,13 @@ class RegisterObservation:
 
     segments: tuple[RegisterSegment, ...]
     """Ordered, immutable, non-overlapping raw-register segments."""
+
+    def __repr__(self) -> str:
+        """Return register-space and redacted segment provenance."""
+        return (
+            f"{type(self).__name__}(register_space={self.register_space!r}, "
+            f"segments={self.segments!r})"
+        )
 
 
 type RegisterObserver = Callable[[tuple[RegisterObservation, ...]], None]

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -323,21 +323,17 @@ class BaseTransport:
         if observer is None or not observations:
             return
 
-        async def invoke_observer() -> bool:
-            try:
-                observer(observations)
-            except (Exception, asyncio.CancelledError):
-                return False
-            return True
+        async def invoke_observer() -> None:
+            observer(observations)
 
         try:
-            succeeded = await asyncio.create_task(invoke_observer())
+            await asyncio.create_task(invoke_observer())
         except asyncio.CancelledError:
             polling_task = asyncio.current_task()
             if polling_task is not None and polling_task.cancelling():
                 raise
-            succeeded = False
-        if not succeeded:
+            self._register_observation_error_count += 1
+        except Exception:
             self._register_observation_error_count += 1
 
     async def __aenter__(self) -> Self:

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -314,20 +314,30 @@ class BaseTransport:
         """Return the monotonic count of suppressed register-observer errors."""
         return self._register_observation_error_count
 
-    def _notify_register_observer(
+    async def _notify_register_observer(
         self,
         observations: tuple[RegisterObservation, ...],
     ) -> None:
         """Notify the observer without affecting transport behavior."""
-        if self._register_observer is None or not observations:
+        observer = self._register_observer
+        if observer is None or not observations:
             return
+
+        async def invoke_observer() -> bool:
+            try:
+                observer(observations)
+            except (Exception, asyncio.CancelledError):
+                return False
+            return True
+
         try:
-            self._register_observer(observations)
-        # This call is synchronous: no external task cancellation can be
-        # delivered inside it.  A CancelledError raised here therefore came
-        # from callback code and is isolated like its other failures.  Genuine
-        # cancellation at transport await points remains untouched.
-        except (Exception, asyncio.CancelledError):
+            succeeded = await asyncio.create_task(invoke_observer())
+        except asyncio.CancelledError:
+            polling_task = asyncio.current_task()
+            if polling_task is not None and polling_task.cancelling():
+                raise
+            succeeded = False
+        if not succeeded:
             self._register_observation_error_count += 1
 
     async def __aenter__(self) -> Self:

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -314,6 +314,11 @@ class BaseTransport:
         """Return the monotonic count of suppressed register-observer errors."""
         return self._register_observation_error_count
 
+    @property
+    def _register_observer_enabled(self) -> bool:
+        """Return whether construction enabled raw-register observation."""
+        return self._register_observer is not None
+
     def _notify_register_observer(
         self,
         observations: tuple[RegisterObservation, ...],
@@ -323,7 +328,11 @@ class BaseTransport:
             return
         try:
             self._register_observer(observations)
-        except Exception:
+        # This call is synchronous: no external task cancellation can be
+        # delivered inside it.  A CancelledError raised here therefore came
+        # from callback code and is isolated like its other failures.  Genuine
+        # cancellation at transport await points remains untouched.
+        except (Exception, asyncio.CancelledError):
             self._register_observation_error_count += 1
 
     async def __aenter__(self) -> Self:

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -12,6 +12,8 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any, Protocol, Self, runtime_checkable
 
+from .observation import RegisterObservation, RegisterObserver
+
 if TYPE_CHECKING:
     from .capabilities import TransportCapabilities
     from .data import BatteryBankData, InverterEnergyData, InverterRuntimeData
@@ -278,15 +280,24 @@ class BaseTransport:
             data = await transport.read_runtime()
     """
 
-    def __init__(self, serial: str) -> None:
+    def __init__(
+        self,
+        serial: str,
+        *,
+        register_observer: RegisterObserver | None = None,
+    ) -> None:
         """Initialize base transport.
 
         Args:
             serial: Inverter serial number
+            register_observer: Optional callback for immutable terminal raw-register
+                segments from successful public reads.
         """
         self._serial = serial
         self._connected = False
         self._op_lock = _ReentrantAsyncLock()
+        self._register_observer = register_observer
+        self._register_observation_error_count = 0
 
     @property
     def serial(self) -> str:
@@ -297,6 +308,23 @@ class BaseTransport:
     def is_connected(self) -> bool:
         """Check if transport is connected."""
         return self._connected
+
+    @property
+    def register_observation_error_count(self) -> int:
+        """Return the monotonic count of suppressed register-observer errors."""
+        return self._register_observation_error_count
+
+    def _notify_register_observer(
+        self,
+        observations: tuple[RegisterObservation, ...],
+    ) -> None:
+        """Notify the observer without affecting transport behavior."""
+        if self._register_observer is None or not observations:
+            return
+        try:
+            self._register_observer(observations)
+        except Exception:
+            self._register_observation_error_count += 1
 
     async def __aenter__(self) -> Self:
         """Enter async context manager, connecting the transport.

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -314,11 +314,6 @@ class BaseTransport:
         """Return the monotonic count of suppressed register-observer errors."""
         return self._register_observation_error_count
 
-    @property
-    def _register_observer_enabled(self) -> bool:
-        """Return whether construction enabled raw-register observation."""
-        return self._register_observer is not None
-
     def _notify_register_observer(
         self,
         observations: tuple[RegisterObservation, ...],

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Sequence
 
 import pytest
 
 from pylxpweb.transports import RegisterObservation, RegisterSegment, RegisterSpace
+from pylxpweb.transports import _register_data as register_data_module
 from pylxpweb.transports._register_data import (
     DEFAULT_INPUT_BLOCK_SIZE,
     INPUT_REGISTER_GROUPS,
@@ -16,6 +19,7 @@ from pylxpweb.transports.exceptions import TransportReadError
 from pylxpweb.transports.protocol import BaseTransport
 
 type ObservationBatch = tuple[RegisterObservation, ...]
+type PublicRead = Callable[[_FakeRegisterTransport], Awaitable[object]]
 
 
 class _FakeRegisterTransport(RegisterDataMixin, BaseTransport):
@@ -55,6 +59,76 @@ class _FakeRegisterTransport(RegisterDataMixin, BaseTransport):
         if request == (RegisterSpace.INPUT, 140, 3):
             return [7] * count
         return [0] * count
+
+
+class _BlockingRegisterTransport(_FakeRegisterTransport):
+    """Transport that exposes cancellation while a real public read awaits I/O."""
+
+    def __init__(self, *, observer: Callable[[ObservationBatch], None]) -> None:
+        super().__init__(observer=observer)
+        self.read_started = asyncio.Event()
+        self.release_read = asyncio.Event()
+
+    async def _read_holding_registers(self, start: int, count: int) -> list[int]:
+        self.reads.append((RegisterSpace.HOLDING, start, count))
+        self.read_started.set()
+        await self.release_read.wait()
+        return [0] * count
+
+
+class _CountingAddress(int):
+    """Integer address counting segment-boundary arithmetic for complexity proof."""
+
+    additions_of_chunk_size = 0
+
+    def __new__(cls, value: int) -> _CountingAddress:
+        return super().__new__(cls, value)
+
+    def __add__(self, other: int) -> _CountingAddress:
+        if other == 40:
+            type(self).additions_of_chunk_size += 1
+        return type(self)(int(self) + other)
+
+
+PUBLIC_OBSERVATION_READS: tuple[object, ...] = (
+    pytest.param(lambda transport: transport.read_quick_charge_remaining_seconds(), id="quick"),
+    pytest.param(lambda transport: transport.read_runtime(), id="runtime"),
+    pytest.param(lambda transport: transport.read_energy(), id="energy"),
+    pytest.param(lambda transport: transport.read_battery(), id="battery"),
+    pytest.param(lambda transport: transport.read_all_input_data(), id="combined"),
+    pytest.param(lambda transport: transport.read_midbox_runtime(), id="midbox"),
+    pytest.param(lambda transport: transport.read_parameters(10, 85), id="parameters"),
+    pytest.param(lambda transport: transport.read_serial_number(), id="serial"),
+    pytest.param(lambda transport: transport.read_firmware_version(), id="firmware"),
+    pytest.param(lambda transport: transport.read_device_type(), id="device-type"),
+    pytest.param(lambda transport: transport.read_parallel_config(), id="parallel"),
+    pytest.param(lambda transport: transport.validate_serial(""), id="validate-serial"),
+)
+
+
+def test_register_observation_repr_redacts_raw_words_from_diagnostics(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw_sentinel = 57005
+    segment = RegisterSegment(123, (raw_sentinel, 48879))
+    observation = RegisterObservation(RegisterSpace.INPUT, (segment,))
+
+    with pytest.raises(AssertionError) as assertion:
+        assert observation == RegisterObservation(RegisterSpace.INPUT, ())
+    logging.getLogger(__name__).warning("synthetic observation: %r", observation)
+
+    rendered = (
+        repr(segment),
+        repr(observation),
+        str(RuntimeError(observation)),
+        str(assertion.value),
+        caplog.text,
+    )
+    assert all(str(raw_sentinel) not in diagnostic for diagnostic in rendered)
+    assert all("123" in diagnostic for diagnostic in rendered[:3])
+    assert all("word_count=2" in diagnostic for diagnostic in rendered[:3])
+    assert "word_count=2" in str(assertion.value)
+    assert "word_count=2" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -116,6 +190,34 @@ async def test_raising_observer_preserves_read_and_advances_redacted_error_count
 
 
 @pytest.mark.asyncio
+async def test_callback_cancelled_error_preserves_read_and_advances_error_count() -> None:
+    def cancel_from_observer(observations: ObservationBatch) -> None:
+        raise asyncio.CancelledError("synthetic callback detail")
+
+    transport = _FakeRegisterTransport(observer=cancel_from_observer)
+
+    result = await transport.read_parameters(10, 1)
+
+    assert result == {10: 0}
+    assert transport.register_observation_error_count == 1
+
+
+@pytest.mark.asyncio
+async def test_external_task_cancellation_remains_cancelled() -> None:
+    observed: list[ObservationBatch] = []
+    transport = _BlockingRegisterTransport(observer=observed.append)
+    task = asyncio.create_task(transport.read_parameters(10, 1))
+    await transport.read_started.wait()
+
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert observed == []
+    assert transport.register_observation_error_count == 0
+
+
+@pytest.mark.asyncio
 async def test_failed_public_read_emits_no_partial_observation() -> None:
     observed: list[ObservationBatch] = []
     transport = _FakeRegisterTransport(
@@ -159,3 +261,68 @@ async def test_observer_adds_zero_reads_and_preserves_request_order() -> None:
             ),
         )
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_read", PUBLIC_OBSERVATION_READS)
+async def test_default_observer_skips_capture_on_every_public_read(
+    monkeypatch: pytest.MonkeyPatch,
+    public_read: PublicRead,
+) -> None:
+    baseline = _FakeRegisterTransport()
+    await public_read(baseline)
+    capture_calls = 0
+    publication_calls = 0
+    capture_states: list[list[RegisterSegment] | None] = []
+    original_append = register_data_module._append_observed_segment
+    original_new = RegisterDataMixin._new_observed_segments
+    original_notify = RegisterDataMixin._notify_observed_segments
+
+    def count_capture_calls(
+        segments: list[RegisterSegment],
+        start: int,
+        values: Sequence[int],
+    ) -> None:
+        nonlocal capture_calls
+        capture_calls += 1
+        original_append(segments, start, values)
+
+    def record_capture_state(self: RegisterDataMixin) -> list[RegisterSegment] | None:
+        state = original_new(self)
+        capture_states.append(state)
+        return state
+
+    def count_publication_calls(
+        self: RegisterDataMixin,
+        *observed: tuple[RegisterSpace, Sequence[RegisterSegment] | None],
+    ) -> None:
+        nonlocal publication_calls
+        publication_calls += 1
+        original_notify(self, *observed)
+
+    monkeypatch.setattr(register_data_module, "_append_observed_segment", count_capture_calls)
+    monkeypatch.setattr(RegisterDataMixin, "_new_observed_segments", record_capture_state)
+    monkeypatch.setattr(RegisterDataMixin, "_notify_observed_segments", count_publication_calls)
+    disabled = _FakeRegisterTransport()
+
+    await public_read(disabled)
+
+    assert disabled.reads == baseline.reads
+    assert capture_states and all(state is None for state in capture_states)
+    assert capture_calls == 0
+    assert publication_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_large_sequential_parameter_capture_is_linear() -> None:
+    observed: list[ObservationBatch] = []
+    transport = _FakeRegisterTransport(observer=observed.append)
+    register_count = 4000
+    chunk_count = register_count // 40
+    _CountingAddress.additions_of_chunk_size = 0
+
+    await transport.read_parameters(_CountingAddress(0), register_count)
+
+    assert len(transport.reads) == chunk_count
+    assert len(observed[0][0].segments) == chunk_count
+    assert _CountingAddress.additions_of_chunk_size <= chunk_count * 3

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -132,6 +132,37 @@ PUBLIC_OBSERVATION_READS: tuple[object, ...] = (
     pytest.param(lambda transport: transport.validate_serial(""), id="validate-serial"),
 )
 
+CANONICAL_OBSERVATION_READS: tuple[object, ...] = (
+    pytest.param(
+        lambda transport: transport.read_serial_number(),
+        RegisterSpace.INPUT,
+        115,
+        5,
+        id="serial",
+    ),
+    pytest.param(
+        lambda transport: transport.read_firmware_version(),
+        RegisterSpace.HOLDING,
+        7,
+        4,
+        id="firmware",
+    ),
+    pytest.param(
+        lambda transport: transport.read_device_type(),
+        RegisterSpace.HOLDING,
+        19,
+        1,
+        id="device-type",
+    ),
+    pytest.param(
+        lambda transport: transport.read_parallel_config(),
+        RegisterSpace.INPUT,
+        113,
+        1,
+        id="parallel",
+    ),
+)
+
 TERMINAL_GROUP_OBSERVATION: ObservationBatch = (
     RegisterObservation(
         RegisterSpace.INPUT,
@@ -351,6 +382,38 @@ async def test_observer_adds_zero_reads_and_preserves_request_order() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("public_read", "space", "start", "count"),
+    CANONICAL_OBSERVATION_READS,
+)
+async def test_canonical_readers_observe_enabled_terminal_segment_without_extra_reads(
+    public_read: PublicRead,
+    space: RegisterSpace,
+    start: int,
+    count: int,
+) -> None:
+    baseline = _FakeRegisterTransport()
+    observed: list[ObservationBatch] = []
+    enabled = _FakeRegisterTransport(observer=observed.append)
+
+    baseline_result = await public_read(baseline)
+    enabled_result = await public_read(enabled)
+
+    expected_read = (space, start, count)
+    assert enabled_result == baseline_result
+    assert baseline.reads == [expected_read]
+    assert enabled.reads == [expected_read]
+    assert observed == [
+        (
+            RegisterObservation(
+                space,
+                (RegisterSegment(start, (0,) * count),),
+            ),
+        )
+    ]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("public_read", PUBLIC_OBSERVATION_READS)
 async def test_default_observer_skips_capture_on_every_public_read(
     monkeypatch: pytest.MonkeyPatch,
@@ -379,13 +442,13 @@ async def test_default_observer_skips_capture_on_every_public_read(
         capture_states.append(state)
         return state
 
-    def count_publication_calls(
+    async def count_publication_calls(
         self: RegisterDataMixin,
         *observed: tuple[RegisterSpace, Sequence[RegisterSegment] | None],
     ) -> None:
         nonlocal publication_calls
         publication_calls += 1
-        original_notify(self, *observed)
+        await original_notify(self, *observed)
 
     monkeypatch.setattr(register_data_module, "_append_observed_segment", count_capture_calls)
     monkeypatch.setattr(RegisterDataMixin, "_new_observed_segments", record_capture_state)

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -14,6 +14,7 @@ from pylxpweb.transports._register_data import (
     DEFAULT_INPUT_BLOCK_SIZE,
     INPUT_REGISTER_GROUPS,
     RegisterDataMixin,
+    _ReadBlock,
 )
 from pylxpweb.transports.exceptions import TransportReadError
 from pylxpweb.transports.protocol import BaseTransport
@@ -74,6 +75,32 @@ class _BlockingRegisterTransport(_FakeRegisterTransport):
         self.read_started.set()
         await self.release_read.wait()
         return [0] * count
+
+
+class _PreCancelledRegisterTransport(_FakeRegisterTransport):
+    """Transport with cancellation already pending before observer dispatch."""
+
+    async def _read_holding_registers(self, start: int, count: int) -> list[int]:
+        task = asyncio.current_task()
+        assert task is not None
+        task.cancel()
+        return await super()._read_holding_registers(start, count)
+
+
+class _GroupFallbackProbeTransport(_FakeRegisterTransport):
+    """Transport recording capture state at each real group-plan attempt."""
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self.attempt_segment_counts: list[int | None] = []
+
+    async def _read_group_plan(
+        self,
+        plan: list[_ReadBlock],
+        segments: list[RegisterSegment] | None = None,
+    ) -> dict[int, int]:
+        self.attempt_segment_counts.append(None if segments is None else len(segments))
+        return await super()._read_group_plan(plan, segments)
 
 
 class _CountingAddress(int):
@@ -202,6 +229,27 @@ async def test_callback_cancelled_error_preserves_read_and_advances_error_count(
     assert transport.register_observation_error_count == 1
 
 
+@pytest.mark.parametrize("raise_after_cancel", [False, True])
+@pytest.mark.asyncio
+async def test_callback_task_cancellation_is_isolated(
+    raise_after_cancel: bool,
+) -> None:
+    def cancel_from_observer(observations: ObservationBatch) -> None:
+        task = asyncio.current_task()
+        assert task is not None
+        task.cancel()
+        if raise_after_cancel:
+            raise RuntimeError("synthetic callback detail")
+
+    transport = _FakeRegisterTransport(observer=cancel_from_observer)
+
+    result = await transport.read_parameters(10, 1)
+    await asyncio.sleep(0)
+
+    assert result == {10: 0}
+    assert transport.register_observation_error_count == 1
+
+
 @pytest.mark.asyncio
 async def test_external_task_cancellation_remains_cancelled() -> None:
     observed: list[ObservationBatch] = []
@@ -215,6 +263,63 @@ async def test_external_task_cancellation_remains_cancelled() -> None:
         await task
     assert observed == []
     assert transport.register_observation_error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cancellation_pending_before_callback_remains_cancelled() -> None:
+    observed: list[ObservationBatch] = []
+    transport = _PreCancelledRegisterTransport(observer=observed.append)
+
+    with pytest.raises(asyncio.CancelledError):
+        await transport.read_parameters(10, 1)
+
+    assert observed == []
+    assert transport.register_observation_error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_group_fallback_discards_failed_attempt_segments() -> None:
+    observed: list[ObservationBatch] = []
+    successful_discarded_probe = (RegisterSpace.INPUT, 0, 113)
+    failed_probe = (RegisterSpace.INPUT, 113, 41)
+    transport = _GroupFallbackProbeTransport(
+        observer=observed.append,
+        max_input_block_size=120,
+        fail_reads={failed_probe},
+    )
+
+    await transport.read_runtime()
+
+    grouped_reads = [
+        (RegisterSpace.INPUT, start, count) for start, count in INPUT_REGISTER_GROUPS.values()
+    ]
+    assert transport.reads == [successful_discarded_probe, failed_probe, *grouped_reads]
+    assert transport.attempt_segment_counts == [0, 0]
+    assert observed == [
+        (
+            RegisterObservation(
+                RegisterSpace.INPUT,
+                (
+                    RegisterSegment(0, (0,) * 32),
+                    RegisterSegment(32, (0,) * 32),
+                    RegisterSegment(64, (0,) * 16),
+                    RegisterSegment(80, (0,) * 33),
+                    RegisterSegment(113, (0,) * 27),
+                    RegisterSegment(140, (7,) * 3),
+                    RegisterSegment(143, (0,) * 11),
+                    RegisterSegment(170, (0,) * 4),
+                    RegisterSegment(193, (0,) * 12),
+                ),
+            ),
+        )
+    ]
+    addresses = [
+        address
+        for observation in observed[0]
+        for segment in observation.segments
+        for address in range(segment.start_address, segment.start_address + len(segment.words))
+    ]
+    assert len(addresses) == len(set(addresses))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -1,0 +1,161 @@
+"""Terminal raw-register observer contract."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from pylxpweb.transports import RegisterObservation, RegisterSegment, RegisterSpace
+from pylxpweb.transports._register_data import (
+    DEFAULT_INPUT_BLOCK_SIZE,
+    INPUT_REGISTER_GROUPS,
+    RegisterDataMixin,
+)
+from pylxpweb.transports.exceptions import TransportReadError
+from pylxpweb.transports.protocol import BaseTransport
+
+type ObservationBatch = tuple[RegisterObservation, ...]
+
+
+class _FakeRegisterTransport(RegisterDataMixin, BaseTransport):
+    """Deterministic transport exercising the real public read paths."""
+
+    def __init__(
+        self,
+        *,
+        observer: Callable[[ObservationBatch], None] | None = None,
+        max_input_block_size: int = DEFAULT_INPUT_BLOCK_SIZE,
+        fail_reads: set[tuple[RegisterSpace, int, int]] | None = None,
+    ) -> None:
+        super().__init__("test-serial", register_observer=observer)
+        self._init_input_coalescing(max_input_block_size)
+        self._inter_register_delay = 0.0
+        self._inverter_family = None
+        self._split_phase = False
+        self._pv_string_count = 3
+        self._fail_reads = fail_reads or set()
+        self.reads: list[tuple[RegisterSpace, int, int]] = []
+
+    async def _read_input_registers(self, start: int, count: int) -> list[int]:
+        return self._read(RegisterSpace.INPUT, start, count)
+
+    async def _read_holding_registers(self, start: int, count: int) -> list[int]:
+        return self._read(RegisterSpace.HOLDING, start, count)
+
+    async def _write_holding_registers(self, start: int, values: list[int]) -> bool:
+        return True
+
+    def _read(self, space: RegisterSpace, start: int, count: int) -> list[int]:
+        request = (space, start, count)
+        self.reads.append(request)
+        if request in self._fail_reads:
+            self._fail_reads.remove(request)
+            raise TransportReadError("simulated read failure")
+        if request == (RegisterSpace.INPUT, 140, 3):
+            return [7] * count
+        return [0] * count
+
+
+@pytest.mark.asyncio
+async def test_coalesced_fallback_observes_only_terminal_winning_segments() -> None:
+    observed: list[ObservationBatch] = []
+    successful_discarded_probe = (RegisterSpace.INPUT, 0, 113)
+    failed_probe = (RegisterSpace.INPUT, 113, 41)
+    transport = _FakeRegisterTransport(
+        observer=observed.append,
+        max_input_block_size=120,
+        fail_reads={failed_probe},
+    )
+
+    await transport.read_all_input_data()
+
+    grouped_reads = [
+        (RegisterSpace.INPUT, start, count) for start, count in INPUT_REGISTER_GROUPS.values()
+    ]
+    assert transport.reads == [successful_discarded_probe, failed_probe, *grouped_reads]
+    assert observed == [
+        (
+            RegisterObservation(
+                RegisterSpace.INPUT,
+                (
+                    RegisterSegment(0, (0,) * 32),
+                    RegisterSegment(32, (0,) * 32),
+                    RegisterSegment(64, (0,) * 16),
+                    RegisterSegment(80, (0,) * 33),
+                    RegisterSegment(113, (0,) * 27),
+                    RegisterSegment(140, (7,) * 3),
+                    RegisterSegment(143, (0,) * 11),
+                    RegisterSegment(170, (0,) * 4),
+                    RegisterSegment(193, (0,) * 12),
+                ),
+            ),
+        )
+    ]
+    addresses = [
+        address
+        for observation in observed[0]
+        for segment in observation.segments
+        for address in range(segment.start_address, segment.start_address + len(segment.words))
+    ]
+    assert len(addresses) == len(set(addresses))
+
+
+@pytest.mark.asyncio
+async def test_raising_observer_preserves_read_and_advances_redacted_error_count() -> None:
+    def raise_from_observer(observations: ObservationBatch) -> None:
+        raise RuntimeError("secret observer detail")
+
+    transport = _FakeRegisterTransport(observer=raise_from_observer)
+
+    runtime, energy, _battery = await transport.read_all_input_data()
+
+    assert runtime is not None
+    assert energy is not None
+    assert transport.register_observation_error_count == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_public_read_emits_no_partial_observation() -> None:
+    observed: list[ObservationBatch] = []
+    transport = _FakeRegisterTransport(
+        observer=observed.append,
+        fail_reads={(RegisterSpace.INPUT, 32, 32)},
+    )
+
+    with pytest.raises(TransportReadError):
+        await transport.read_runtime()
+
+    assert observed == []
+    assert transport.register_observation_error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_observer_adds_zero_reads_and_preserves_request_order() -> None:
+    baseline = _FakeRegisterTransport()
+    observed: list[ObservationBatch] = []
+    with_observer = _FakeRegisterTransport(observer=observed.append)
+
+    baseline_result = await baseline.read_parameters(10, 85)
+    observed_result = await with_observer.read_parameters(10, 85)
+
+    expected_reads = [
+        (RegisterSpace.HOLDING, 10, 40),
+        (RegisterSpace.HOLDING, 50, 40),
+        (RegisterSpace.HOLDING, 90, 5),
+    ]
+    assert baseline_result == observed_result
+    assert baseline.reads == expected_reads
+    assert with_observer.reads == expected_reads
+    assert observed == [
+        (
+            RegisterObservation(
+                RegisterSpace.HOLDING,
+                (
+                    RegisterSegment(10, (0,) * 40),
+                    RegisterSegment(50, (0,) * 40),
+                    RegisterSegment(90, (0,) * 5),
+                ),
+            ),
+        )
+    ]

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -135,30 +135,22 @@ PUBLIC_OBSERVATION_READS: tuple[object, ...] = (
 CANONICAL_OBSERVATION_READS: tuple[object, ...] = (
     pytest.param(
         lambda transport: transport.read_serial_number(),
-        RegisterSpace.INPUT,
-        115,
-        5,
+        (RegisterSpace.INPUT, 115, 5),
         id="serial",
     ),
     pytest.param(
         lambda transport: transport.read_firmware_version(),
-        RegisterSpace.HOLDING,
-        7,
-        4,
+        (RegisterSpace.HOLDING, 7, 4),
         id="firmware",
     ),
     pytest.param(
         lambda transport: transport.read_device_type(),
-        RegisterSpace.HOLDING,
-        19,
-        1,
+        (RegisterSpace.HOLDING, 19, 1),
         id="device-type",
     ),
     pytest.param(
         lambda transport: transport.read_parallel_config(),
-        RegisterSpace.INPUT,
-        113,
-        1,
+        (RegisterSpace.INPUT, 113, 1),
         id="parallel",
     ),
 )
@@ -383,14 +375,12 @@ async def test_observer_adds_zero_reads_and_preserves_request_order() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("public_read", "space", "start", "count"),
+    ("public_read", "expected_read"),
     CANONICAL_OBSERVATION_READS,
 )
 async def test_canonical_readers_observe_enabled_terminal_segment_without_extra_reads(
     public_read: PublicRead,
-    space: RegisterSpace,
-    start: int,
-    count: int,
+    expected_read: tuple[RegisterSpace, int, int],
 ) -> None:
     baseline = _FakeRegisterTransport()
     observed: list[ObservationBatch] = []
@@ -399,7 +389,7 @@ async def test_canonical_readers_observe_enabled_terminal_segment_without_extra_
     baseline_result = await public_read(baseline)
     enabled_result = await public_read(enabled)
 
-    expected_read = (space, start, count)
+    space, start, count = expected_read
     assert enabled_result == baseline_result
     assert baseline.reads == [expected_read]
     assert enabled.reads == [expected_read]

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -132,6 +132,32 @@ PUBLIC_OBSERVATION_READS: tuple[object, ...] = (
     pytest.param(lambda transport: transport.validate_serial(""), id="validate-serial"),
 )
 
+TERMINAL_GROUP_OBSERVATION: ObservationBatch = (
+    RegisterObservation(
+        RegisterSpace.INPUT,
+        (
+            RegisterSegment(0, (0,) * 32),
+            RegisterSegment(32, (0,) * 32),
+            RegisterSegment(64, (0,) * 16),
+            RegisterSegment(80, (0,) * 33),
+            RegisterSegment(113, (0,) * 27),
+            RegisterSegment(140, (7,) * 3),
+            RegisterSegment(143, (0,) * 11),
+            RegisterSegment(170, (0,) * 4),
+            RegisterSegment(193, (0,) * 12),
+        ),
+    ),
+)
+
+
+def _observed_addresses(observed: list[ObservationBatch]) -> list[int]:
+    return [
+        address
+        for observation in observed[0]
+        for segment in observation.segments
+        for address in range(segment.start_address, segment.start_address + len(segment.words))
+    ]
+
 
 def test_register_observation_repr_redacts_raw_words_from_diagnostics(
     caplog: pytest.LogCaptureFixture,
@@ -175,30 +201,8 @@ async def test_coalesced_fallback_observes_only_terminal_winning_segments() -> N
         (RegisterSpace.INPUT, start, count) for start, count in INPUT_REGISTER_GROUPS.values()
     ]
     assert transport.reads == [successful_discarded_probe, failed_probe, *grouped_reads]
-    assert observed == [
-        (
-            RegisterObservation(
-                RegisterSpace.INPUT,
-                (
-                    RegisterSegment(0, (0,) * 32),
-                    RegisterSegment(32, (0,) * 32),
-                    RegisterSegment(64, (0,) * 16),
-                    RegisterSegment(80, (0,) * 33),
-                    RegisterSegment(113, (0,) * 27),
-                    RegisterSegment(140, (7,) * 3),
-                    RegisterSegment(143, (0,) * 11),
-                    RegisterSegment(170, (0,) * 4),
-                    RegisterSegment(193, (0,) * 12),
-                ),
-            ),
-        )
-    ]
-    addresses = [
-        address
-        for observation in observed[0]
-        for segment in observation.segments
-        for address in range(segment.start_address, segment.start_address + len(segment.words))
-    ]
+    assert observed == [TERMINAL_GROUP_OBSERVATION]
+    addresses = _observed_addresses(observed)
     assert len(addresses) == len(set(addresses))
 
 
@@ -295,30 +299,8 @@ async def test_runtime_group_fallback_discards_failed_attempt_segments() -> None
     ]
     assert transport.reads == [successful_discarded_probe, failed_probe, *grouped_reads]
     assert transport.attempt_segment_counts == [0, 0]
-    assert observed == [
-        (
-            RegisterObservation(
-                RegisterSpace.INPUT,
-                (
-                    RegisterSegment(0, (0,) * 32),
-                    RegisterSegment(32, (0,) * 32),
-                    RegisterSegment(64, (0,) * 16),
-                    RegisterSegment(80, (0,) * 33),
-                    RegisterSegment(113, (0,) * 27),
-                    RegisterSegment(140, (7,) * 3),
-                    RegisterSegment(143, (0,) * 11),
-                    RegisterSegment(170, (0,) * 4),
-                    RegisterSegment(193, (0,) * 12),
-                ),
-            ),
-        )
-    ]
-    addresses = [
-        address
-        for observation in observed[0]
-        for segment in observation.segments
-        for address in range(segment.start_address, segment.start_address + len(segment.words))
-    ]
+    assert observed == [TERMINAL_GROUP_OBSERVATION]
+    addresses = _observed_addresses(observed)
     assert len(addresses) == len(set(addresses))
 
 


### PR DESCRIPTION
## Summary

- add a construction-time `register_observer` seam to local register transports and their public factories
- publish immutable, typed input/holding register observations only after a public read succeeds
- retain only the terminal winning coalesced/fallback plan, with last-read-wins overlap normalization and no gap filling
- suppress observer exceptions behind a redacted monotonic `register_observation_error_count`
- isolate callback-originated task cancellation without swallowing pre-existing or external polling-task cancellation

## Scope

This is the upstream observation seam only. It does not retain snapshots or partial attempts, emit incomplete-read events, observe writes, add cloud behavior, or add downstream integrations.

## Validation

- `uv run pytest -q tests/unit/transports/test_register_observer.py` — 28 passed
- `uv run pytest -q tests/unit/transports` — 815 passed
- `uv run pytest -q` — 3,272 passed, 4 skipped, 80 deselected
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — 220 files formatted
- `uv run mypy --strict src/pylxpweb/` — 95 source files clean
- `uv build` and `uv run twine check <artifacts>` — wheel and sdist passed

## Mutation evidence

- premature emission of a discarded coalesced attempt: red, then green restored
- suppressed counter increment after observer failure: red, then green restored
- premature partial emission from a failed public read: red, then green restored
- observer-only extra holding-register request: red, then green restored
- callback self-cancellation left pending on the polling task: 2 red, then 2 green
- polling cancellation swallowed at observer dispatch: red, then green
- `_read_register_groups` fallback capture reset removed: red, then green
- enabled canonical-reader `_capture_register_reads` bypass: 4 red, then 4 green
- synchronous publication spy replacing the async notifier: red with the faulty unawaited path, then green with an async spy awaiting the original notifier

Closes #279
