### PR TITLE
chore(release): prepare 0.10.0b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0b2] - 2026-08-15
+
+### Added
+
+- **Opt-in raw-register observation for local transports**
+  ([#279](https://github.com/joyfulhouse/pylxpweb/issues/279), PR
+  [#280](https://github.com/joyfulhouse/pylxpweb/pull/280), release issue
+  [#281](https://github.com/joyfulhouse/pylxpweb/issues/281)):
+  local transport constructors and public factories now accept an optional
+  construction-time `register_observer`. After a public read succeeds, the
+  observer receives immutable `RegisterObservation` and `RegisterSegment`
+  values containing only the terminal winning segments from that read's
+  coalesced or fallback plan; failed and discarded partial attempts are not
+  published. Observer failures are isolated from transport behavior and
+  reflected only by the redacted, monotonic
+  `register_observation_error_count`. Observation reuses the Modbus reads
+  already performed by the public operation and issues no additional Modbus
+  reads. The API does not retain or publish downstream snapshots.
+
 ## [0.10.0b1] - 2026-08-14
 
 ### Added
@@ -2641,7 +2660,8 @@ ac_power = inverter.ac_charge_power_limit  # Property access (uses 1-hour cache)
 - **v0.1.1** (2025-11-15): Bug fixes and improvements
 - **v0.1.0** (2025-11-14): Initial release with core functionality
 
-[Unreleased]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b1...HEAD
+[Unreleased]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b2...HEAD
+[0.10.0b2]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b1...v0.10.0b2
 [0.10.0b1]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.39b11...v0.10.0b1
 [0.9.32]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.29...v0.9.32
 [0.9.29]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.26...v0.9.29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.10.0b1"
+version = "0.10.0b2"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.10.0b1"
+version = "0.10.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- bump the project and lockfile self-version from `0.10.0b1` to `0.10.0b2`
- add the dated `0.10.0b2` Keep a Changelog entry for the raw-register observer API merged in #280
- add the `0.10.0b2` compare-link definition using the real `v0.10.0b1` tag and advance the `Unreleased` comparison base
- keep the release-preparation diff limited to `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`

## Why

PR #280 added a construction-time observer seam for successful local raw-register reads. This PR prepares the next beta metadata so that contract is documented accurately and can be packaged as `0.10.0b2` in a separate release operation.

## Public contract

Local transport constructors and public factories accept an optional construction-time `register_observer`. After a public read succeeds, it receives immutable observations containing only the terminal winning segments from that read's coalesced or fallback plan. Failed and discarded partial attempts are not published. Observer failures do not alter transport behavior and are exposed only through the redacted, monotonic `register_observation_error_count`. Observation reuses reads already made by the public operation, with zero additional Modbus reads. The API does not retain or publish downstream snapshots.

## User impact

Consumers of the eventual `0.10.0b2` prerelease can opt into raw input/holding-register observations without adding another Modbus polling path. Existing callers that do not provide an observer retain the prior behavior.

## Validation

- [x] `uv lock --check` — resolved 70 packages with no lockfile changes
- [x] `uv sync --all-extras --frozen` — installed pylxpweb `0.10.0b2`
- [x] version consistency script — `pyproject.toml`, `uv.lock`, and installed metadata all report `0.10.0b2`
- [x] changelog footer check — `0.10.0b2` resolves to `v0.10.0b1...v0.10.0b2`; `Unreleased` resolves to `v0.10.0b2...HEAD`
- [x] `uv run ruff check src/ tests/` — passed
- [x] `uv run ruff format --check src/ tests/` — 220 files already formatted
- [x] `uv run mypy --strict src/pylxpweb/` — passed for 95 source files
- [x] `uv run pytest -q` — 3,272 passed, 4 skipped, 80 deselected
- [x] `uv build` — wheel and sdist built successfully
- [x] `uv run twine check dist/*` — both distributions passed
- [x] wheel `METADATA` and sdist `PKG-INFO` — both report `Version: 0.10.0b2`
- [x] `git diff --check` — passed

## Lockfile and scope

- [x] `uv lock` changed only the editable `pylxpweb` self-version from `0.10.0b1` to `0.10.0b2`; no dependency drift
- [x] changed paths are exactly `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`
- [x] no source, tests, workflows, or downstream dependency pins changed

## Mutation testing

No tests were added or materially changed, so mutation evidence is not applicable.

## Release safety

- [x] confirmed `v0.10.0b1` exists and resolves to commit `43d110941263a1caf83992c852b3bd559b32175d`
- [x] confirmed immediately before committing that no `v0.10.0b2` tag, GitHub release, or PyPI release exists
- [x] confirmed `release.yml` runs only for a published GitHub release or manual dispatch, not for a normal PR merge
- [x] no tag or GitHub release created
- [x] no TestPyPI/PyPI upload performed
- [x] no release workflow manually triggered
- [x] merging this metadata-preparation PR does not create a tag, release, or package publication

Closes #281