### PR TITLE
feat(transports): add runtime observer control

### DIFF
--- a/src/pylxpweb/transports/__init__.py
+++ b/src/pylxpweb/transports/__init__.py
@@ -95,6 +95,7 @@ from .observation import RegisterObservation, RegisterObserver, RegisterSegment,
 from .protocol import (
     BaseTransport,
     InverterTransport,
+    RegisterObserverControl,
     TerminalInverterTransport,
     TerminalTransport,
 )
@@ -133,6 +134,7 @@ __all__ = [
     "AttachResult",
     # Protocol
     "InverterTransport",
+    "RegisterObserverControl",
     "TerminalInverterTransport",
     "TerminalTransport",
     "BaseTransport",

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -213,7 +213,7 @@ def _append_observed_segment(
     values: Sequence[int],
 ) -> None:
     """Merge a terminal segment, making later overlapping reads authoritative."""
-    if (isinstance(segments, _RegisterCapture) and not segments.is_active) or not values:
+    if (isinstance(segments, _RegisterCapture) and not segments.active) or not values:
         return
 
     new_segment = RegisterSegment(start, tuple(values))

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -52,7 +52,13 @@ from .exceptions import (
     TransportResponseMismatchError,
     TransportTimeoutError,
 )
-from .observation import RegisterObservation, RegisterObserver, RegisterSegment, RegisterSpace
+from .observation import (
+    RegisterObservation,
+    RegisterObserver,
+    RegisterSegment,
+    RegisterSpace,
+    _RegisterCapture,
+)
 
 if TYPE_CHECKING:
     from pylxpweb.devices.inverters._features import InverterFamily
@@ -207,7 +213,7 @@ def _append_observed_segment(
     values: Sequence[int],
 ) -> None:
     """Merge a terminal segment, making later overlapping reads authoritative."""
-    if not values:
+    if (isinstance(segments, _RegisterCapture) and not segments.is_active) or not values:
         return
 
     new_segment = RegisterSegment(start, tuple(values))
@@ -310,6 +316,8 @@ if TYPE_CHECKING:
         _input_coalescing_latched_off: bool
         _register_observer: RegisterObserver | None
 
+        def _new_register_capture(self) -> _RegisterCapture: ...
+
         async def _read_input_registers(self, start: int, count: int) -> list[int]: ...
 
         async def _read_holding_registers(self, start: int, count: int) -> list[int]: ...
@@ -391,9 +399,9 @@ class RegisterDataMixin(_DataMixinBase):
         )
         await self._notify_register_observer(observations)
 
-    def _new_observed_segments(self) -> list[RegisterSegment] | None:
+    def _new_observed_segments(self) -> _RegisterCapture | None:
         """Allocate capture state only when an observer was configured."""
-        return [] if self._register_observer is not None else None
+        return self._new_register_capture() if self._register_observer is not None else None
 
     async def _read_individual_battery_registers(
         self,

--- a/src/pylxpweb/transports/hybrid.py
+++ b/src/pylxpweb/transports/hybrid.py
@@ -19,6 +19,7 @@ from .exceptions import (
     TransportTimeoutError,
     TransportWriteError,
 )
+from .observation import RegisterObserver
 from .protocol import BaseTransport
 
 if TYPE_CHECKING:
@@ -123,6 +124,10 @@ class HybridTransport(BaseTransport):
     def register_observation_error_count(self) -> int:
         """Return the local transport's redacted observer-error count."""
         return self._local.register_observation_error_count
+
+    def set_register_observer(self, observer: RegisterObserver | None) -> None:
+        """Delegate runtime observer replacement to the local transport only."""
+        self._local.set_register_observer(observer)
 
     def _mark_local_failed(self) -> None:
         """Mark local transport as failed, enabling HTTP fallback."""

--- a/src/pylxpweb/transports/observation.py
+++ b/src/pylxpweb/transports/observation.py
@@ -47,6 +47,26 @@ type RegisterObserver = Callable[[tuple[RegisterObservation, ...]], None]
 """Observer callback for successful local raw-register reads."""
 
 
+class _RegisterCapture(list[RegisterSegment]):
+    """Revocable enabled-only staging buffer for one public register read."""
+
+    __slots__ = ("_is_active", "__weakref__")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._is_active = True
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether the capture may still accept register segments."""
+        return self._is_active
+
+    def revoke(self) -> None:
+        """Synchronously clear the capture and reject subsequent appends."""
+        self._is_active = False
+        self.clear()
+
+
 __all__ = [
     "RegisterObservation",
     "RegisterObserver",

--- a/src/pylxpweb/transports/observation.py
+++ b/src/pylxpweb/transports/observation.py
@@ -50,20 +50,15 @@ type RegisterObserver = Callable[[tuple[RegisterObservation, ...]], None]
 class _RegisterCapture(list[RegisterSegment]):
     """Revocable enabled-only staging buffer for one public register read."""
 
-    __slots__ = ("_is_active", "__weakref__")
+    __slots__ = ("active", "__weakref__")
 
     def __init__(self) -> None:
         super().__init__()
-        self._is_active = True
-
-    @property
-    def is_active(self) -> bool:
-        """Return whether the capture may still accept register segments."""
-        return self._is_active
+        self.active = True
 
     def revoke(self) -> None:
         """Synchronously clear the capture and reject subsequent appends."""
-        self._is_active = False
+        self.active = False
         self.clear()
 
 

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import weakref
 from typing import TYPE_CHECKING, Any, Protocol, Self, runtime_checkable
 
-from .observation import RegisterObservation, RegisterObserver
+from .observation import RegisterObservation, RegisterObserver, _RegisterCapture
 
 if TYPE_CHECKING:
     from .capabilities import TransportCapabilities
@@ -25,6 +26,15 @@ _LOGGER = logging.getLogger(__name__)
 # rather than mislabelling unknown bits — writing one would flip an unknown
 # device setting, which is the failure mode of eg4_web_monitor #476.
 _PLACEHOLDER_PARAM_RE = re.compile(r"FUNC_\d+_BIT\d+")
+
+
+@runtime_checkable
+class RegisterObserverControl(Protocol):
+    """Optional capability for synchronous runtime observer replacement."""
+
+    def set_register_observer(self, observer: RegisterObserver | None) -> None:
+        """Replace or detach the synchronous, non-blocking observer callback."""
+        ...
 
 
 class _ReentrantAsyncLock:
@@ -297,6 +307,9 @@ class BaseTransport:
         self._connected = False
         self._op_lock = _ReentrantAsyncLock()
         self._register_observer = register_observer
+        self._register_observer_captures: weakref.WeakValueDictionary[int, _RegisterCapture] = (
+            weakref.WeakValueDictionary()
+        )
         self._register_observation_error_count = 0
 
     @property
@@ -314,17 +327,38 @@ class BaseTransport:
         """Return the monotonic count of suppressed register-observer errors."""
         return self._register_observation_error_count
 
+    def set_register_observer(self, observer: RegisterObserver | None) -> None:
+        """Synchronously replace or detach the non-blocking register observer.
+
+        The callback must complete synchronously and must not return awaitable
+        work. Passing ``None`` detaches observation without reconnecting or
+        otherwise changing transport operation.
+        """
+        if observer is self._register_observer:
+            return
+        for capture in tuple(self._register_observer_captures.values()):
+            capture.revoke()
+        self._register_observer_captures.clear()
+        self._register_observer = observer
+
+    def _new_register_capture(self) -> _RegisterCapture:
+        """Create and track an enabled capture for synchronous revocation."""
+        capture = _RegisterCapture()
+        self._register_observer_captures[id(capture)] = capture
+        return capture
+
     async def _notify_register_observer(
         self,
         observations: tuple[RegisterObservation, ...],
     ) -> None:
         """Notify the observer without affecting transport behavior."""
-        observer = self._register_observer
-        if observer is None or not observations:
+        if self._register_observer is None or not observations:
             return
 
         async def invoke_observer() -> None:
-            observer(observations)
+            observer = self._register_observer
+            if observer is not None:
+                observer(observations)
 
         try:
             await asyncio.create_task(invoke_observer())

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -8,10 +8,12 @@ implementations must follow. Using Protocol allows for structural subtyping
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import re
 import weakref
-from typing import TYPE_CHECKING, Any, Protocol, Self, runtime_checkable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol, Self, cast, runtime_checkable
 
 from .observation import RegisterObservation, RegisterObserver, _RegisterCapture
 
@@ -307,6 +309,8 @@ class BaseTransport:
         self._connected = False
         self._op_lock = _ReentrantAsyncLock()
         self._register_observer = register_observer
+        self._register_observer_generation = 0
+        # Captures inherit list and are unhashable, so WeakSet cannot track them.
         self._register_observer_captures: weakref.WeakValueDictionary[int, _RegisterCapture] = (
             weakref.WeakValueDictionary()
         )
@@ -340,6 +344,7 @@ class BaseTransport:
             capture.revoke()
         self._register_observer_captures.clear()
         self._register_observer = observer
+        self._register_observer_generation += 1
 
     def _new_register_capture(self) -> _RegisterCapture:
         """Create and track an enabled capture for synchronous revocation."""
@@ -354,11 +359,25 @@ class BaseTransport:
         """Notify the observer without affecting transport behavior."""
         if self._register_observer is None or not observations:
             return
+        observer = self._register_observer
+        generation = self._register_observer_generation
 
         async def invoke_observer() -> None:
-            observer = self._register_observer
-            if observer is not None:
-                observer(observations)
+            if (
+                observer is self._register_observer
+                and generation == self._register_observer_generation
+            ):
+                runtime_observer = cast(
+                    Callable[[tuple[RegisterObservation, ...]], object], observer
+                )
+                result = runtime_observer(observations)
+                if inspect.iscoroutine(result):
+                    result.close()
+                    raise TypeError("register observer must return None")
+                if isinstance(result, asyncio.Future):
+                    if not result.done():
+                        result.cancel()
+                    raise TypeError("register observer must return None")
 
         try:
             await asyncio.create_task(invoke_observer())

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -379,8 +379,6 @@ class BaseTransport:
                             result.result()
                     elif result.exception() is None:
                         result.result()
-                else:
-                    result.cancel()
             elif isinstance(result, Coroutine) or (
                 inspect.isawaitable(result) and inspect.isgenerator(result)
             ):

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -8,11 +8,12 @@ implementations must follow. Using Protocol allows for structural subtyping
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import logging
 import re
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Protocol, Self, cast, runtime_checkable
 
 from .observation import RegisterObservation, RegisterObserver, _RegisterCapture
@@ -359,25 +360,32 @@ class BaseTransport:
         """Notify the observer without affecting transport behavior."""
         if self._register_observer is None or not observations:
             return
-        observer = self._register_observer
         generation = self._register_observer_generation
 
         async def invoke_observer() -> None:
-            if (
-                observer is self._register_observer
-                and generation == self._register_observer_generation
+            observer = self._register_observer
+            if observer is None or generation != self._register_observer_generation:
+                return
+            runtime_observer = cast(Callable[[tuple[RegisterObservation, ...]], object], observer)
+            result = runtime_observer(observations)
+            if result is None:
+                return
+            if inspect.iscoroutine(result):
+                result.close()
+            elif isinstance(result, asyncio.Future):
+                if result.done():
+                    if result.cancelled():
+                        with contextlib.suppress(asyncio.CancelledError):
+                            result.result()
+                    elif result.exception() is None:
+                        result.result()
+                else:
+                    result.cancel()
+            elif isinstance(result, Coroutine) or (
+                inspect.isawaitable(result) and inspect.isgenerator(result)
             ):
-                runtime_observer = cast(
-                    Callable[[tuple[RegisterObservation, ...]], object], observer
-                )
-                result = runtime_observer(observations)
-                if inspect.iscoroutine(result):
-                    result.close()
-                    raise TypeError("register observer must return None")
-                if isinstance(result, asyncio.Future):
-                    if not result.done():
-                        result.cancel()
-                    raise TypeError("register observer must return None")
+                result.close()
+            raise TypeError("register observer must return None")
 
         try:
             await asyncio.create_task(invoke_observer())

--- a/src/pylxpweb/transports/protocol.py
+++ b/src/pylxpweb/transports/protocol.py
@@ -374,11 +374,8 @@ class BaseTransport:
                 result.close()
             elif isinstance(result, asyncio.Future):
                 if result.done():
-                    if result.cancelled():
-                        with contextlib.suppress(asyncio.CancelledError):
-                            result.result()
-                    elif result.exception() is None:
-                        result.result()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        result.exception()
             elif isinstance(result, Coroutine) or (
                 inspect.isawaitable(result) and inspect.isgenerator(result)
             ):

--- a/tests/unit/transports/test_hybrid.py
+++ b/tests/unit/transports/test_hybrid.py
@@ -150,6 +150,21 @@ class TestHybridTransportProperties:
         transport = HybridTransport(mock_local_transport, mock_http_transport)
         assert transport.http_transport is mock_http_transport
 
+    def test_register_observer_control_delegates_to_local_only(
+        self, mock_local_transport: MagicMock, mock_http_transport: MagicMock
+    ) -> None:
+        observer = MagicMock()
+        transport = HybridTransport(mock_local_transport, mock_http_transport)
+
+        transport.set_register_observer(observer)
+        transport.set_register_observer(None)
+
+        assert mock_local_transport.set_register_observer.call_args_list == [
+            ((observer,), {}),
+            ((None,), {}),
+        ]
+        mock_http_transport.set_register_observer.assert_not_called()
+
 
 class TestHybridTransportConnect:
     """Tests for HybridTransport connect/disconnect."""

--- a/tests/unit/transports/test_protocol.py
+++ b/tests/unit/transports/test_protocol.py
@@ -2,8 +2,19 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
+from pylxpweb.transports import (
+    DongleTransport,
+    HTTPTransport,
+    HybridTransport,
+    InverterTransport,
+    ModbusSerialTransport,
+    ModbusTransport,
+    RegisterObserverControl,
+)
 from pylxpweb.transports.capabilities import (
     HTTP_CAPABILITIES,
     MODBUS_CAPABILITIES,
@@ -73,6 +84,36 @@ class ConcreteTransport(BaseTransport):
         self._connected = False
 
 
+class MinimalStructuralTransport:
+    """Third-party-shaped transport intentionally lacking observer control."""
+
+    serial = "CE12345678"
+    is_connected = True
+    capabilities = HTTP_CAPABILITIES
+
+    async def connect(self) -> None: ...
+
+    async def disconnect(self) -> None: ...
+
+    async def read_runtime(self) -> None: ...
+
+    async def read_energy(self) -> None: ...
+
+    async def read_battery(self) -> None: ...
+
+    async def read_parameters(self, start_address: int, count: int) -> dict[int, int]:
+        return {}
+
+    async def write_parameters(self, parameters: dict[int, int]) -> bool:
+        return True
+
+    async def read_named_parameters(self, start_address: int, count: int) -> dict[str, object]:
+        return {}
+
+    async def write_named_parameters(self, parameters: dict[str, object]) -> bool:
+        return True
+
+
 class TestBaseTransport:
     """Tests for BaseTransport abstract class."""
 
@@ -110,3 +151,25 @@ class TestBaseTransport:
 
         # Should not raise
         transport._ensure_connected()
+
+
+def test_observer_control_is_narrow_and_does_not_widen_existing_protocol() -> None:
+    transport = MinimalStructuralTransport()
+
+    assert isinstance(transport, InverterTransport)
+    assert not isinstance(transport, RegisterObserverControl)
+
+
+def test_concrete_transports_conform_to_observer_control_protocol() -> None:
+    client = MagicMock()
+    local = ModbusTransport("127.0.0.1", serial="CE12345678")
+    http = HTTPTransport(client, "CE12345678")
+    transports = (
+        local,
+        ModbusSerialTransport("loop://", serial="CE12345678"),
+        DongleTransport("127.0.0.1", "BA12345678", "CE12345678"),
+        http,
+        HybridTransport(local, http),
+    )
+
+    assert all(isinstance(transport, RegisterObserverControl) for transport in transports)

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -629,31 +629,52 @@ async def test_coroutine_return_is_closed_and_counted_once(
 
 @pytest.mark.parametrize("return_task", [False, True], ids=["future", "task"])
 @pytest.mark.asyncio
-async def test_future_return_is_cancelled_and_counted_once(return_task: bool) -> None:
-    returned: list[asyncio.Future[None]] = []
-    baseline_tasks = asyncio.all_tasks()
-
+async def test_pending_borrowed_future_return_is_not_cancelled(return_task: bool) -> None:
     async def wait_forever() -> None:
         await asyncio.Event().wait()
 
-    def malformed_return(observations: ObservationBatch) -> object:
-        value: asyncio.Future[None]
+    borrowed: asyncio.Future[None]
+    if return_task:
+        borrowed = asyncio.create_task(wait_forever())
+    else:
+        borrowed = asyncio.get_running_loop().create_future()
+    transport = _FakeRegisterTransport(observer=lambda observations: borrowed)
+
+    try:
+        result = await transport.read_parameters(10, 1)
+
+        assert result == {10: 0}
+        assert transport.register_observation_error_count == 1
+        assert not borrowed.done()
+    finally:
+        borrowed.cancel()
         if return_task:
-            value = asyncio.create_task(wait_forever())
-        else:
-            value = asyncio.get_running_loop().create_future()
-        returned.append(value)
-        return value
+            with pytest.raises(asyncio.CancelledError):
+                await borrowed
 
-    transport = _FakeRegisterTransport(observer=malformed_return)
 
-    result = await transport.read_parameters(10, 1)
-    await asyncio.sleep(0)
+@pytest.mark.asyncio
+async def test_pending_public_read_task_return_is_not_cancelled() -> None:
+    polling_task: asyncio.Task[dict[int, int]] | None = None
 
-    assert result == {10: 0}
+    def return_polling_task(observations: ObservationBatch) -> object:
+        assert polling_task is not None
+        return polling_task
+
+    transport = _FakeRegisterTransport(observer=return_polling_task)
+
+    async def public_read() -> dict[int, int]:
+        nonlocal polling_task
+        polling_task = asyncio.current_task()
+        assert polling_task is not None
+        return await transport.read_parameters(10, 1)
+
+    task = asyncio.create_task(public_read())
+
+    assert await task == {10: 0}
+    assert not task.cancelled()
+    assert task.cancelling() == 0
     assert transport.register_observation_error_count == 1
-    assert returned[0].cancelled()
-    assert asyncio.all_tasks() == baseline_tasks
 
 
 @pytest.mark.parametrize("return_task", [False, True], ids=["future", "task"])

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -234,17 +234,24 @@ def test_register_observation_repr_redacts_raw_words_from_diagnostics(
         assert observation == RegisterObservation(RegisterSpace.INPUT, ())
     logging.getLogger(__name__).warning("synthetic observation: %r", observation)
 
-    rendered = (
+    deterministic_renderings = (
         repr(segment),
         repr(observation),
         str(RuntimeError(observation)),
+    )
+    rendered = (
+        *deterministic_renderings,
         str(assertion.value),
         caplog.text,
     )
-    assert all(str(raw_sentinel) not in diagnostic for diagnostic in rendered)
-    assert all("123" in diagnostic for diagnostic in rendered[:3])
-    assert all("word_count=2" in diagnostic for diagnostic in rendered[:3])
-    assert "word_count=2" in str(assertion.value)
+    raw_word_spellings = (str(raw_sentinel), "48879", "0xdead", "0xbeef")
+    assert all(
+        spelling not in diagnostic.lower()
+        for diagnostic in rendered
+        for spelling in raw_word_spellings
+    )
+    assert all("123" in diagnostic for diagnostic in deterministic_renderings)
+    assert all("word_count=2" in diagnostic for diagnostic in deterministic_renderings)
     assert "word_count=2" in caplog.text
 
 

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -234,13 +234,10 @@ def test_register_observation_repr_redacts_raw_words_from_diagnostics(
         assert observation == RegisterObservation(RegisterSpace.INPUT, ())
     logging.getLogger(__name__).warning("synthetic observation: %r", observation)
 
-    deterministic_renderings = (
+    rendered = (
         repr(segment),
         repr(observation),
         str(RuntimeError(observation)),
-    )
-    rendered = (
-        *deterministic_renderings,
         str(assertion.value),
         caplog.text,
     )
@@ -250,8 +247,8 @@ def test_register_observation_repr_redacts_raw_words_from_diagnostics(
         for diagnostic in rendered
         for spelling in raw_word_spellings
     )
-    assert all("123" in diagnostic for diagnostic in deterministic_renderings)
-    assert all("word_count=2" in diagnostic for diagnostic in deterministic_renderings)
+    assert all("123" in diagnostic for diagnostic in rendered[:3])
+    assert all("word_count=2" in diagnostic for diagnostic in rendered[:3])
     assert "word_count=2" in caplog.text
 
 

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import asdict, is_dataclass
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -14,7 +16,9 @@ from pylxpweb.transports._register_data import (
     DEFAULT_INPUT_BLOCK_SIZE,
     INPUT_REGISTER_GROUPS,
     RegisterDataMixin,
+    _append_observed_segment,
     _ReadBlock,
+    _RegisterCapture,
 )
 from pylxpweb.transports.exceptions import TransportReadError
 from pylxpweb.transports.protocol import BaseTransport
@@ -180,6 +184,20 @@ def _observed_addresses(observed: list[ObservationBatch]) -> list[int]:
         for segment in observation.segments
         for address in range(segment.start_address, segment.start_address + len(segment.words))
     ]
+
+
+def _without_timestamps(value: object) -> object:
+    """Normalize generated model timestamps while preserving parsed payloads."""
+    if isinstance(value, tuple):
+        return tuple(_without_timestamps(item) for item in value)
+    if is_dataclass(value) and not isinstance(value, type):
+        payload = asdict(value)
+        payload.pop("timestamp", None)
+        return payload
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(exclude={"timestamp"})
+    return value
 
 
 def test_register_observation_repr_redacts_raw_words_from_diagnostics(
@@ -466,3 +484,154 @@ async def test_large_sequential_parameter_capture_is_linear() -> None:
     assert len(transport.reads) == chunk_count
     assert len(observed[0][0].segments) == chunk_count
     assert _CountingAddress.additions_of_chunk_size <= chunk_count * 3
+
+
+@pytest.mark.asyncio
+async def test_detach_during_unlocked_modbus_read_revokes_capture_before_append() -> None:
+    """A direct mixin read can finish, but its detached capture cannot publish."""
+    observed: list[ObservationBatch] = []
+    transport = _BlockingRegisterTransport(observer=observed.append)
+    task = asyncio.create_task(RegisterDataMixin.read_parameters(transport, 10, 1))
+    await transport.read_started.wait()
+
+    transport.set_register_observer(None)
+    transport.release_read.set()
+
+    assert await task == {10: 0}
+    assert observed == []
+
+
+@pytest.mark.asyncio
+async def test_scheduled_dispatch_rereads_observer_after_detach(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A callback task queued before detach must consult the slot when it runs."""
+    observed: list[ObservationBatch] = []
+    transport = _FakeRegisterTransport(observer=observed.append)
+    observation = (RegisterObservation(RegisterSpace.HOLDING, (RegisterSegment(10, (0,)),)),)
+    scheduled = asyncio.Event()
+    release = asyncio.Event()
+    original_create_task = asyncio.create_task
+
+    def gated_create_task(coro: Awaitable[None]) -> asyncio.Task[None]:
+        async def gated() -> None:
+            scheduled.set()
+            await release.wait()
+            await coro
+
+        return original_create_task(gated())
+
+    monkeypatch.setattr(asyncio, "create_task", gated_create_task)
+    dispatch = original_create_task(transport._notify_register_observer(observation))
+    await scheduled.wait()
+
+    transport.set_register_observer(None)
+    release.set()
+    await dispatch
+
+    assert observed == []
+
+
+def test_detach_revokes_clears_and_rejects_late_capture_appends() -> None:
+    observed: list[ObservationBatch] = []
+    transport = _FakeRegisterTransport(observer=observed.append)
+    capture = transport._new_observed_segments()
+    assert isinstance(capture, _RegisterCapture)
+    _append_observed_segment(capture, 10, [1])
+
+    transport.set_register_observer(None)
+    _append_observed_segment(capture, 11, [2])
+
+    assert capture == []
+    assert capture.is_active is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public_read", PUBLIC_OBSERVATION_READS)
+async def test_detached_observer_uses_zero_overhead_path_on_every_public_read(
+    monkeypatch: pytest.MonkeyPatch,
+    public_read: PublicRead,
+) -> None:
+    baseline = _FakeRegisterTransport()
+    baseline_result = await public_read(baseline)
+    observed: list[ObservationBatch] = []
+    detached = _FakeRegisterTransport(observer=observed.append)
+    detached.set_register_observer(None)
+    capture_calls = 0
+    publication_calls = 0
+    capture_states: list[_RegisterCapture | None] = []
+    original_append = register_data_module._append_observed_segment
+    original_new = RegisterDataMixin._new_observed_segments
+    original_notify = RegisterDataMixin._notify_observed_segments
+
+    def count_capture_calls(
+        segments: _RegisterCapture,
+        start: int,
+        values: Sequence[int],
+    ) -> None:
+        nonlocal capture_calls
+        capture_calls += 1
+        original_append(segments, start, values)
+
+    def record_capture_state(self: RegisterDataMixin) -> _RegisterCapture | None:
+        state = original_new(self)
+        capture_states.append(state)
+        return state
+
+    async def count_publication_calls(
+        self: RegisterDataMixin,
+        *captured: tuple[RegisterSpace, Sequence[RegisterSegment] | None],
+    ) -> None:
+        nonlocal publication_calls
+        publication_calls += 1
+        await original_notify(self, *captured)
+
+    monkeypatch.setattr(register_data_module, "_append_observed_segment", count_capture_calls)
+    monkeypatch.setattr(RegisterDataMixin, "_new_observed_segments", record_capture_state)
+    monkeypatch.setattr(RegisterDataMixin, "_notify_observed_segments", count_publication_calls)
+
+    detached_result = await public_read(detached)
+
+    assert _without_timestamps(detached_result) == _without_timestamps(baseline_result)
+    assert detached.reads == baseline.reads
+    assert capture_states and all(state is None for state in capture_states)
+    assert capture_calls == 0
+    assert publication_calls == 0
+    assert observed == []
+
+
+@pytest.mark.asyncio
+async def test_detach_reattach_is_idempotent_preserves_counter_and_does_not_reconnect() -> None:
+    old_observer = MagicMock(side_effect=RuntimeError("old observer"))
+    new_observer = MagicMock()
+    transport = _FakeRegisterTransport(observer=old_observer)
+    transport.connect = AsyncMock()
+    transport.disconnect = AsyncMock()
+    await transport.read_parameters(10, 1)
+    assert transport.register_observation_error_count == 1
+
+    transport.set_register_observer(None)
+    transport.set_register_observer(None)
+    transport.set_register_observer(new_observer)
+    transport.set_register_observer(new_observer)
+    await transport.read_parameters(11, 1)
+
+    assert transport.register_observation_error_count == 1
+    old_observer.assert_called_once()
+    new_observer.assert_called_once()
+    transport.connect.assert_not_awaited()
+    transport.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reattach_dispatches_only_to_replacement_observer() -> None:
+    old_observer = MagicMock()
+    new_observer = MagicMock()
+    transport = _FakeRegisterTransport(observer=old_observer)
+
+    transport.set_register_observer(None)
+    transport.set_register_observer(new_observer)
+    await transport.read_parameters(10, 1)
+
+    old_observer.assert_not_called()
+    new_observer.assert_called_once()

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import logging
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import asdict, is_dataclass
@@ -534,6 +535,93 @@ async def test_scheduled_dispatch_rereads_observer_after_detach(
     await dispatch
 
     assert observed == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reuse_observer", [False, True], ids=["replacement", "same-identity"])
+async def test_scheduled_dispatch_rejects_detach_reattach_aba(
+    monkeypatch: pytest.MonkeyPatch,
+    reuse_observer: bool,
+) -> None:
+    old_observer = MagicMock()
+    new_observer = old_observer if reuse_observer else MagicMock()
+    transport = _FakeRegisterTransport(observer=old_observer)
+    observation = (RegisterObservation(RegisterSpace.HOLDING, (RegisterSegment(10, (0,)),)),)
+    scheduled = asyncio.Event()
+    release = asyncio.Event()
+    original_create_task = asyncio.create_task
+
+    def gated_create_task(coro: Awaitable[None]) -> asyncio.Task[None]:
+        async def gated() -> None:
+            scheduled.set()
+            await release.wait()
+            await coro
+
+        return original_create_task(gated())
+
+    monkeypatch.setattr(asyncio, "create_task", gated_create_task)
+    dispatch = original_create_task(transport._notify_register_observer(observation))
+    await scheduled.wait()
+
+    transport.set_register_observer(None)
+    transport.set_register_observer(new_observer)
+    release.set()
+    await dispatch
+
+    old_observer.assert_not_called()
+    if not reuse_observer:
+        new_observer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_coroutine_return_is_closed_and_counted_once(
+    recwarn: pytest.WarningsRecorder,
+) -> None:
+    ran = False
+
+    async def malformed_return() -> None:
+        nonlocal ran
+        ran = True
+
+    def observer(observations: ObservationBatch) -> object:
+        return malformed_return()
+
+    transport = _FakeRegisterTransport(observer=observer)
+
+    result = await transport.read_parameters(10, 1)
+    gc.collect()
+
+    assert result == {10: 0}
+    assert ran is False
+    assert transport.register_observation_error_count == 1
+    assert not [warning for warning in recwarn if issubclass(warning.category, RuntimeWarning)]
+
+
+@pytest.mark.parametrize("return_task", [False, True], ids=["future", "task"])
+@pytest.mark.asyncio
+async def test_future_return_is_cancelled_and_counted_once(return_task: bool) -> None:
+    returned: list[asyncio.Future[None]] = []
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    def malformed_return(observations: ObservationBatch) -> object:
+        value: asyncio.Future[None]
+        if return_task:
+            value = asyncio.create_task(wait_forever())
+        else:
+            value = asyncio.get_running_loop().create_future()
+        returned.append(value)
+        return value
+
+    transport = _FakeRegisterTransport(observer=malformed_return)
+
+    result = await transport.read_parameters(10, 1)
+    await asyncio.sleep(0)
+
+    assert result == {10: 0}
+    assert transport.register_observation_error_count == 1
+    assert returned[0].cancelled()
 
 
 def test_detach_revokes_clears_and_rejects_late_capture_appends() -> None:

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -194,9 +194,6 @@ def _without_timestamps(value: object) -> object:
         payload = asdict(value)
         payload.pop("timestamp", None)
         return payload
-    model_dump = getattr(value, "model_dump", None)
-    if callable(model_dump):
-        return model_dump(exclude={"timestamp"})
     return value
 
 
@@ -423,12 +420,18 @@ async def test_canonical_readers_observe_enabled_terminal_segment_without_extra_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("public_read", PUBLIC_OBSERVATION_READS)
-async def test_default_observer_skips_capture_on_every_public_read(
+@pytest.mark.parametrize("detach_after_init", [False, True], ids=["default", "detached"])
+async def test_disabled_observer_skips_capture_on_every_public_read(
     monkeypatch: pytest.MonkeyPatch,
     public_read: PublicRead,
+    detach_after_init: bool,
 ) -> None:
     baseline = _FakeRegisterTransport()
-    await public_read(baseline)
+    baseline_result = await public_read(baseline)
+    observed: list[ObservationBatch] = []
+    disabled = _FakeRegisterTransport(observer=observed.append if detach_after_init else None)
+    if detach_after_init:
+        disabled.set_register_observer(None)
     capture_calls = 0
     publication_calls = 0
     capture_states: list[list[RegisterSegment] | None] = []
@@ -461,14 +464,15 @@ async def test_default_observer_skips_capture_on_every_public_read(
     monkeypatch.setattr(register_data_module, "_append_observed_segment", count_capture_calls)
     monkeypatch.setattr(RegisterDataMixin, "_new_observed_segments", record_capture_state)
     monkeypatch.setattr(RegisterDataMixin, "_notify_observed_segments", count_publication_calls)
-    disabled = _FakeRegisterTransport()
 
-    await public_read(disabled)
+    disabled_result = await public_read(disabled)
 
+    assert _without_timestamps(disabled_result) == _without_timestamps(baseline_result)
     assert disabled.reads == baseline.reads
     assert capture_states and all(state is None for state in capture_states)
     assert capture_calls == 0
     assert publication_calls == 0
+    assert observed == []
 
 
 @pytest.mark.asyncio
@@ -543,61 +547,7 @@ def test_detach_revokes_clears_and_rejects_late_capture_appends() -> None:
     _append_observed_segment(capture, 11, [2])
 
     assert capture == []
-    assert capture.is_active is False
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("public_read", PUBLIC_OBSERVATION_READS)
-async def test_detached_observer_uses_zero_overhead_path_on_every_public_read(
-    monkeypatch: pytest.MonkeyPatch,
-    public_read: PublicRead,
-) -> None:
-    baseline = _FakeRegisterTransport()
-    baseline_result = await public_read(baseline)
-    observed: list[ObservationBatch] = []
-    detached = _FakeRegisterTransport(observer=observed.append)
-    detached.set_register_observer(None)
-    capture_calls = 0
-    publication_calls = 0
-    capture_states: list[_RegisterCapture | None] = []
-    original_append = register_data_module._append_observed_segment
-    original_new = RegisterDataMixin._new_observed_segments
-    original_notify = RegisterDataMixin._notify_observed_segments
-
-    def count_capture_calls(
-        segments: _RegisterCapture,
-        start: int,
-        values: Sequence[int],
-    ) -> None:
-        nonlocal capture_calls
-        capture_calls += 1
-        original_append(segments, start, values)
-
-    def record_capture_state(self: RegisterDataMixin) -> _RegisterCapture | None:
-        state = original_new(self)
-        capture_states.append(state)
-        return state
-
-    async def count_publication_calls(
-        self: RegisterDataMixin,
-        *captured: tuple[RegisterSpace, Sequence[RegisterSegment] | None],
-    ) -> None:
-        nonlocal publication_calls
-        publication_calls += 1
-        await original_notify(self, *captured)
-
-    monkeypatch.setattr(register_data_module, "_append_observed_segment", count_capture_calls)
-    monkeypatch.setattr(RegisterDataMixin, "_new_observed_segments", record_capture_state)
-    monkeypatch.setattr(RegisterDataMixin, "_notify_observed_segments", count_publication_calls)
-
-    detached_result = await public_read(detached)
-
-    assert _without_timestamps(detached_result) == _without_timestamps(baseline_result)
-    assert detached.reads == baseline.reads
-    assert capture_states and all(state is None for state in capture_states)
-    assert capture_calls == 0
-    assert publication_calls == 0
-    assert observed == []
+    assert capture.active is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import gc
 import logging
+import types
+import weakref
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import asdict, is_dataclass
 from unittest.mock import AsyncMock, MagicMock
@@ -574,6 +576,48 @@ async def test_scheduled_dispatch_rejects_detach_reattach_aba(
 
 
 @pytest.mark.asyncio
+async def test_detach_releases_callback_while_dispatch_is_gated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[ObservationBatch] = []
+
+    class Observer:
+        def __call__(self, observations: ObservationBatch) -> None:
+            observed.append(observations)
+
+    observer = Observer()
+    observer_ref = weakref.ref(observer)
+    transport = _FakeRegisterTransport(observer=observer)
+    observation = (RegisterObservation(RegisterSpace.HOLDING, (RegisterSegment(10, (0,)),)),)
+    scheduled = asyncio.Event()
+    release = asyncio.Event()
+    original_create_task = asyncio.create_task
+
+    def gated_create_task(coro: Awaitable[None]) -> asyncio.Task[None]:
+        async def gated() -> None:
+            scheduled.set()
+            await release.wait()
+            await coro
+
+        return original_create_task(gated())
+
+    monkeypatch.setattr(asyncio, "create_task", gated_create_task)
+    dispatch = original_create_task(transport._notify_register_observer(observation))
+    await scheduled.wait()
+
+    transport.set_register_observer(None)
+    del observer
+    try:
+        gc.collect()
+        assert observer_ref() is None
+    finally:
+        release.set()
+        await dispatch
+
+    assert observed == []
+
+
+@pytest.mark.asyncio
 async def test_coroutine_return_is_closed_and_counted_once(
     recwarn: pytest.WarningsRecorder,
 ) -> None:
@@ -589,7 +633,9 @@ async def test_coroutine_return_is_closed_and_counted_once(
     transport = _FakeRegisterTransport(observer=observer)
 
     result = await transport.read_parameters(10, 1)
+    await asyncio.sleep(0)
     gc.collect()
+    await asyncio.sleep(0)
 
     assert result == {10: 0}
     assert ran is False
@@ -601,6 +647,7 @@ async def test_coroutine_return_is_closed_and_counted_once(
 @pytest.mark.asyncio
 async def test_future_return_is_cancelled_and_counted_once(return_task: bool) -> None:
     returned: list[asyncio.Future[None]] = []
+    baseline_tasks = asyncio.all_tasks()
 
     async def wait_forever() -> None:
         await asyncio.Event().wait()
@@ -622,6 +669,125 @@ async def test_future_return_is_cancelled_and_counted_once(return_task: bool) ->
     assert result == {10: 0}
     assert transport.register_observation_error_count == 1
     assert returned[0].cancelled()
+    assert asyncio.all_tasks() == baseline_tasks
+
+
+@pytest.mark.parametrize("return_task", [False, True], ids=["future", "task"])
+@pytest.mark.parametrize("outcome", ["success", "failure", "cancelled"])
+@pytest.mark.asyncio
+async def test_completed_future_return_is_retrieved_and_counted_once(
+    return_task: bool,
+    outcome: str,
+) -> None:
+    loop = asyncio.get_running_loop()
+    loop_errors: list[dict[str, object]] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda loop, context: loop_errors.append(context))
+    baseline_tasks = asyncio.all_tasks()
+
+    async def complete() -> None:
+        if outcome == "failure":
+            raise RuntimeError("malformed callback result")
+
+    if return_task:
+        returned: asyncio.Future[None] = asyncio.create_task(complete())
+        if outcome == "cancelled":
+            returned.cancel()
+        await asyncio.sleep(0)
+    else:
+        returned = loop.create_future()
+        if outcome == "success":
+            returned.set_result(None)
+        elif outcome == "failure":
+            returned.set_exception(RuntimeError("malformed callback result"))
+        else:
+            returned.cancel()
+    holder = [returned]
+
+    def observer(observations: ObservationBatch) -> object:
+        return holder.pop()
+
+    transport = _FakeRegisterTransport(observer=observer)
+    try:
+        result = await transport.read_parameters(10, 1)
+
+        assert result == {10: 0}
+        assert transport.register_observation_error_count == 1
+        assert returned.done()
+
+        del returned
+        gc.collect()
+        await asyncio.sleep(0)
+        assert loop_errors == []
+        assert asyncio.all_tasks() == baseline_tasks
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+
+@pytest.mark.asyncio
+async def test_generic_awaitable_return_is_discarded_without_execution() -> None:
+    started = False
+
+    class GenericAwaitable:
+        def __await__(self):
+            nonlocal started
+            started = True
+            yield
+
+    awaitable = GenericAwaitable()
+    awaitable_ref = weakref.ref(awaitable)
+    holder = [awaitable]
+    baseline_tasks = asyncio.all_tasks()
+
+    def observer(observations: ObservationBatch) -> object:
+        return holder.pop()
+
+    transport = _FakeRegisterTransport(observer=observer)
+
+    result = await transport.read_parameters(10, 1)
+    await asyncio.sleep(0)
+    del awaitable
+    gc.collect()
+
+    assert result == {10: 0}
+    assert started is False
+    assert awaitable_ref() is None
+    assert transport.register_observation_error_count == 1
+    assert asyncio.all_tasks() == baseline_tasks
+
+
+@pytest.mark.asyncio
+async def test_generator_awaitable_return_uses_standard_close_hook() -> None:
+    closed = False
+
+    @types.coroutine
+    def generator_awaitable():
+        nonlocal closed
+        try:
+            yield
+        finally:
+            closed = True
+
+    awaitable = generator_awaitable()
+    next(awaitable)
+    transport = _FakeRegisterTransport(observer=lambda observations: awaitable)
+
+    result = await transport.read_parameters(10, 1)
+
+    assert result == {10: 0}
+    assert closed is True
+    assert transport.register_observation_error_count == 1
+
+
+@pytest.mark.parametrize("malformed", [0, "value", object()], ids=["zero", "string", "object"])
+@pytest.mark.asyncio
+async def test_non_none_return_is_counted_once(malformed: object) -> None:
+    transport = _FakeRegisterTransport(observer=lambda observations: malformed)
+
+    result = await transport.read_parameters(10, 1)
+
+    assert result == {10: 0}
+    assert transport.register_observation_error_count == 1
 
 
 def test_detach_revokes_clears_and_rejects_late_capture_appends() -> None:
@@ -641,7 +807,7 @@ def test_detach_revokes_clears_and_rejects_late_capture_appends() -> None:
 @pytest.mark.asyncio
 async def test_detach_reattach_is_idempotent_preserves_counter_and_does_not_reconnect() -> None:
     old_observer = MagicMock(side_effect=RuntimeError("old observer"))
-    new_observer = MagicMock()
+    new_observer = MagicMock(return_value=None)
     transport = _FakeRegisterTransport(observer=old_observer)
     transport.connect = AsyncMock()
     transport.disconnect = AsyncMock()
@@ -663,8 +829,8 @@ async def test_detach_reattach_is_idempotent_preserves_counter_and_does_not_reco
 
 @pytest.mark.asyncio
 async def test_reattach_dispatches_only_to_replacement_observer() -> None:
-    old_observer = MagicMock()
-    new_observer = MagicMock()
+    old_observer = MagicMock(return_value=None)
+    new_observer = MagicMock(return_value=None)
     transport = _FakeRegisterTransport(observer=old_observer)
 
     transport.set_register_observer(None)

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -200,6 +200,29 @@ def _without_timestamps(value: object) -> object:
     return value
 
 
+def _gate_observer_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: _FakeRegisterTransport,
+    observations: ObservationBatch,
+) -> tuple[asyncio.Task[None], asyncio.Event, asyncio.Event]:
+    """Delay the observer task while leaving its caller runnable."""
+    scheduled = asyncio.Event()
+    release = asyncio.Event()
+    original_create_task = asyncio.create_task
+
+    def gated_create_task(coro: Awaitable[None]) -> asyncio.Task[None]:
+        async def gated() -> None:
+            scheduled.set()
+            await release.wait()
+            await coro
+
+        return original_create_task(gated())
+
+    monkeypatch.setattr(asyncio, "create_task", gated_create_task)
+    dispatch = original_create_task(transport._notify_register_observer(observations))
+    return dispatch, scheduled, release
+
+
 def test_register_observation_repr_redacts_raw_words_from_diagnostics(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -516,20 +539,7 @@ async def test_scheduled_dispatch_rereads_observer_after_detach(
     observed: list[ObservationBatch] = []
     transport = _FakeRegisterTransport(observer=observed.append)
     observation = (RegisterObservation(RegisterSpace.HOLDING, (RegisterSegment(10, (0,)),)),)
-    scheduled = asyncio.Event()
-    release = asyncio.Event()
-    original_create_task = asyncio.create_task
-
-    def gated_create_task(coro: Awaitable[None]) -> asyncio.Task[None]:
-        async def gated() -> None:
-            scheduled.set()
-            await release.wait()
-            await coro
-
-        return original_create_task(gated())
-
-    monkeypatch.setattr(asyncio, "create_task", gated_create_task)
-    dispatch = original_create_task(transport._notify_register_observer(observation))
+    dispatch, scheduled, release = _gate_observer_dispatch(monkeypatch, transport, observation)
     await scheduled.wait()
 
     transport.set_register_observer(None)
@@ -549,20 +559,7 @@ async def test_scheduled_dispatch_rejects_detach_reattach_aba(
     new_observer = old_observer if reuse_observer else MagicMock()
     transport = _FakeRegisterTransport(observer=old_observer)
     observation = (RegisterObservation(RegisterSpace.HOLDING, (RegisterSegment(10, (0,)),)),)
-    scheduled = asyncio.Event()
-    release = asyncio.Event()
-    original_create_task = asyncio.create_task
-
-    def gated_create_task(coro: Awaitable[None]) -> asyncio.Task[None]:
-        async def gated() -> None:
-            scheduled.set()
-            await release.wait()
-            await coro
-
-        return original_create_task(gated())
-
-    monkeypatch.setattr(asyncio, "create_task", gated_create_task)
-    dispatch = original_create_task(transport._notify_register_observer(observation))
+    dispatch, scheduled, release = _gate_observer_dispatch(monkeypatch, transport, observation)
     await scheduled.wait()
 
     transport.set_register_observer(None)
@@ -589,20 +586,7 @@ async def test_detach_releases_callback_while_dispatch_is_gated(
     observer_ref = weakref.ref(observer)
     transport = _FakeRegisterTransport(observer=observer)
     observation = (RegisterObservation(RegisterSpace.HOLDING, (RegisterSegment(10, (0,)),)),)
-    scheduled = asyncio.Event()
-    release = asyncio.Event()
-    original_create_task = asyncio.create_task
-
-    def gated_create_task(coro: Awaitable[None]) -> asyncio.Task[None]:
-        async def gated() -> None:
-            scheduled.set()
-            await release.wait()
-            await coro
-
-        return original_create_task(gated())
-
-    monkeypatch.setattr(asyncio, "create_task", gated_create_task)
-    dispatch = original_create_task(transport._notify_register_observer(observation))
+    dispatch, scheduled, release = _gate_observer_dispatch(monkeypatch, transport, observation)
     await scheduled.wait()
 
     transport.set_register_observer(None)


### PR DESCRIPTION
## Summary

- export a narrow runtime-checkable `RegisterObserverControl` without widening existing transport protocols
- synchronously detach/replace observers, revoke enabled in-flight capture buffers, and suppress queued dispatch after detach or detach/reattach ABA without retaining detached callbacks
- require synchronous observers to return exactly `None`; close native/standard coroutine forms, cancel pending Future/Task returns, consume completed outcomes, and reject opaque awaitables/scalars without scheduling work
- delegate Hybrid observer control to the local transport only
- cover direct unlocked reads, queued dispatch generation, callback collectability, capture revocation, disabled fast paths, reattachment, exhaustive malformed returns, protocol compatibility, and lifecycle invariants

## Validation

- focused observer/protocol/Hybrid tests: 99 passed
- full local suite: 3309 passed, 4 skipped, 80 deselected
- Ruff check and format: passed
- strict mypy: passed
- `uv lock --check`, `uv build`, and `twine check`: passed
- mutation RED/GREEN audit completed for every new/materially changed test

Closes #284