### PR TITLE
docs: clarify EG4 slave firmware registers

### DIFF
--- a/src/pylxpweb/battery_protocols/eg4_slave.py
+++ b/src/pylxpweb/battery_protocols/eg4_slave.py
@@ -6,16 +6,17 @@ Register map sourced from ricardocello's eg4_waveshare.py.
 Register layout:
   - Regs 0-38: Runtime state (voltage, current, cells, temps, SOC, etc.)
   - Regs 33-35: Packed per-cell NTC temperatures (2 per register, high/low byte)
-  - Regs 105-116, 120-127: Model and serial fields (unpopulated on observed
-    EG4-LL WP-16/280 firmware)
+  - Regs 105-116, 120-127: Model and serial fields (no serial data on observed
+    EG4-LL WP-16/280 firmware; Z02T11 returns ``0x41F4`` then ``0xFFFF`` padding)
   - Regs 117-119: BMS firmware; observed Z02T11 units return ASCII ``Z02T11``
 
 Note on device info: Firmware RE of one WP-16/280 firmware found that its slave
 code path never populates the Modbus buffer positions for regs 105-127 with
 ASCII data. That finding is hardware- and firmware-specific: captures from
-Z02T11 units populate the firmware field at regs 117-119, while their model and
-serial fields remain unpopulated. The full info block is read because other EG4
-battery models and firmware may populate additional fields.
+Z02T11 units populate the firmware field at regs 117-119. Their serial-specific
+regs 120-127 contain ``0x41F4`` followed by ``0xFFFF`` padding rather than serial
+data. The full info block is read because other EG4 battery models and firmware
+may populate additional fields.
 """
 
 from __future__ import annotations
@@ -68,7 +69,8 @@ class EG4SlaveProtocol(BatteryProtocol):
     Modbus register lookup (FUN_2CDB4) serves regs 105-127 from a flat buffer
     that the slave code path does not populate with ASCII device info. This is
     not universal: observed Z02T11 units return their ASCII BMS firmware version
-    in regs 117-119, while their model and serial-specific fields are unpopulated.
+    in regs 117-119. Their serial-specific regs 120-127 contain ``0x41F4`` then
+    ``0xFFFF`` padding, not a battery serial number.
     """
 
     name = "eg4_slave"

--- a/src/pylxpweb/battery_protocols/eg4_slave.py
+++ b/src/pylxpweb/battery_protocols/eg4_slave.py
@@ -6,12 +6,16 @@ Register map sourced from ricardocello's eg4_waveshare.py.
 Register layout:
   - Regs 0-38: Runtime state (voltage, current, cells, temps, SOC, etc.)
   - Regs 33-35: Packed per-cell NTC temperatures (2 per register, high/low byte)
-  - Regs 105-127: Device info block (read but empty on EG4-LL WP-16/280 firmware)
+  - Regs 105-116, 120-127: Model and serial fields (unpopulated on observed
+    EG4-LL WP-16/280 firmware)
+  - Regs 117-119: BMS firmware; observed Z02T11 units return ASCII ``Z02T11``
 
-Note on device info: Firmware RE confirmed that the Modbus buffer positions for
-regs 105-127 are never populated with ASCII data by the slave code path.
-Device info (model, FW, serial) is only available via CAN bus.
-The info block is still read in case other EG4 battery models do populate it.
+Note on device info: Firmware RE of one WP-16/280 firmware found that its slave
+code path never populates the Modbus buffer positions for regs 105-127 with
+ASCII data. That finding is hardware- and firmware-specific: captures from
+Z02T11 units populate the firmware field at regs 117-119, while their model and
+serial fields remain unpopulated. The full info block is read because other EG4
+battery models and firmware may populate additional fields.
 """
 
 from __future__ import annotations
@@ -60,10 +64,11 @@ class EG4SlaveProtocol(BatteryProtocol):
     Decodes runtime registers (0-38) and device info registers (105-127)
     into a BatteryData object with all values properly scaled.
 
-    Note: On EG4-LL WP-16/280 firmware, device info registers (105-127)
-    return all zeros. The firmware's Modbus register lookup (FUN_2CDB4)
-    serves from a flat buffer that the slave code path never populates
-    with ASCII data. Device info is only available via CAN bus (cloud API).
+    Note: Reverse engineering of one EG4-LL WP-16/280 firmware found that its
+    Modbus register lookup (FUN_2CDB4) serves regs 105-127 from a flat buffer
+    that the slave code path does not populate with ASCII device info. This is
+    not universal: observed Z02T11 units return their ASCII BMS firmware version
+    in regs 117-119, while their model and serial-specific fields are unpopulated.
     """
 
     name = "eg4_slave"

--- a/tests/unit/battery_protocols/test_eg4_slave.py
+++ b/tests/unit/battery_protocols/test_eg4_slave.py
@@ -152,15 +152,27 @@ class TestEG4SlaveProtocol:
         data = self.protocol.decode(raw, battery_index=0)
         assert "EG4-LL" in data.model
 
-    def test_decode_z02t11_firmware_with_empty_serial(self) -> None:
-        """Z02T11 firmware occupies regs 117-119 while serial regs are empty."""
+    def test_decode_z02t11_hardware_capture(self) -> None:
+        """Decode the captured Z02T11 firmware and unpopulated serial region."""
         raw: dict[int, int] = dict.fromkeys(range(128), 0)
         raw[117] = 0x5A30  # "Z0"
         raw[118] = 0x3254  # "2T"
         raw[119] = 0x3131  # "11"
+        raw[120] = 0x41F4
+        for address in range(121, 128):
+            raw[address] = 0xFFFF
         data = self.protocol.decode(raw, battery_index=0)
         assert data.firmware_version == "Z02T11"
-        assert data.serial_number == ""
+        assert data.serial_number == "A" + "\ufffd" * 15
+
+    def test_decode_device_info_firmware_strips_embedded_null(self) -> None:
+        """Firmware decoding removes an embedded null byte."""
+        raw: dict[int, int] = dict.fromkeys(range(39), 0)
+        raw[117] = 0x3231  # "21"
+        raw[118] = 0x3700  # "7\0"
+        raw[119] = 0
+        data = self.protocol.decode(raw, battery_index=0)
+        assert data.firmware_version == "217"
 
     def test_decode_device_info_serial(self) -> None:
         """Serial number at regs 120-127 decoded as ASCII."""

--- a/tests/unit/battery_protocols/test_eg4_slave.py
+++ b/tests/unit/battery_protocols/test_eg4_slave.py
@@ -152,16 +152,15 @@ class TestEG4SlaveProtocol:
         data = self.protocol.decode(raw, battery_index=0)
         assert "EG4-LL" in data.model
 
-    def test_decode_device_info_firmware(self) -> None:
-        """Firmware at regs 117-119 decoded as ASCII."""
-        raw: dict[int, int] = dict.fromkeys(range(39), 0)
-        # "217" -> 0x3231 ("21"), 0x3700 ("7\x00")
-        raw[117] = 0x3231  # "21"
-        raw[118] = 0x3700  # "7\0"
-        raw[119] = 0
+    def test_decode_z02t11_firmware_with_empty_serial(self) -> None:
+        """Z02T11 firmware occupies regs 117-119 while serial regs are empty."""
+        raw: dict[int, int] = dict.fromkeys(range(128), 0)
+        raw[117] = 0x5A30  # "Z0"
+        raw[118] = 0x3254  # "2T"
+        raw[119] = 0x3131  # "11"
         data = self.protocol.decode(raw, battery_index=0)
-        assert data.firmware_version != ""
-        assert "217" in data.firmware_version
+        assert data.firmware_version == "Z02T11"
+        assert data.serial_number == ""
 
     def test_decode_device_info_serial(self) -> None:
         """Serial number at regs 120-127 decoded as ASCII."""


### PR DESCRIPTION
## Summary

- scope the EG4 slave device-info empty-range notes to the hardware and firmware actually observed
- document that Z02T11 units populate holding registers 117-119 with ASCII BMS firmware `Z02T11`
- characterize both public Z02T11 slave captures exactly: reg 120 is `0x41F4` and regs 121-127 are `0xFFFF`, with no battery serial encoded
- preserve the decoder's existing serial output for that sentinel sequence without changing identity semantics
- restore separate firmware coverage for an embedded null byte (`0x3700` decoding to `"7"`)

## Scope

This is a documentation correction plus characterization of existing runtime behavior. No decoder logic, register reads, or battery identity behavior changed. The diff is limited to `src/pylxpweb/battery_protocols/eg4_slave.py` and `tests/unit/battery_protocols/test_eg4_slave.py`.

## Primary-source evidence

The public dumps on `joyfulhouse/eg4_web_monitor#574`, summarized by `joyfulhouse/eg4_web_monitor#578`, agree for both reported Z02T11 slave units:

- regs 117-119: `0x5A30`, `0x3254`, `0x3131` → `Z02T11`
- reg 120: `0x41F4`
- regs 121-127: `0xFFFF`

Issue #578 identifies regs 120-127 as unpopulated/no serial despite those sentinel values. With unchanged `decode_ascii` semantics, that region currently decodes to `"A"` followed by 15 replacement characters; the hardware test now characterizes that exact result rather than substituting all-zero registers.

## Validation

- [x] `uv run pytest -q tests/unit/battery_protocols/test_eg4_slave.py` — 26 passed
- [x] `uv run pytest tests/unit/ --cov=pylxpweb --cov-report=term-missing --cov-report=xml --cov-report=html -v` — 3,235 passed; 89.55% coverage
- [x] `uv run ruff check src/ tests/` — passed
- [x] `uv run ruff format --check src/ tests/` — 220 files already formatted
- [x] `uv run mypy --strict src/pylxpweb/` — no issues in 95 source files
- [x] `git diff --check` — passed
- [x] independent scoped review — no findings

## Characterization evidence

The production documentation edit was stashed with:

`git stash push -m 'issue-578-round1-characterization' -- src/pylxpweb/battery_protocols/eg4_slave.py`

With that production edit reverted:

- `uv run pytest -q tests/unit/battery_protocols/test_eg4_slave.py::TestEG4SlaveProtocol::test_decode_z02t11_hardware_capture` — **1 passed**
- `uv run pytest -q tests/unit/battery_protocols/test_eg4_slave.py::TestEG4SlaveProtocol::test_decode_device_info_firmware_strips_embedded_null` — **1 passed**

After `git stash pop`, both exact commands again passed 1 test each.

These no-fix probes are intentionally green. Both tests characterize runtime decode behavior that existed before this documentation correction; production-code reversion cannot create a legitimate RED, and no assertion or documentation mutation was used to fabricate one.

Fixes joyfulhouse/eg4_web_monitor#578
