### PR TITLE
chore(release): prepare 0.10.0b3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the new runtime-checkable `RegisterObserverControl` capability lets callers
   use `set_register_observer(...)` on concrete local transports to replace or
   detach their synchronous register observer without reconnecting. Hybrid
-  transports delegate that control only to their local transport. A change
-  revokes enabled captures that have not reached observer dispatch and rejects
-  queued dispatch from an older observer generation; it does not cancel or
-  drain transport operations, and it does not widen the existing transport
-  protocols. Observer callbacks must still return `None`; a borrowed
-  `Future` or `Task` returned in error is rejected without being cancelled.
+  transports apply the change only to their local transport. Observations
+  still being captured or queued for delivery are not sent to the previous
+  observer after a change. Existing structural transport protocols remain
+  unchanged, and observers remain synchronous callbacks that return `None`.
 
 ## [0.10.0b2] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0b3] - 2026-08-16
+
+### Added
+
+- **Runtime register-observer replacement and detach control**
+  ([#284](https://github.com/joyfulhouse/pylxpweb/issues/284), PR
+  [#285](https://github.com/joyfulhouse/pylxpweb/pull/285), release issue
+  [#287](https://github.com/joyfulhouse/pylxpweb/issues/287)):
+  the new runtime-checkable `RegisterObserverControl` capability lets callers
+  use `set_register_observer(...)` on concrete local transports to replace or
+  detach their synchronous register observer without reconnecting. Hybrid
+  transports delegate that control only to their local transport. A change
+  revokes enabled captures that have not reached observer dispatch and rejects
+  queued dispatch from an older observer generation; it does not cancel or
+  drain transport operations, and it does not widen the existing transport
+  protocols. Observer callbacks must still return `None`; a borrowed
+  `Future` or `Task` returned in error is rejected without being cancelled.
+
 ## [0.10.0b2] - 2026-08-15
 
 ### Added
@@ -2660,7 +2678,8 @@ ac_power = inverter.ac_charge_power_limit  # Property access (uses 1-hour cache)
 - **v0.1.1** (2025-11-15): Bug fixes and improvements
 - **v0.1.0** (2025-11-14): Initial release with core functionality
 
-[Unreleased]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b2...HEAD
+[Unreleased]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b3...HEAD
+[0.10.0b3]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b2...v0.10.0b3
 [0.10.0b2]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b1...v0.10.0b2
 [0.10.0b1]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.39b11...v0.10.0b1
 [0.9.32]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.29...v0.9.32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.10.0b2"
+version = "0.10.0b3"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1172,7 +1172,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.10.0b2"
+version = "0.10.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- bump the project and lockfile self-version from `0.10.0b2` to `0.10.0b3`
- add the dated `0.10.0b3` Keep a Changelog entry for the runtime register-observer control merged in #285
- add the `0.10.0b3` compare-link definition using the existing `v0.10.0b2` tag and advance the `Unreleased` comparison base
- keep the release-preparation diff limited to `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`

## Why

PR #285 added an optional public runtime capability for replacing or detaching a synchronous local register observer without reconnecting. This PR prepares the next beta metadata so that capability is documented accurately and can be packaged as `0.10.0b3` in a separate release operation.

## Public contract

The runtime-checkable `RegisterObserverControl` exposes `set_register_observer(...)` on concrete local transports; Hybrid applies the change only to its local transport. Observations still being captured or queued for delivery are not sent to the previous observer after a change. Existing structural transport protocols remain unchanged, and observers remain synchronous callbacks that return `None`.

## User impact

Consumers of the eventual `0.10.0b3` prerelease can replace or detach a supported local register observer at runtime without reconnecting the transport. Existing callers and transport protocols remain compatible.

## Validation

- [x] `uv lock --check` — resolved 70 packages with no lockfile changes
- [x] `uv sync --all-extras --frozen` — installed pylxpweb `0.10.0b3`
- [x] version consistency script — `pyproject.toml`, `uv.lock`, and installed metadata all report `0.10.0b3`
- [x] changelog footer check — `0.10.0b3` resolves to `v0.10.0b2...v0.10.0b3`; `Unreleased` resolves to `v0.10.0b3...HEAD`
- [x] `uv run ruff check src/ tests/` — passed
- [x] `uv run ruff format --check src/ tests/` — 220 files already formatted
- [x] `uv run mypy --strict src/pylxpweb/` — passed for 95 source files
- [x] `uv run pytest tests/unit/ --cov=pylxpweb --cov-report=term-missing -q` — 3,272 passed; 89.59% coverage
- [x] `uv run pytest -q` — 3,310 passed, 4 skipped, 80 deselected
- [x] `uv build` — wheel and sdist built successfully
- [x] `uv run twine check dist/*` — both distributions passed
- [x] wheel `METADATA` and sdist `PKG-INFO` — both report `Name: pylxpweb` and `Version: 0.10.0b3`
- [x] `git diff --check` — passed

## Lockfile and scope

- [x] `uv lock` changed only the editable `pylxpweb` self-version from `0.10.0b2` to `0.10.0b3`; no dependency drift
- [x] changed paths are exactly `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`
- [x] no source, tests, workflows, generated process docs, package-publication files, or downstream dependency pins changed

## Mutation testing

No tests were added or materially changed, so mutation evidence is not applicable.

## Release safety

- [x] confirmed `v0.10.0b2` exists and resolves to commit `0f5a664a53d9a09594eb22b06983b54969250dd2`
- [x] confirmed immediately before committing that no `v0.10.0b3` tag, GitHub release, or PyPI release exists
- [x] confirmed `release.yml` runs only for a published GitHub release or manual dispatch, not for a normal PR merge
- [x] no tag or GitHub release created
- [x] no TestPyPI/PyPI upload performed
- [x] no release workflow manually triggered
- [x] merging this metadata-preparation PR does not create a tag, release, or package publication

Closes #287
