### PR TITLE
Return None for an unreported state of health instead of 100

### DIFF
--- a/src/pylxpweb/transports/data.py
+++ b/src/pylxpweb/transports/data.py
@@ -633,7 +633,7 @@ class InverterRuntimeData:
                         soc = raw & 0xFF
                         soh = (raw >> 8) & 0xFF
                         if soh == 0:
-                            soh = 100  # Default to 100% if not reported
+                            soh = None  # not reported; absent, not perfect health
                         kwargs["battery_soc"] = soc
                         kwargs["battery_soh"] = soh
                 elif reg.canonical_name == "parallel_config":
@@ -1318,7 +1318,7 @@ class BatteryData:
             voltage=float(kwargs.get("voltage", 0.0)),
             current=float(kwargs.get("current", 0.0)),
             soc=soc,
-            soh=soh if soh > 0 else 100,
+            soh=soh if soh > 0 else None,
             temperature=max_cell_temp,
             max_capacity=max_capacity,
             current_capacity=current_capacity,
@@ -1735,7 +1735,7 @@ class BatteryBankData:
 
         actual_soh: int | None = battery_soh
         if battery_soh is not None and battery_soh == 0:
-            actual_soh = 100  # 0 is invalid, assume healthy
+            actual_soh = None  # not reported; absent, not perfect health
 
         return cls(
             timestamp=datetime.now(),


### PR DESCRIPTION
# Return None for an unreported state of health instead of 100

## The behaviour

`transports/data.py` substitutes 100 for a state-of-health of 0, on three paths. Line numbers are `main` at 0.10.0b2, with the released 0.9.38 alongside — the code is identical in both:

| main | 0.9.38 | code |
|---|---|---|
| 636 | 636 | `if soh == 0: soh = 100  # Default to 100% if not reported` |
| 1321 | 1292 | `soh=soh if soh > 0 else 100,` |
| 1738 | 1707 | `if battery_soh is not None and battery_soh == 0: actual_soh = 100  # 0 is invalid, assume healthy` |

Every other value passes through unchanged. This needs nothing but `pylxpweb`:

```python
from pylxpweb.transports.data import BatteryBankData, InverterRuntimeData

BASE = {4: 537, 101: 3364, 102: 3358, 106: 11200}   # cell voltages + capacity present
reg5 = lambda soc, soh: (soh << 8) | soc            # SOC low byte, SOH high byte

print(f"  {'SOH byte':>10s}  {'battery_soh':>12s}  {'_raw_soh':>9s}")
for soh in (0, 1, 5, 40, 80, 99, 100):
    r = InverterRuntimeData.from_modbus_registers({**BASE, 5: reg5(64, soh)}, "EG4_HYBRID")
    print(f"  {soh:>10d}  {r.battery_soh:>12}  {r._raw_soh:>9}")

for soh in (0, 1, 100):
    bank = BatteryBankData.from_modbus_registers({**BASE, 5: reg5(64, soh)})
    print(f"  bank soh={soh:<4d} -> {None if bank is None else bank.soh}")
```

Output, identical on 0.9.38 and on `main` at 0.10.0b2:

```
    SOH byte   battery_soh   _raw_soh
           0           100        100   <- substituted
           1             1          1
           5             5          5
          40            40         40
          80            80         80
          99            99         99
         100           100        100

  bank soh=0    -> 100
  bank soh=1    -> 1
  bank soh=100  -> 100
```

A pack reporting 1% health reports 1%. A pack reporting 0% reports 100%.

## The proposal

**Return `None` rather than 100 for the unreported case.** Three lines:

```diff
-                        if soh == 0:
-                            soh = 100  # Default to 100% if not reported
+                        if soh == 0:
+                            soh = None  # not reported; absent, not perfect health

-            soh=soh if soh > 0 else 100,
+            soh=soh if soh > 0 else None,

-        if battery_soh is not None and battery_soh == 0:
-            actual_soh = 100  # 0 is invalid, assume healthy
+        if battery_soh is not None and battery_soh == 0:
+            actual_soh = None  # not reported; absent, not perfect health
```

This keeps your reading of the hardware. The comments say a zero means the field was not reported, and that is almost certainly right — a pack at literally 0% health while still answering on CAN would be remarkable, and its reported capacity would have collapsed long before the figure did. The interpretation is not the issue; the value chosen to express it is. `None` says "not reported". `100` says "perfect health", which is a different claim and a confident one.

`None` is also never wrong under either reading. If a zero means the field is absent, `None` is exactly right. If a zero ever means a genuinely failed pack, `None` is merely silent where `100` is actively false.

The field is already `int | None`, and Home Assistant renders `None` as *unknown*, so downstream displays degrade to an honest gap rather than to an alarming zero.

## Why not a smaller change

The lighter touch would be to assign `_raw_soh` *before* the substitution rather than after. It is currently set in `__post_init__` (0.9.38 lines 315, 1044, 1420), by which point `from_modbus_registers` has already substituted — so despite its comment, *"Pre-clamp raw values for corruption detection"*, it holds 100 too, as the table above shows. The `Canary: raw_soh=%d > 100` warnings only fire above 100 and never trip on this.

Moving that assignment would let a consumer distinguish the two cases, and would be enough to unblock me specifically. I would rather not propose it. It leaves a pack reporting 100% to every consumer that does not know to reach for a private attribute — including anyone reading the Home Assistant sensor directly — and a leading-underscore field is not a contract anyone should have to depend on. It would hide the defect rather than remove it.

## Tests

`tests/unit` on `main` with the change applied: **3221 passed, 1 failed**. The single failure, `test_register_observation_repr_redacts_raw_words_from_diagnostics`, fails identically on stock `main` and is unrelated.

The two tests asserting `soh == 100` are unaffected: one checks a dataclass default, the other a fixture whose SOH byte genuinely is 100. The substitution itself has no test.

## Why I went looking

In my project, [ArraySense](https://github.com/sjordan0228/arraysense) — solar and battery monitoring for EG4 and LuxPower inverters — reading an EG4 18kPV over RS485, with four EG4 indoor 280 Ah batteries.

Because a genuine 100 and a substituted 100 are the same value, I refused 100 outright rather than store a figure that might be invented. That cost me **every state-of-health reading, on all four packs, for seven consecutive days**, on a bank that was healthy throughout:

```
day            pack1  pack2  pack3  pack4
2026-08-08        —      —      —      —
   ... every day ...
2026-08-14        —      —      —      —
2026-08-15    99-99  99-99  99-99      —
```

A battery firmware update on the 15th moved three packs from reporting 100 to reporting 99, and they became visible immediately. The fourth is genuinely at 100%, confirmed in EG4's own app, and stayed hidden.

I then ran the patch above on that installation, against 0.9.38, alongside the change on my side that trusts a reported 100. All four packs now record:

```
Battery_ID_01  soh=99
Battery_ID_02  soh=99
Battery_ID_03  soh=99
Battery_ID_04  soh=100   <- eight days of nothing, now correct
```

Collector connected throughout, no gaps, no errors. Every figure in this report was produced by running the code.

Happy to adjust the shape if you would rather express absence differently — a `soh_reported: bool` beside the value, or something else. The substitution is the part I think is worth changing.

---

*Separately, and not part of this PR: the same block-level assumption appears to affect temperature. During that firmware update one pack recorded 0 °C for four consecutive samples while its cell voltages and capacity read normally — so a per-block "the BMS answered" check passes while an individual field is still zero-filled. Four rows in a year of history, so hardly urgent, but I can file it with the capture if useful.*
