### PR TITLE
ci: harden release artifact promotion

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -29,21 +29,29 @@ Publishing is a four-job promotion chain:
 1. `build` resolves the release's existing `v*` tag, peels it to a commit and
    tree, and checks that the tag version, project metadata, release event, release
    target, checked-out commit, and `origin/main` ancestry agree. It builds exactly
-   one wheel and one source distribution from a locked, unchanged checkout, runs
-   `twine check`, records source identity in `release-source.json`, and records
-   each distribution and the source manifest in `SHA256SUMS`.
+   one wheel and one source distribution under Python 3.13 from a locked,
+   unchanged checkout, runs `twine check`, records source identity in
+   `release-source.json`, and records each distribution and the source manifest
+   in `SHA256SUMS`.
 2. `publish-testpypi` downloads and revalidates that one named Actions artifact,
    then publishes it to TestPyPI with trusted publishing. `skip-existing` is
    permitted here so an interrupted release can resume at the verification gate.
 3. `verify-testpypi` is unprivileged. It downloads and revalidates the original
    Actions artifact, polls the exact TestPyPI name and version with bounded
-   retries, requires the exact non-yanked filename and SHA256 set, downloads the
-   allowlisted HTTPS wheel, and rehashes it. The job installs that local wheel in
-   a clean environment while resolving dependencies only from production PyPI,
-   then validates installed metadata and import behavior.
+   retries, requires the exact non-yanked filename and SHA256 set, then downloads
+   and rehashes both the allowlisted HTTPS wheel and source distribution. The job
+   installs the verified local wheel in a clean Python 3.13 environment while
+   resolving dependencies only from production PyPI, then validates installed
+   metadata and import behavior.
 4. `publish-pypi` runs only after verification succeeds. It again downloads and
-   revalidates the original artifact, then publishes those same bytes to PyPI. It
-   never rebuilds and never uses `skip-existing`.
+   revalidates the original artifact, checks any files already present for the
+   version on PyPI, and accepts only a non-yanked, hash-matching subset of the
+   wheel and source distribution. It stages and publishes only absent files from
+   the original artifact. If the complete exact set already exists, it skips the
+   publisher. It never rebuilds and never uses `skip-existing`. After publication,
+   it polls PyPI with bounded retries until the final filenames, yanked states,
+   and hashes exactly match. An upload race fails the publisher closed and can be
+   retried through the same preflight path.
 
 The build artifact is named from the project version and peeled commit and is
 retained for 30 days. The workflow default permission is `contents: read`; only
@@ -88,8 +96,25 @@ or mutate repository, environment, or package-index settings.
 6. Review the TestPyPI verification result and approve the protected `pypi`
    environment when prompted.
 
-Do not create a second production upload for an existing version. Production
-publication deliberately fails instead of skipping existing files.
+If production publication is interrupted, rerun the same release workflow. The
+preflight accepts matching files already published from the original artifact and
+stages only the absent distribution; it never enables production `skip-existing`.
+
+## Package publishing compromise response
+
+If a release workflow or authorized GitHub identity may be compromised:
+
+1. Cancel active release workflow runs and pending environment approvals.
+2. Disable the `pypi` and `testpypi` environments or remove the corresponding
+   trusted-publisher bindings so no new package-index identity can be minted.
+3. Audit the compromised GitHub identity and revoke its sessions, tokens, and
+   keys. Review repository, environment, release, and package-index audit records
+   for unauthorized changes or publications.
+4. Restore environments and trusted-publisher bindings only after recovery,
+   identity rotation, artifact verification, and review are complete.
+
+Trusted publishing remains secretless. No long-lived package-index credential is
+introduced for normal publication or recovery.
 
 ## Executable builds (`build-executables.yml`)
 

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -46,12 +46,15 @@ Publishing is a four-job promotion chain:
 4. `publish-pypi` runs only after verification succeeds. It again downloads and
    revalidates the original artifact, checks any files already present for the
    version on PyPI, and accepts only a non-yanked, hash-matching subset of the
-   wheel and source distribution. It stages and publishes only absent files from
-   the original artifact. If the complete exact set already exists, it skips the
-   publisher. It never rebuilds and never uses `skip-existing`. After publication,
-   it polls PyPI with bounded retries until the final filenames, yanked states,
-   and hashes exactly match. An upload race fails the publisher closed and can be
-   retried through the same preflight path.
+   wheel and source distribution. The preflight retries transient index failures
+   up to three times while treating a genuine version 404 as an empty set. It
+   stages and publishes only absent files from the original artifact. If the
+   complete exact set already exists, it skips the publisher. It never rebuilds
+   and never uses `skip-existing`. After publication, it polls PyPI with bounded
+   retries until the final filenames, yanked states, and hashes exactly match.
+   The final retry budget leaves at least five minutes of the job timeout for
+   setup and upload. An upload race fails the publisher closed and can be retried
+   through the same preflight path.
 
 The build artifact is named from the project version and peeled commit and is
 retained for 30 days. The workflow default permission is `contents: read`; only

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -1,190 +1,135 @@
-# GitHub Workflows Documentation
+# GitHub Workflows
 
-This document explains the CI/CD setup for pylxpweb.
+This document describes the CI and package-publication paths for pylxpweb. The
+workflow files are the source of truth for their executable details.
 
-## Overview
+## Pull request CI (`ci.yml`)
 
-The project uses a three-stage workflow optimized for efficiency:
+CI runs for pull requests and can also be started manually. It does not run for
+pushes to `main`.
 
-```
-PR → CI runs → Merge to main (no CI rerun) → Tag → Auto-release → Publish to PyPI
-```
+The workflow has four jobs:
 
-## Workflows
+1. `lint` runs Ruff checks, Ruff formatting validation, and strict mypy.
+2. `test` runs the unit suite with coverage and uploads coverage artifacts.
+3. `integration` runs after lint and unit tests in the protected
+   `integration-tests` environment. Dependabot pull requests skip this job.
+4. `ci-success` aggregates the preceding results for branch protection.
 
-### 1. CI Workflow (`ci.yml`)
+## Package release (`release.yml`)
 
-**Trigger**: Pull requests only (not pushes to main)
+The only publishing trigger is a GitHub Release `published` event. Pushing a tag
+does not run this workflow, and a manual dispatch cannot publish to either package
+index.
 
-**Purpose**: Run all quality checks before code is merged
+### Published-release path
 
-**Jobs**:
-- Lint & Type Check (ruff, mypy)
-- Unit Tests (pytest with coverage)
-- Integration Tests (real API tests)
-- CI Success (aggregate status check)
+Publishing is a four-job promotion chain:
 
-**Why no push to main?**
-- Prevents redundant CI runs
-- Branch protection ensures CI passes before merge
-- Code is already tested in the PR
+1. `build` resolves the release's existing `v*` tag, peels it to a commit and
+   tree, and checks that the tag version, project metadata, release event, release
+   target, checked-out commit, and `origin/main` ancestry agree. It builds exactly
+   one wheel and one source distribution from a locked, unchanged checkout, runs
+   `twine check`, records source identity in `release-source.json`, and records
+   each distribution and the source manifest in `SHA256SUMS`.
+2. `publish-testpypi` downloads and revalidates that one named Actions artifact,
+   then publishes it to TestPyPI with trusted publishing. `skip-existing` is
+   permitted here so an interrupted release can resume at the verification gate.
+3. `verify-testpypi` is unprivileged. It downloads and revalidates the original
+   Actions artifact, polls the exact TestPyPI name and version with bounded
+   retries, requires the exact non-yanked filename and SHA256 set, downloads the
+   allowlisted HTTPS wheel, and rehashes it. The job installs that local wheel in
+   a clean environment while resolving dependencies only from production PyPI,
+   then validates installed metadata and import behavior.
+4. `publish-pypi` runs only after verification succeeds. It again downloads and
+   revalidates the original artifact, then publishes those same bytes to PyPI. It
+   never rebuilds and never uses `skip-existing`.
 
-### 2. Release Workflow (`release.yml`)
+The build artifact is named from the project version and peeled commit and is
+retained for 30 days. The workflow default permission is `contents: read`; only
+the two publisher jobs receive `id-token: write`. Production uses the protected
+`pypi` environment, while TestPyPI uses `testpypi`.
 
-**Trigger**: Version tags (`v*.*.*`)
+### Manual validation path
 
-**Purpose**: Automatically create GitHub Release with changelog
-
-**Example**:
-```bash
-git tag v0.3.4
-git push origin v0.3.4
-# → Automatically creates GitHub Release
-```
-
-**What it does**:
-1. Extracts version from tag
-2. Pulls changelog section for that version from CHANGELOG.md
-3. Creates GitHub Release with changelog
-
-### 3. Publish Workflow (`publish.yml`)
-
-**Trigger**: GitHub Release published (automatic from release.yml)
-
-**Purpose**: Build and publish package to PyPI
-
-**Jobs**:
-1. Build package (uv build + twine check)
-2. Publish to TestPyPI (for verification)
-3. Publish to PyPI (production)
-
-**Why no tests?**
-- All code is already tested in the PR (via CI workflow)
-- Branch protection prevents untested code from reaching main
-- Re-running tests would be redundant and wasteful
-
-## Branch Protection
-
-The `main` branch is protected with these rules:
-
-- ✅ Require pull request before merging (no direct commits)
-- ✅ Require "CI Success" status check to pass
-- ✅ Require branches to be up to date before merging
-- ✅ Dismiss stale PR reviews when new commits pushed
-- ✅ Enforce rules for administrators
-- ✅ Block force pushes
-- ✅ Block branch deletion
-
-### Setup Branch Protection
-
-Run once to configure:
+Manual dispatch requires an existing `v*` tag:
 
 ```bash
-.github/setup-branch-protection.sh
+gh workflow run release.yml --ref main -f tag=v0.10.0b3
 ```
 
-Or configure manually at:
-https://github.com/joyfulhouse/pylxpweb/settings/branches
+The dispatch must select `main`. It runs only the source-identity, build, package,
+manifest, and artifact checks. All publication and remote-index verification jobs
+are skipped. Use this path to validate release construction without publishing.
 
-## Release Process
+### Required repository settings
 
-### Standard Release (Patch/Minor)
+Before relying on the published-release path, verify these settings after the
+workflow change merges:
 
-1. **Bump version** in PR:
-   ```bash
-   # Update version in:
-   # - src/pylxpweb/__init__.py
-   # - pyproject.toml
-   # - CHANGELOG.md
-   ```
+- The `pypi` environment requires a reviewer, limits deployment tags to `v*`, and
+  does not allow administrators to bypass protection.
+- The `testpypi` environment limits deployment tags to `v*`.
+- PyPI and TestPyPI trusted-publisher bindings match this repository, the
+  `release.yml` workflow, and their respective environment names.
 
-2. **Create and merge PR**:
-   - CI runs automatically
-   - Merge after "CI Success" passes
+These are post-merge settings gates. The workflow and this document do not apply
+or mutate repository, environment, or package-index settings.
 
-3. **Tag and push**:
-   ```bash
-   git checkout main
-   git pull
-   git tag v0.3.4
-   git push origin v0.3.4
-   ```
+## Release procedure
 
-4. **Automatic from here**:
-   - `release.yml` creates GitHub Release
-   - `publish.yml` publishes to PyPI
+1. Prepare the version in a pull request. `project.version` in `pyproject.toml`
+   must be the intended tag without the leading `v`.
+2. Merge the reviewed change to `main` after CI succeeds.
+3. Create the `v*` tag on the intended `main` commit.
+4. Optionally run the manual validation path for that tag.
+5. Publish a GitHub Release for the same tag. Publication starts the package
+   promotion chain.
+6. Review the TestPyPI verification result and approve the protected `pypi`
+   environment when prompted.
 
-### Manual Publish (Emergency)
+Do not create a second production upload for an existing version. Production
+publication deliberately fails instead of skipping existing files.
 
-If you need to publish without creating a release:
+## Executable builds (`build-executables.yml`)
+
+Publishing a GitHub Release also starts the separate executable-build workflow for
+Windows, macOS, and Linux. It can be dispatched manually. This path is independent
+of the Python package promotion artifact described above.
+
+## Local validation
+
+Use the locked uv environment:
 
 ```bash
-gh workflow run publish.yml -f environment=pypi
-```
-
-## Workflow Efficiency
-
-### Before (Old Setup)
-```
-PR: CI runs (5 min)
-Merge: CI runs again (5 min) ❌ Redundant!
-Release: CI runs third time (5 min) ❌ Redundant!
-Publish: 2 min
-Total: 17 minutes, 2 redundant CI runs
-```
-
-### After (New Setup)
-```
-PR: CI runs (5 min)
-Merge: No CI (instant) ✅
-Tag: Release created (10 sec) ✅
-Publish: 2 min ✅
-Total: 7 minutes, zero redundancy
-```
-
-**Savings**: 10 minutes per release + 2 fewer CI runs
-
-## CI Run Statistics
-
-- **Unit Tests**: ~53 seconds (492 tests)
-- **Integration Tests**: ~2.5 minutes (67 tests)
-- **Lint & Type Check**: ~14 seconds
-- **Total CI Time**: ~3.5 minutes per PR
-
-## Troubleshooting
-
-### CI didn't run on my PR
-- Check that the PR is targeting `main` branch
-- Manually trigger: Go to Actions → CI → Run workflow
-
-### Release didn't create
-- Verify tag format: `v*.*.*` (e.g., `v0.3.4`)
-- Check Actions tab for errors
-- Manually create release via GitHub UI
-
-### Publish failed
-- Check PyPI credentials (OIDC configured?)
-- Verify version doesn't already exist on PyPI
-- Check Actions tab for detailed error logs
-
-## Local Testing
-
-Before pushing:
-
-```bash
-# Run all checks locally
-uv run ruff check --fix && uv run ruff format
+uv sync --locked --all-extras
+uv run pytest tests/unit/test_release_workflow.py -v
+uv run pytest tests/unit/ -q
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
 uv run mypy --strict src/pylxpweb/
-uv run pytest tests/unit/ --cov=pylxpweb
-uv run pytest tests/integration/ -m integration  # Requires .env
-
-# Build package
 uv build
 uv run twine check dist/*
 ```
 
+No local command exercises a publisher job. TestPyPI and PyPI publication require
+the GitHub-hosted release event, protected environments, and trusted publishing.
+
+## Troubleshooting
+
+- A manual run with skipped `build` selected a ref other than `main`.
+- A source-identity failure means the event tag, project version, commit, tree,
+  release target, or `main` ancestry did not agree. Correct the release inputs; do
+  not weaken the check.
+- A TestPyPI verification failure means the remote name, version, filenames,
+  yanked state, hashes, downloaded wheel, dependency install, metadata, or import
+  did not match the built artifact.
+- A PyPI job waiting for approval is enforcing the production environment gate.
+- An OIDC failure requires checking the corresponding trusted-publisher binding;
+  do not add long-lived package-index credentials.
+
 ## References
 
-- [GitHub Branch Protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches)
 - [GitHub Actions](https://docs.github.com/en/actions)
-- [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+- [GitHub deployment environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)
+- [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -515,9 +515,12 @@ jobs:
         env:
           EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
           EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-          MAX_ATTEMPTS: '1'
+          BACKOFF_SECONDS: '2'
+          MAX_ATTEMPTS: '3'
+          MAX_BACKOFF_SECONDS: '5'
           MODE: prepare
           PYPI_JSON_BASE_URL: https://pypi.org/pypi
+          REQUEST_TIMEOUT_SECONDS: '10'
           UPLOAD_DIR: pypi-upload
         run: &verify-pypi-state |
           python3 - <<'PY'
@@ -553,13 +556,18 @@ jobs:
           mode = os.environ["MODE"]
           assert mode in {"prepare", "verify"}, "invalid PyPI verification mode"
           attempts = int(os.environ["MAX_ATTEMPTS"])
+          backoff_seconds = int(os.environ["BACKOFF_SECONDS"])
+          max_backoff_seconds = int(os.environ["MAX_BACKOFF_SECONDS"])
+          request_timeout_seconds = int(os.environ["REQUEST_TIMEOUT_SECONDS"])
           url = f'{os.environ["PYPI_JSON_BASE_URL"]}/{project}/{version}/json'
           request = urllib.request.Request(url, headers={"User-Agent": "pylxpweb-release-verifier"})
 
           for attempt in range(1, attempts + 1):
               try:
                   try:
-                      with urllib.request.urlopen(request, timeout=30) as response:
+                      with urllib.request.urlopen(
+                          request, timeout=request_timeout_seconds
+                      ) as response:
                           payload = json.load(response)
                   except urllib.error.HTTPError as error:
                       if error.code != 404:
@@ -589,7 +597,7 @@ jobs:
               except (AssertionError, KeyError, OSError, TypeError, ValueError):
                   if attempt == attempts:
                       raise
-                  time.sleep(min(5 * attempt, 30))
+                  time.sleep(min(backoff_seconds * attempt, max_backoff_seconds))
 
           if mode == "prepare":
               upload_dir = pathlib.Path(os.environ["UPLOAD_DIR"])
@@ -603,7 +611,7 @@ jobs:
 
       - id: publish-pypi
         name: Publish to PyPI with trusted publishing
-        if: steps.prepare-pypi.outputs.upload-needed == 'true'
+        if: success() && steps.prepare-pypi.outputs.upload-needed == 'true'
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: pypi-upload/
@@ -613,8 +621,11 @@ jobs:
         env:
           EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
           EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-          MAX_ATTEMPTS: '12'
+          BACKOFF_SECONDS: '5'
+          MAX_ATTEMPTS: '8'
+          MAX_BACKOFF_SECONDS: '20'
           MODE: verify
           PYPI_JSON_BASE_URL: https://pypi.org/pypi
+          REQUEST_TIMEOUT_SECONDS: '15'
           UPLOAD_DIR: pypi-upload
         run: *verify-pypi-state

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,6 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ github.event.release.target_commitish }}
           RELEASE_URL: ${{ github.event.release.html_url }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -93,7 +92,6 @@ jobs:
 
           if [[ "$EVENT_NAME" == "release" ]]; then
             [[ "$EVENT_SHA" == "$commit" ]]
-            [[ "$RELEASE_TAG" == "$tag" ]]
             target_commit=$(git rev-parse "$RELEASE_TARGET^{commit}")
             git merge-base --is-ancestor "$commit" "$target_commit"
           fi
@@ -235,7 +233,7 @@ jobs:
           EXPECTED_TAG: ${{ steps.resolve-source.outputs.tag }}
           EXPECTED_TREE: ${{ steps.resolve-source.outputs.tree }}
           EXPECTED_VERSION: ${{ steps.resolve-source.outputs.version }}
-        run: |
+        run: &validate-release-bundle |
           set -euo pipefail
           (cd release-bundle && sha256sum --check SHA256SUMS)
           python3 - <<'PY'
@@ -290,18 +288,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: testpypi
-    permissions:
+    permissions: &publisher-permissions
       contents: read
       id-token: write
     steps:
-      - id: download-release-artifact
+      - &download-release-artifact
+        id: download-release-artifact
         name: Download original release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ needs.build.outputs.artifact-name }}
           path: release-bundle/
 
-      - id: revalidate-release-bundle
+      - &revalidate-release-artifact
+        id: revalidate-release-bundle
         name: Revalidate original release artifact
         env:
           EXPECTED_ARTIFACT_NAME: ${{ needs.build.outputs.artifact-name }}
@@ -310,44 +310,7 @@ jobs:
           EXPECTED_TAG: ${{ needs.build.outputs.tag }}
           EXPECTED_TREE: ${{ needs.build.outputs.tree }}
           EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          set -euo pipefail
-          (cd release-bundle && sha256sum --check SHA256SUMS)
-          python3 - <<'PY'
-          import json
-          import os
-          import pathlib
-
-          bundle = pathlib.Path("release-bundle")
-          source = json.loads(bundle.joinpath("release-source.json").read_text())
-          expected = {
-              "artifact_name": os.environ["EXPECTED_ARTIFACT_NAME"],
-              "commit": os.environ["EXPECTED_COMMIT"],
-              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
-              "tag": os.environ["EXPECTED_TAG"],
-              "tree": os.environ["EXPECTED_TREE"],
-              "version": os.environ["EXPECTED_VERSION"],
-          }
-          assert {key: source[key] for key in expected} == expected
-          wheels = list(bundle.glob("dist/*.whl"))
-          sdists = list(bundle.glob("dist/*.tar.gz"))
-          assert len(wheels) == 1, wheels
-          assert len(sdists) == 1, sdists
-          manifest_paths = {
-              line.split("  ", 1)[1]
-              for line in bundle.joinpath("SHA256SUMS").read_text().splitlines()
-          }
-          expected_hashed = {
-              "release-source.json",
-              wheels[0].relative_to(bundle).as_posix(),
-              sdists[0].relative_to(bundle).as_posix(),
-          }
-          assert manifest_paths == expected_hashed
-          all_files = {
-              path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
-          }
-          assert all_files == expected_hashed | {"SHA256SUMS"}
-          PY
+        run: *validate-release-bundle
 
       - id: publish-testpypi
         name: Publish to TestPyPI with trusted publishing
@@ -366,60 +329,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - id: download-release-artifact
-        name: Download original release artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ needs.build.outputs.artifact-name }}
-          path: release-bundle/
+      - *download-release-artifact
 
-      - id: revalidate-release-bundle
-        name: Revalidate original release artifact
-        env:
-          EXPECTED_ARTIFACT_NAME: ${{ needs.build.outputs.artifact-name }}
-          EXPECTED_COMMIT: ${{ needs.build.outputs.commit }}
-          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
-          EXPECTED_TAG: ${{ needs.build.outputs.tag }}
-          EXPECTED_TREE: ${{ needs.build.outputs.tree }}
-          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          set -euo pipefail
-          (cd release-bundle && sha256sum --check SHA256SUMS)
-          python3 - <<'PY'
-          import json
-          import os
-          import pathlib
-
-          bundle = pathlib.Path("release-bundle")
-          source = json.loads(bundle.joinpath("release-source.json").read_text())
-          expected = {
-              "artifact_name": os.environ["EXPECTED_ARTIFACT_NAME"],
-              "commit": os.environ["EXPECTED_COMMIT"],
-              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
-              "tag": os.environ["EXPECTED_TAG"],
-              "tree": os.environ["EXPECTED_TREE"],
-              "version": os.environ["EXPECTED_VERSION"],
-          }
-          assert {key: source[key] for key in expected} == expected
-          wheels = list(bundle.glob("dist/*.whl"))
-          sdists = list(bundle.glob("dist/*.tar.gz"))
-          assert len(wheels) == 1, wheels
-          assert len(sdists) == 1, sdists
-          manifest_paths = {
-              line.split("  ", 1)[1]
-              for line in bundle.joinpath("SHA256SUMS").read_text().splitlines()
-          }
-          expected_hashed = {
-              "release-source.json",
-              wheels[0].relative_to(bundle).as_posix(),
-              sdists[0].relative_to(bundle).as_posix(),
-          }
-          assert manifest_paths == expected_hashed
-          all_files = {
-              path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
-          }
-          assert all_files == expected_hashed | {"SHA256SUMS"}
-          PY
+      - *revalidate-release-artifact
 
       - id: setup-uv
         name: Install uv
@@ -440,7 +352,6 @@ jobs:
           import os
           import pathlib
           import time
-          import urllib.error
           import urllib.parse
           import urllib.request
 
@@ -471,7 +382,7 @@ jobs:
                   assert parsed.scheme == "https"
                   assert parsed.hostname == os.environ["ALLOWED_WHEEL_HOST"]
                   break
-              except (AssertionError, KeyError, OSError, ValueError, urllib.error.URLError):
+              except (AssertionError, KeyError, OSError, ValueError):
                   if attempt == attempts:
                       raise
                   time.sleep(min(5 * attempt, 30))
@@ -546,64 +457,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi
-    permissions:
-      contents: read
-      id-token: write
+    permissions: *publisher-permissions
     steps:
-      - id: download-release-artifact
-        name: Download original release artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ needs.build.outputs.artifact-name }}
-          path: release-bundle/
+      - *download-release-artifact
 
-      - id: revalidate-release-bundle
-        name: Revalidate original release artifact
-        env:
-          EXPECTED_ARTIFACT_NAME: ${{ needs.build.outputs.artifact-name }}
-          EXPECTED_COMMIT: ${{ needs.build.outputs.commit }}
-          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
-          EXPECTED_TAG: ${{ needs.build.outputs.tag }}
-          EXPECTED_TREE: ${{ needs.build.outputs.tree }}
-          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          set -euo pipefail
-          (cd release-bundle && sha256sum --check SHA256SUMS)
-          python3 - <<'PY'
-          import json
-          import os
-          import pathlib
-
-          bundle = pathlib.Path("release-bundle")
-          source = json.loads(bundle.joinpath("release-source.json").read_text())
-          expected = {
-              "artifact_name": os.environ["EXPECTED_ARTIFACT_NAME"],
-              "commit": os.environ["EXPECTED_COMMIT"],
-              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
-              "tag": os.environ["EXPECTED_TAG"],
-              "tree": os.environ["EXPECTED_TREE"],
-              "version": os.environ["EXPECTED_VERSION"],
-          }
-          assert {key: source[key] for key in expected} == expected
-          wheels = list(bundle.glob("dist/*.whl"))
-          sdists = list(bundle.glob("dist/*.tar.gz"))
-          assert len(wheels) == 1, wheels
-          assert len(sdists) == 1, sdists
-          manifest_paths = {
-              line.split("  ", 1)[1]
-              for line in bundle.joinpath("SHA256SUMS").read_text().splitlines()
-          }
-          expected_hashed = {
-              "release-source.json",
-              wheels[0].relative_to(bundle).as_posix(),
-              sdists[0].relative_to(bundle).as_posix(),
-          }
-          assert manifest_paths == expected_hashed
-          all_files = {
-              path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
-          }
-          assert all_files == expected_hashed | {"SHA256SUMS"}
-          PY
+      - *revalidate-release-artifact
 
       - id: publish-pypi
         name: Publish to PyPI with trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
     if: github.event_name == 'release' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      UV_PYTHON: '3.13'
     outputs:
       artifact-name: ${{ steps.resolve-source.outputs.artifact-name }}
       commit: ${{ steps.resolve-source.outputs.commit }}
@@ -64,36 +66,56 @@ jobs:
         run: |
           set -euo pipefail
 
+          die() {
+            echo "$1" >&2
+            exit 1
+          }
+
           if [[ "$EVENT_NAME" == "release" ]]; then
             tag="$RELEASE_TAG"
-            [[ "$RELEASE_DRAFT" == "false" ]]
-            [[ "$RELEASE_ID" =~ ^[0-9]+$ ]]
-            [[ -n "$RELEASE_URL" ]]
-          else
+            [[ "$RELEASE_DRAFT" == "false" ]] || die "release must be published"
+            [[ "$RELEASE_ID" =~ ^[0-9]+$ ]] || die "release ID is malformed"
+            [[ -n "$RELEASE_URL" ]] || die "release URL is missing"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             tag="$DISPATCH_TAG"
+          else
+            die "unsupported release workflow event"
           fi
 
-          [[ "$tag" == v?* ]]
-          git show-ref --verify --quiet "refs/tags/$tag"
+          [[ "$tag" == v?* ]] || die "release tag must start with v"
+          git show-ref --verify --quiet "refs/tags/$tag" || die "release tag does not exist"
 
           tag_object=$(git rev-parse "refs/tags/$tag")
           commit=$(git rev-parse "refs/tags/$tag^{commit}")
           tree=$(git rev-parse "refs/tags/$tag^{tree}")
-          [[ "$(git rev-parse HEAD)" == "$commit" ]]
-          [[ "$(git rev-parse HEAD^{tree})" == "$tree" ]]
-          git merge-base --is-ancestor "$commit" origin/main
+          [[ "$(git rev-parse HEAD)" == "$commit" ]] || die "checked-out commit does not match tag commit"
+          [[ "$(git rev-parse HEAD^{tree})" == "$tree" ]] || die "checked-out tree does not match tag tree"
+          git merge-base --is-ancestor "$commit" refs/remotes/origin/main || \
+            die "release tag is not an ancestor of origin/main"
 
           project_name=$(python3 -c \
             'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["name"])')
           version=$(python3 -c \
             'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
-          [[ "$project_name" == "pylxpweb" ]]
-          [[ "$tag" == "v$version" ]]
+          [[ "$project_name" == "pylxpweb" ]] || die "unexpected project name"
+          [[ "$tag" == "v$version" ]] || die "release tag does not match project version"
 
           if [[ "$EVENT_NAME" == "release" ]]; then
-            [[ "$EVENT_SHA" == "$commit" ]]
-            target_commit=$(git rev-parse "$RELEASE_TARGET^{commit}")
-            git merge-base --is-ancestor "$commit" "$target_commit"
+            [[ "$EVENT_SHA" == "$commit" ]] || die "release event commit does not match tag commit"
+            if [[ "$RELEASE_TARGET" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              target_commit=$(git rev-parse --verify "$RELEASE_TARGET^{commit}") || \
+                die "invalid or unresolved release target"
+            elif git check-ref-format "refs/remotes/origin/$RELEASE_TARGET" >/dev/null 2>&1; then
+              target_ref="refs/remotes/origin/$RELEASE_TARGET"
+              git show-ref --verify --quiet "$target_ref" || \
+                die "invalid or unresolved release target"
+              target_commit=$(git rev-parse --verify "$target_ref^{commit}") || \
+                die "invalid or unresolved release target"
+            else
+              die "invalid or unresolved release target"
+            fi
+            git merge-base --is-ancestor "$commit" "$target_commit" || \
+              die "release tag is not an ancestor of release target"
           fi
 
           artifact_name="pylxpweb-release-$version-${commit:0:12}"
@@ -251,7 +273,8 @@ jobs:
               "tree": os.environ["EXPECTED_TREE"],
               "version": os.environ["EXPECTED_VERSION"],
           }
-          assert {key: source[key] for key in expected} == expected
+          assert {key: source[key] for key in expected} == expected, \
+              "release source identity does not match"
           wheels = list(bundle.glob("dist/*.whl"))
           sdists = list(bundle.glob("dist/*.tar.gz"))
           assert len(wheels) == 1, wheels
@@ -338,9 +361,9 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - id: query-testpypi
-        name: Verify TestPyPI JSON and download the published wheel
+        name: Verify TestPyPI JSON and download both distributions
         env:
-          ALLOWED_WHEEL_HOST: test-files.pythonhosted.org
+          ALLOWED_DISTRIBUTION_HOST: test-files.pythonhosted.org
           EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
           EXPECTED_VERSION: ${{ needs.build.outputs.version }}
           MAX_ATTEMPTS: '12'
@@ -359,7 +382,13 @@ jobs:
           hashes = {}
           for line in bundle.joinpath("SHA256SUMS").read_text().splitlines():
               digest, path = line.split("  ", 1)
-              hashes[pathlib.PurePosixPath(path).name] = digest
+              manifest_path = pathlib.PurePosixPath(path)
+              if manifest_path.parts[0] == "dist":
+                  hashes[manifest_path.name] = digest
+
+          assert len(hashes) == 2, "release artifact must contain exactly two distributions"
+          assert sum(name.endswith(".whl") for name in hashes) == 1, "release artifact must contain one wheel"
+          assert sum(name.endswith(".tar.gz") for name in hashes) == 1, "release artifact must contain one sdist"
 
           project = os.environ["EXPECTED_PROJECT_NAME"]
           version = os.environ["EXPECTED_VERSION"]
@@ -371,41 +400,59 @@ jobs:
               try:
                   with urllib.request.urlopen(request, timeout=30) as response:
                       payload = json.load(response)
-                  assert payload["info"]["name"] == project
-                  assert payload["info"]["version"] == version
+                  assert payload["info"]["name"] == project, "package index project name does not match"
+                  assert payload["info"]["version"] == version, "package index version does not match"
                   releases = payload["urls"]
-                  assert {release["filename"] for release in releases} == set(hashes) - {"release-source.json"}
-                  assert all(release["yanked"] is False for release in releases)
-                  assert all(release["digests"]["sha256"] == hashes[release["filename"]] for release in releases)
-                  wheel = next(release for release in releases if release["filename"].endswith(".whl"))
-                  parsed = urllib.parse.urlparse(wheel["url"])
-                  assert parsed.scheme == "https"
-                  assert parsed.hostname == os.environ["ALLOWED_WHEEL_HOST"]
+                  filenames = {release["filename"] for release in releases}
+                  assert len(releases) == len(hashes) and filenames == set(hashes), \
+                      "package index file set does not match"
+                  assert all(release["yanked"] is False for release in releases), \
+                      "package index contains yanked file"
+                  assert all(
+                      release["digests"]["sha256"] == hashes[release["filename"]]
+                      for release in releases
+                  ), "package index hash does not match"
+                  for release in releases:
+                      parsed = urllib.parse.urlparse(release["url"])
+                      assert (
+                          parsed.scheme == "https"
+                          and parsed.hostname == os.environ["ALLOWED_DISTRIBUTION_HOST"]
+                      ), "distribution URL is not allowlisted HTTPS"
                   break
-              except (AssertionError, KeyError, OSError, ValueError):
+              except (AssertionError, KeyError, OSError, TypeError, ValueError):
                   if attempt == attempts:
                       raise
                   time.sleep(min(5 * attempt, 30))
 
-          wheel_request = urllib.request.Request(
-              wheel["url"], headers={"User-Agent": "pylxpweb-release-verifier"}
-          )
-          with urllib.request.urlopen(wheel_request, timeout=60) as response:
-              final_url = urllib.parse.urlparse(response.geturl())
-              assert final_url.scheme == "https"
-              assert final_url.hostname == os.environ["ALLOWED_WHEEL_HOST"]
-              wheel_bytes = response.read()
-          assert hashlib.sha256(wheel_bytes).hexdigest() == hashes[wheel["filename"]]
-          wheel_path = pathlib.Path("verified-wheel") / wheel["filename"]
-          wheel_path.parent.mkdir()
-          wheel_path.write_bytes(wheel_bytes)
+          verified = pathlib.Path("verified-distributions")
+          verified.mkdir()
+          wheel_path = None
+          for release in releases:
+              download_request = urllib.request.Request(
+                  release["url"], headers={"User-Agent": "pylxpweb-release-verifier"}
+              )
+              with urllib.request.urlopen(download_request, timeout=60) as response:
+                  final_url = urllib.parse.urlparse(response.geturl())
+                  assert (
+                      final_url.scheme == "https"
+                      and final_url.hostname == os.environ["ALLOWED_DISTRIBUTION_HOST"]
+                  ), "distribution URL is not allowlisted HTTPS"
+                  content = response.read()
+              filename = release["filename"]
+              assert hashlib.sha256(content).hexdigest() == hashes[filename], \
+                  "downloaded distribution hash does not match"
+              path = verified / filename
+              path.write_bytes(content)
+              if filename.endswith(".whl"):
+                  wheel_path = path
+          assert wheel_path is not None, "verified wheel is missing"
           with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
               print(f"wheel-path={wheel_path}", file=output)
           PY
 
       - id: create-verification-environment
         name: Create clean verification environment
-        run: uv venv --python 3.12 .verify-venv
+        run: uv venv --python 3.13 .verify-venv
 
       - id: install-testpypi-wheel
         name: Install downloaded wheel with dependencies from production PyPI only
@@ -463,8 +510,111 @@ jobs:
 
       - *revalidate-release-artifact
 
+      - id: prepare-pypi
+        name: Validate existing PyPI files and stage absent distributions
+        env:
+          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
+          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
+          MAX_ATTEMPTS: '1'
+          MODE: prepare
+          PYPI_JSON_BASE_URL: https://pypi.org/pypi
+          UPLOAD_DIR: pypi-upload
+        run: &verify-pypi-state |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          import pathlib
+          import shutil
+          import time
+          import urllib.error
+          import urllib.request
+
+          bundle = pathlib.Path("release-bundle")
+          hashes = {}
+          paths = {}
+          for line in bundle.joinpath("SHA256SUMS").read_text().splitlines():
+              digest, path = line.split("  ", 1)
+              manifest_path = pathlib.PurePosixPath(path)
+              if manifest_path.parts[0] == "dist":
+                  hashes[manifest_path.name] = digest
+                  paths[manifest_path.name] = bundle.joinpath(*manifest_path.parts)
+
+          assert len(hashes) == 2, "release artifact must contain exactly two distributions"
+          assert sum(name.endswith(".whl") for name in hashes) == 1, "release artifact must contain one wheel"
+          assert sum(name.endswith(".tar.gz") for name in hashes) == 1, "release artifact must contain one sdist"
+          for filename, path in paths.items():
+              assert path.is_file(), f"release artifact is missing {filename}"
+              assert hashlib.sha256(path.read_bytes()).hexdigest() == hashes[filename], \
+                  f"release artifact hash does not match for {filename}"
+
+          project = os.environ["EXPECTED_PROJECT_NAME"]
+          version = os.environ["EXPECTED_VERSION"]
+          mode = os.environ["MODE"]
+          assert mode in {"prepare", "verify"}, "invalid PyPI verification mode"
+          attempts = int(os.environ["MAX_ATTEMPTS"])
+          url = f'{os.environ["PYPI_JSON_BASE_URL"]}/{project}/{version}/json'
+          request = urllib.request.Request(url, headers={"User-Agent": "pylxpweb-release-verifier"})
+
+          for attempt in range(1, attempts + 1):
+              try:
+                  try:
+                      with urllib.request.urlopen(request, timeout=30) as response:
+                          payload = json.load(response)
+                  except urllib.error.HTTPError as error:
+                      if error.code != 404:
+                          raise
+                      payload = None
+
+                  if payload is None:
+                      releases = []
+                  else:
+                      assert payload["info"]["name"] == project, "PyPI project name does not match"
+                      assert payload["info"]["version"] == version, "PyPI version does not match"
+                      releases = payload["urls"]
+
+                  filenames = [release["filename"] for release in releases]
+                  filename_set = set(filenames)
+                  assert len(filenames) == len(filename_set), "PyPI contains duplicate filenames"
+                  assert filename_set <= set(hashes), "PyPI contains unexpected file"
+                  assert all(release["yanked"] is False for release in releases), \
+                      "PyPI contains yanked file"
+                  assert all(
+                      release["digests"]["sha256"] == hashes[release["filename"]]
+                      for release in releases
+                  ), "PyPI hash does not match"
+                  if mode == "verify":
+                      assert filename_set == set(hashes), "PyPI final file set does not match"
+                  break
+              except (AssertionError, KeyError, OSError, TypeError, ValueError):
+                  if attempt == attempts:
+                      raise
+                  time.sleep(min(5 * attempt, 30))
+
+          if mode == "prepare":
+              upload_dir = pathlib.Path(os.environ["UPLOAD_DIR"])
+              upload_dir.mkdir()
+              absent = set(hashes) - filename_set
+              for filename in sorted(absent):
+                  shutil.copyfile(paths[filename], upload_dir / filename)
+              with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+                  print(f"upload-needed={'true' if absent else 'false'}", file=output)
+          PY
+
       - id: publish-pypi
         name: Publish to PyPI with trusted publishing
+        if: steps.prepare-pypi.outputs.upload-needed == 'true'
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          packages-dir: release-bundle/dist/
+          packages-dir: pypi-upload/
+
+      - id: verify-pypi
+        name: Verify final exact PyPI distribution set
+        env:
+          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
+          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
+          MAX_ATTEMPTS: '12'
+          MODE: verify
+          PYPI_JSON_BASE_URL: https://pypi.org/pypi
+          UPLOAD_DIR: pypi-upload
+        run: *verify-pypi-state

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,121 +1,612 @@
 name: Publish to PyPI
 
-# Triggered when a GitHub Release is published (created manually via gh CLI or UI)
-# Workflow: gh release create v0.6.5 ... → This workflow builds and publishes to PyPI
-
 on:
   release:
     types: [published]
   workflow_dispatch:
     inputs:
-      environment:
-        description: 'Environment to publish to (skip-publish, testpypi, or pypi)'
+      tag:
+        description: Existing v* tag to validate
         required: true
-        type: choice
-        options:
-          - skip-publish
-          - testpypi
-          - pypi
+        type: string
 
-# Only one release at a time
 concurrency:
-  group: release-publish
+  group: release-publish-${{ github.event.release.tag_name || inputs.tag }}
   cancel-in-progress: false
 
 permissions:
   contents: read
-  id-token: write  # Required for OIDC PyPI publishing
 
 jobs:
   build:
-    name: Build Package
+    name: Build and attest release artifact
+    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    outputs:
+      artifact-name: ${{ steps.resolve-source.outputs.artifact-name }}
+      commit: ${{ steps.resolve-source.outputs.commit }}
+      project-name: ${{ steps.resolve-source.outputs.project-name }}
+      tag: ${{ steps.resolve-source.outputs.tag }}
+      tree: ${{ steps.resolve-source.outputs.tree }}
+      version: ${{ steps.resolve-source.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - id: checkout-source
+        name: Check out the requested tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name || github.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - id: setup-uv
+        name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          cache-dependency-glob: uv.lock
 
-      - name: Set up Python
+      - id: setup-python
+        name: Set up Python
         run: uv python install 3.13
 
-      - name: Install dependencies
+      - id: resolve-source
+        name: Resolve and bind release source identity
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
+          RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            tag="$RELEASE_TAG"
+            [[ "$RELEASE_DRAFT" == "false" ]]
+            [[ "$RELEASE_ID" =~ ^[0-9]+$ ]]
+            [[ -n "$RELEASE_URL" ]]
+          else
+            tag="$DISPATCH_TAG"
+          fi
+
+          [[ "$tag" == v?* ]]
+          git show-ref --verify --quiet "refs/tags/$tag"
+
+          tag_object=$(git rev-parse "refs/tags/$tag")
+          commit=$(git rev-parse "refs/tags/$tag^{commit}")
+          tree=$(git rev-parse "refs/tags/$tag^{tree}")
+          [[ "$(git rev-parse HEAD)" == "$commit" ]]
+          [[ "$(git rev-parse HEAD^{tree})" == "$tree" ]]
+          git merge-base --is-ancestor "$commit" origin/main
+
+          project_name=$(python3 -c \
+            'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["name"])')
+          version=$(python3 -c \
+            'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          [[ "$project_name" == "pylxpweb" ]]
+          [[ "$tag" == "v$version" ]]
+
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            [[ "$EVENT_SHA" == "$commit" ]]
+            [[ "$RELEASE_TAG" == "$tag" ]]
+            target_commit=$(git rev-parse "$RELEASE_TARGET^{commit}")
+            git merge-base --is-ancestor "$commit" "$target_commit"
+          fi
+
+          artifact_name="pylxpweb-release-$version-${commit:0:12}"
+          {
+            echo "artifact-name=$artifact_name"
+            echo "commit=$commit"
+            echo "project-name=$project_name"
+            echo "tag=$tag"
+            echo "tag-object=$tag_object"
+            echo "tree=$tree"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - id: sync-build-tools
+        name: Install locked build tools
+        env:
+          UV_LOCKED: '1'
         run: uv sync --all-extras
 
-      - name: Build package
-        run: uv build
+      - id: verify-clean-source
+        name: Verify dependency setup preserved bound source
+        run: git diff --exit-code
 
-      - name: Check package
-        run: uv run twine check dist/*
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: python-package-distributions
-          path: dist/
-          retention-days: 7
-
-      - name: Create build summary
+      - id: build-distributions
+        name: Build wheel and source distribution once
         run: |
-          echo "## Package Built" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Built packages:" >> $GITHUB_STEP_SUMMARY
-          ls -lh dist/ >> $GITHUB_STEP_SUMMARY
+          uv build --out-dir release-bundle/dist
+          rm -f release-bundle/dist/.gitignore
+
+      - id: check-distributions
+        name: Check built distributions
+        run: uv run twine check release-bundle/dist/*
+
+      - id: validate-distributions
+        name: Validate distribution count and metadata
+        env:
+          EXPECTED_PROJECT_NAME: ${{ steps.resolve-source.outputs.project-name }}
+          EXPECTED_VERSION: ${{ steps.resolve-source.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import email
+          import os
+          import pathlib
+          import tarfile
+          import zipfile
+
+          dist = pathlib.Path("release-bundle/dist")
+          wheels = list(dist.glob("*.whl"))
+          sdists = list(dist.glob("*.tar.gz"))
+          files = [path for path in dist.iterdir() if path.is_file()]
+          assert len(wheels) == 1, wheels
+          assert len(sdists) == 1, sdists
+          assert len(files) == 2, files
+
+          with zipfile.ZipFile(wheels[0]) as archive:
+              members = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+              assert len(members) == 1, members
+              wheel_metadata = email.message_from_bytes(archive.read(members[0]))
+
+          with tarfile.open(sdists[0], "r:gz") as archive:
+              members = [member for member in archive.getmembers() if member.name.count("/") == 1 and member.name.endswith("/PKG-INFO")]
+              assert len(members) == 1, members
+              extracted = archive.extractfile(members[0])
+              assert extracted is not None
+              sdist_metadata = email.message_from_binary_file(extracted)
+
+          for metadata in (wheel_metadata, sdist_metadata):
+              assert metadata["Name"] == os.environ["EXPECTED_PROJECT_NAME"]
+              assert metadata["Version"] == os.environ["EXPECTED_VERSION"]
+          PY
+
+      - id: write-source-manifest
+        name: Write machine-readable source manifest
+        env:
+          ARTIFACT_NAME: ${{ steps.resolve-source.outputs.artifact-name }}
+          COMMIT: ${{ steps.resolve-source.outputs.commit }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
+          PROJECT_NAME: ${{ steps.resolve-source.outputs.project-name }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.resolve-source.outputs.tag }}
+          TAG_OBJECT: ${{ steps.resolve-source.outputs.tag-object }}
+          TREE: ${{ steps.resolve-source.outputs.tree }}
+          VERSION: ${{ steps.resolve-source.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+
+          keys = (
+              "ARTIFACT_NAME",
+              "COMMIT",
+              "EVENT_NAME",
+              "EVENT_SHA",
+              "PROJECT_NAME",
+              "RELEASE_ID",
+              "RELEASE_TARGET",
+              "RELEASE_URL",
+              "REPOSITORY",
+              "TAG",
+              "TAG_OBJECT",
+              "TREE",
+              "VERSION",
+          )
+          manifest = {key.lower(): os.environ[key] for key in keys}
+          manifest["schema_version"] = 1
+          path = pathlib.Path("release-bundle/release-source.json")
+          path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+          PY
+
+      - id: write-sha256-manifest
+        name: Write per-file SHA256 manifest
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import pathlib
+
+          bundle = pathlib.Path("release-bundle")
+          files = sorted([bundle / "release-source.json", *bundle.joinpath("dist").iterdir()])
+          lines = []
+          for path in files:
+              digest = hashlib.sha256(path.read_bytes()).hexdigest()
+              lines.append(f"{digest}  {path.relative_to(bundle).as_posix()}")
+          bundle.joinpath("SHA256SUMS").write_text("\n".join(lines) + "\n")
+          PY
+
+      - id: validate-release-bundle
+        name: Validate complete release bundle
+        env:
+          EXPECTED_ARTIFACT_NAME: ${{ steps.resolve-source.outputs.artifact-name }}
+          EXPECTED_COMMIT: ${{ steps.resolve-source.outputs.commit }}
+          EXPECTED_PROJECT_NAME: ${{ steps.resolve-source.outputs.project-name }}
+          EXPECTED_TAG: ${{ steps.resolve-source.outputs.tag }}
+          EXPECTED_TREE: ${{ steps.resolve-source.outputs.tree }}
+          EXPECTED_VERSION: ${{ steps.resolve-source.outputs.version }}
+        run: |
+          set -euo pipefail
+          (cd release-bundle && sha256sum --check SHA256SUMS)
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+
+          bundle = pathlib.Path("release-bundle")
+          source = json.loads(bundle.joinpath("release-source.json").read_text())
+          expected = {
+              "artifact_name": os.environ["EXPECTED_ARTIFACT_NAME"],
+              "commit": os.environ["EXPECTED_COMMIT"],
+              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
+              "tag": os.environ["EXPECTED_TAG"],
+              "tree": os.environ["EXPECTED_TREE"],
+              "version": os.environ["EXPECTED_VERSION"],
+          }
+          assert {key: source[key] for key in expected} == expected
+          wheels = list(bundle.glob("dist/*.whl"))
+          sdists = list(bundle.glob("dist/*.tar.gz"))
+          assert len(wheels) == 1, wheels
+          assert len(sdists) == 1, sdists
+          manifest_paths = {
+              line.split("  ", 1)[1]
+              for line in bundle.joinpath("SHA256SUMS").read_text().splitlines()
+          }
+          expected_hashed = {
+              "release-source.json",
+              wheels[0].relative_to(bundle).as_posix(),
+              sdists[0].relative_to(bundle).as_posix(),
+          }
+          assert manifest_paths == expected_hashed
+          all_files = {
+              path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
+          }
+          assert all_files == expected_hashed | {"SHA256SUMS"}
+          PY
+
+      - id: upload-release-artifact
+        name: Upload immutable release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.resolve-source.outputs.artifact-name }}
+          path: release-bundle/
+          if-no-files-found: error
+          retention-days: 30
 
   publish-testpypi:
-    name: Publish to TestPyPI
+    name: Publish original artifact to TestPyPI
+    if: github.event_name == 'release'
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment != 'skip-publish')
     environment: testpypi
     permissions:
+      contents: read
       id-token: write
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
+      - id: download-release-artifact
+        name: Download original release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: python-package-distributions
-          path: dist/
+          name: ${{ needs.build.outputs.artifact-name }}
+          path: release-bundle/
 
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - id: revalidate-release-bundle
+        name: Revalidate original release artifact
+        env:
+          EXPECTED_ARTIFACT_NAME: ${{ needs.build.outputs.artifact-name }}
+          EXPECTED_COMMIT: ${{ needs.build.outputs.commit }}
+          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
+          EXPECTED_TAG: ${{ needs.build.outputs.tag }}
+          EXPECTED_TREE: ${{ needs.build.outputs.tree }}
+          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          (cd release-bundle && sha256sum --check SHA256SUMS)
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+
+          bundle = pathlib.Path("release-bundle")
+          source = json.loads(bundle.joinpath("release-source.json").read_text())
+          expected = {
+              "artifact_name": os.environ["EXPECTED_ARTIFACT_NAME"],
+              "commit": os.environ["EXPECTED_COMMIT"],
+              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
+              "tag": os.environ["EXPECTED_TAG"],
+              "tree": os.environ["EXPECTED_TREE"],
+              "version": os.environ["EXPECTED_VERSION"],
+          }
+          assert {key: source[key] for key in expected} == expected
+          wheels = list(bundle.glob("dist/*.whl"))
+          sdists = list(bundle.glob("dist/*.tar.gz"))
+          assert len(wheels) == 1, wheels
+          assert len(sdists) == 1, sdists
+          manifest_paths = {
+              line.split("  ", 1)[1]
+              for line in bundle.joinpath("SHA256SUMS").read_text().splitlines()
+          }
+          expected_hashed = {
+              "release-source.json",
+              wheels[0].relative_to(bundle).as_posix(),
+              sdists[0].relative_to(bundle).as_posix(),
+          }
+          assert manifest_paths == expected_hashed
+          all_files = {
+              path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
+          }
+          assert all_files == expected_hashed | {"SHA256SUMS"}
+          PY
+
+      - id: publish-testpypi
+        name: Publish to TestPyPI with trusted publishing
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
+          packages-dir: release-bundle/dist/
           repository-url: https://test.pypi.org/legacy/
-          print-hash: true
+          skip-existing: true
+
+  verify-testpypi:
+    name: Verify TestPyPI artifact and isolated install
+    if: github.event_name == 'release'
+    needs: [build, publish-testpypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - id: download-release-artifact
+        name: Download original release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+          path: release-bundle/
+
+      - id: revalidate-release-bundle
+        name: Revalidate original release artifact
+        env:
+          EXPECTED_ARTIFACT_NAME: ${{ needs.build.outputs.artifact-name }}
+          EXPECTED_COMMIT: ${{ needs.build.outputs.commit }}
+          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
+          EXPECTED_TAG: ${{ needs.build.outputs.tag }}
+          EXPECTED_TREE: ${{ needs.build.outputs.tree }}
+          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          (cd release-bundle && sha256sum --check SHA256SUMS)
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+
+          bundle = pathlib.Path("release-bundle")
+          source = json.loads(bundle.joinpath("release-source.json").read_text())
+          expected = {
+              "artifact_name": os.environ["EXPECTED_ARTIFACT_NAME"],
+              "commit": os.environ["EXPECTED_COMMIT"],
+              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
+              "tag": os.environ["EXPECTED_TAG"],
+              "tree": os.environ["EXPECTED_TREE"],
+              "version": os.environ["EXPECTED_VERSION"],
+          }
+          assert {key: source[key] for key in expected} == expected
+          wheels = list(bundle.glob("dist/*.whl"))
+          sdists = list(bundle.glob("dist/*.tar.gz"))
+          assert len(wheels) == 1, wheels
+          assert len(sdists) == 1, sdists
+          manifest_paths = {
+              line.split("  ", 1)[1]
+              for line in bundle.joinpath("SHA256SUMS").read_text().splitlines()
+          }
+          expected_hashed = {
+              "release-source.json",
+              wheels[0].relative_to(bundle).as_posix(),
+              sdists[0].relative_to(bundle).as_posix(),
+          }
+          assert manifest_paths == expected_hashed
+          all_files = {
+              path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
+          }
+          assert all_files == expected_hashed | {"SHA256SUMS"}
+          PY
+
+      - id: setup-uv
+        name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - id: query-testpypi
+        name: Verify TestPyPI JSON and download the published wheel
+        env:
+          ALLOWED_WHEEL_HOST: test-files.pythonhosted.org
+          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
+          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
+          MAX_ATTEMPTS: '12'
+          TESTPYPI_JSON_BASE_URL: https://test.pypi.org/pypi
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          import pathlib
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          bundle = pathlib.Path("release-bundle")
+          hashes = {}
+          for line in bundle.joinpath("SHA256SUMS").read_text().splitlines():
+              digest, path = line.split("  ", 1)
+              hashes[pathlib.PurePosixPath(path).name] = digest
+
+          project = os.environ["EXPECTED_PROJECT_NAME"]
+          version = os.environ["EXPECTED_VERSION"]
+          url = f'{os.environ["TESTPYPI_JSON_BASE_URL"]}/{project}/{version}/json'
+          attempts = int(os.environ["MAX_ATTEMPTS"])
+          request = urllib.request.Request(url, headers={"User-Agent": "pylxpweb-release-verifier"})
+
+          for attempt in range(1, attempts + 1):
+              try:
+                  with urllib.request.urlopen(request, timeout=30) as response:
+                      payload = json.load(response)
+                  assert payload["info"]["name"] == project
+                  assert payload["info"]["version"] == version
+                  releases = payload["urls"]
+                  assert {release["filename"] for release in releases} == set(hashes) - {"release-source.json"}
+                  assert all(release["yanked"] is False for release in releases)
+                  assert all(release["digests"]["sha256"] == hashes[release["filename"]] for release in releases)
+                  wheel = next(release for release in releases if release["filename"].endswith(".whl"))
+                  parsed = urllib.parse.urlparse(wheel["url"])
+                  assert parsed.scheme == "https"
+                  assert parsed.hostname == os.environ["ALLOWED_WHEEL_HOST"]
+                  break
+              except (AssertionError, KeyError, OSError, ValueError, urllib.error.URLError):
+                  if attempt == attempts:
+                      raise
+                  time.sleep(min(5 * attempt, 30))
+
+          wheel_request = urllib.request.Request(
+              wheel["url"], headers={"User-Agent": "pylxpweb-release-verifier"}
+          )
+          with urllib.request.urlopen(wheel_request, timeout=60) as response:
+              final_url = urllib.parse.urlparse(response.geturl())
+              assert final_url.scheme == "https"
+              assert final_url.hostname == os.environ["ALLOWED_WHEEL_HOST"]
+              wheel_bytes = response.read()
+          assert hashlib.sha256(wheel_bytes).hexdigest() == hashes[wheel["filename"]]
+          wheel_path = pathlib.Path("verified-wheel") / wheel["filename"]
+          wheel_path.parent.mkdir()
+          wheel_path.write_bytes(wheel_bytes)
+          with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              print(f"wheel-path={wheel_path}", file=output)
+          PY
+
+      - id: create-verification-environment
+        name: Create clean verification environment
+        run: uv venv --python 3.12 .verify-venv
+
+      - id: install-testpypi-wheel
+        name: Install downloaded wheel with dependencies from production PyPI only
+        env:
+          PYPI_INDEX_URL: https://pypi.org/simple
+          WHEEL_PATH: ${{ steps.query-testpypi.outputs.wheel-path }}
+        run: |
+          env \
+            -u PIP_EXTRA_INDEX_URL \
+            -u PIP_INDEX_URL \
+            -u UV_DEFAULT_INDEX \
+            -u UV_EXTRA_INDEX_URL \
+            -u UV_INDEX \
+            -u UV_INDEX_URL \
+            uv --no-config pip install \
+              --python .verify-venv/bin/python \
+              --default-index "$PYPI_INDEX_URL" \
+              --index-strategy first-index \
+              --strict \
+              "$WHEEL_PATH"
+
+      - id: verify-installed-package
+        name: Validate installed metadata and import
+        env:
+          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
+          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          cd "$RUNNER_TEMP"
+          "$GITHUB_WORKSPACE/.verify-venv/bin/python" - <<'PY'
+          import importlib.metadata
+          import os
+          import pathlib
+          import sys
+
+          import pylxpweb
+
+          distribution = importlib.metadata.distribution(os.environ["EXPECTED_PROJECT_NAME"])
+          assert distribution.metadata["Name"] == os.environ["EXPECTED_PROJECT_NAME"]
+          assert distribution.version == os.environ["EXPECTED_VERSION"]
+          assert pylxpweb.__version__ == os.environ["EXPECTED_VERSION"]
+          package_path = pathlib.Path(pylxpweb.__file__).resolve()
+          package_path.relative_to(pathlib.Path(sys.prefix).resolve())
+          PY
 
   publish-pypi:
-    name: Publish to PyPI
+    name: Publish verified original artifact to PyPI
+    if: github.event_name == 'release'
+    needs: [build, verify-testpypi]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, publish-testpypi]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'pypi')
     environment: pypi
     permissions:
+      contents: read
       id-token: write
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
+      - id: download-release-artifact
+        name: Download original release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: python-package-distributions
-          path: dist/
+          name: ${{ needs.build.outputs.artifact-name }}
+          path: release-bundle/
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          print-hash: true
-
-      - name: Create PyPI summary
+      - id: revalidate-release-bundle
+        name: Revalidate original release artifact
+        env:
+          EXPECTED_ARTIFACT_NAME: ${{ needs.build.outputs.artifact-name }}
+          EXPECTED_COMMIT: ${{ needs.build.outputs.commit }}
+          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
+          EXPECTED_TAG: ${{ needs.build.outputs.tag }}
+          EXPECTED_TREE: ${{ needs.build.outputs.tree }}
+          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          echo "## Published to PyPI" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Package: pylxpweb" >> $GITHUB_STEP_SUMMARY
-          echo "Install: \`pip install pylxpweb\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "View on PyPI: https://pypi.org/project/pylxpweb/" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+          (cd release-bundle && sha256sum --check SHA256SUMS)
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+
+          bundle = pathlib.Path("release-bundle")
+          source = json.loads(bundle.joinpath("release-source.json").read_text())
+          expected = {
+              "artifact_name": os.environ["EXPECTED_ARTIFACT_NAME"],
+              "commit": os.environ["EXPECTED_COMMIT"],
+              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
+              "tag": os.environ["EXPECTED_TAG"],
+              "tree": os.environ["EXPECTED_TREE"],
+              "version": os.environ["EXPECTED_VERSION"],
+          }
+          assert {key: source[key] for key in expected} == expected
+          wheels = list(bundle.glob("dist/*.whl"))
+          sdists = list(bundle.glob("dist/*.tar.gz"))
+          assert len(wheels) == 1, wheels
+          assert len(sdists) == 1, sdists
+          manifest_paths = {
+              line.split("  ", 1)[1]
+              for line in bundle.joinpath("SHA256SUMS").read_text().splitlines()
+          }
+          expected_hashed = {
+              "release-source.json",
+              wheels[0].relative_to(bundle).as_posix(),
+              sdists[0].relative_to(bundle).as_posix(),
+          }
+          assert manifest_paths == expected_hashed
+          all_files = {
+              path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
+          }
+          assert all_files == expected_hashed | {"SHA256SUMS"}
+          PY
+
+      - id: publish-pypi
+        name: Publish to PyPI with trusted publishing
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          packages-dir: release-bundle/dist/

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -104,7 +104,6 @@ def test_build_exports_bound_source_and_artifact_identity() -> None:
         "RELEASE_TAG": "${{ github.event.release.tag_name }}",
         "RELEASE_TARGET": "${{ github.event.release.target_commitish }}",
         "RELEASE_URL": "${{ github.event.release.html_url }}",
-        "REPOSITORY": "${{ github.repository }}",
     }
 
 

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -18,6 +18,12 @@ import yaml
 _WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
 _WORKFLOW_DOCS_PATH = Path(__file__).resolve().parents[2] / ".github" / "WORKFLOWS.md"
 _FULL_SHA_ACTION = re.compile(r"^[^\s@]+@[0-9a-f]{40}$")
+_WHEEL_NAME = "pylxpweb-1.2.3-py3-none-any.whl"
+_SDIST_NAME = "pylxpweb-1.2.3.tar.gz"
+_DISTRIBUTIONS = {_WHEEL_NAME: b"wheel bytes", _SDIST_NAME: b"sdist bytes"}
+_DISTRIBUTION_HASHES = {
+    name: hashlib.sha256(content).hexdigest() for name, content in _DISTRIBUTIONS.items()
+}
 
 
 def _workflow() -> dict[str, Any]:
@@ -116,6 +122,15 @@ def _python_heredoc(job_id: str, step_id: str) -> str:
     return match.group("code")
 
 
+def _execute_python_heredoc(job_id: str, step_id: str) -> None:
+    namespace: dict[str, Any] = {"__builtins__": __builtins__}
+    exec(
+        compile(_python_heredoc(job_id, step_id), step_id, "exec"),
+        namespace,
+        namespace,
+    )
+
+
 class _Response(io.BytesIO):
     def __init__(self, content: bytes, url: str) -> None:
         super().__init__(content)
@@ -125,28 +140,39 @@ class _Response(io.BytesIO):
         return self._url
 
 
-def _testpypi_payload(
-    wheel_name: str,
-    sdist_name: str,
-    hashes: dict[str, str],
+def _index_payload(
+    filenames: list[str] | tuple[str, ...],
+    *,
+    file_host: str | None = None,
 ) -> dict[str, Any]:
-    return {
-        "info": {"name": "pylxpweb", "version": "1.2.3"},
-        "urls": [
-            {
-                "filename": wheel_name,
-                "url": f"https://files.test/{wheel_name}",
-                "yanked": False,
-                "digests": {"sha256": hashes[wheel_name]},
-            },
-            {
-                "filename": sdist_name,
-                "url": f"https://files.test/{sdist_name}",
-                "yanked": False,
-                "digests": {"sha256": hashes[sdist_name]},
-            },
-        ],
-    }
+    releases = []
+    for filename in filenames:
+        release = {
+            "filename": filename,
+            "yanked": False,
+            "digests": {"sha256": _DISTRIBUTION_HASHES.get(filename, "0" * 64)},
+        }
+        if file_host is not None:
+            release["url"] = f"https://{file_host}/{filename}"
+        releases.append(release)
+    return {"info": {"name": "pylxpweb", "version": "1.2.3"}, "urls": releases}
+
+
+def _write_release_bundle(tmp_path: Path) -> None:
+    bundle = tmp_path / "release-bundle"
+    dist = bundle / "dist"
+    dist.mkdir(parents=True)
+    for filename, content in _DISTRIBUTIONS.items():
+        dist.joinpath(filename).write_bytes(content)
+    bundle.joinpath("SHA256SUMS").write_text(
+        "\n".join(
+            [
+                f"{'0' * 64}  release-source.json",
+                *(f"{_DISTRIBUTION_HASHES[name]}  dist/{name}" for name in sorted(_DISTRIBUTIONS)),
+            ]
+        )
+        + "\n"
+    )
 
 
 def _run_testpypi_verifier(
@@ -155,26 +181,11 @@ def _run_testpypi_verifier(
     *,
     payload: dict[str, Any],
     downloads: dict[str, bytes],
-    hashes: dict[str, str],
 ) -> None:
-    bundle = tmp_path / "release-bundle"
-    bundle.mkdir()
-    wheel_name = "pylxpweb-1.2.3-py3-none-any.whl"
-    sdist_name = "pylxpweb-1.2.3.tar.gz"
-    bundle.joinpath("SHA256SUMS").write_text(
-        "\n".join(
-            [
-                f"{'0' * 64}  release-source.json",
-                f"{hashes[wheel_name]}  dist/{wheel_name}",
-                f"{hashes[sdist_name]}  dist/{sdist_name}",
-            ]
-        )
-        + "\n"
-    )
+    _write_release_bundle(tmp_path)
     output = tmp_path / "github-output"
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("ALLOWED_DISTRIBUTION_HOST", "files.test")
-    monkeypatch.setenv("ALLOWED_WHEEL_HOST", "files.test")
     monkeypatch.setenv("EXPECTED_PROJECT_NAME", "pylxpweb")
     monkeypatch.setenv("EXPECTED_VERSION", "1.2.3")
     monkeypatch.setenv("GITHUB_OUTPUT", str(output))
@@ -190,36 +201,25 @@ def _run_testpypi_verifier(
         return _Response(downloads[filename], url)
 
     monkeypatch.setattr("urllib.request.urlopen", urlopen)
-    namespace: dict[str, Any] = {"__builtins__": __builtins__}
-    exec(
-        compile(_python_heredoc("verify-testpypi", "query-testpypi"), "query-testpypi", "exec"),
-        namespace,
-        namespace,
-    )
+    _execute_python_heredoc("verify-testpypi", "query-testpypi")
 
 
 def test_testpypi_verifier_downloads_and_hashes_both_distributions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Remote verification covers the wheel and sdist while exporting the wheel."""
-    wheel_name = "pylxpweb-1.2.3-py3-none-any.whl"
-    sdist_name = "pylxpweb-1.2.3.tar.gz"
-    downloads = {wheel_name: b"wheel bytes", sdist_name: b"sdist bytes"}
-    hashes = {name: hashlib.sha256(content).hexdigest() for name, content in downloads.items()}
-
     _run_testpypi_verifier(
         tmp_path,
         monkeypatch,
-        payload=_testpypi_payload(wheel_name, sdist_name, hashes),
-        downloads=downloads,
-        hashes=hashes,
+        payload=_index_payload(tuple(_DISTRIBUTIONS), file_host="files.test"),
+        downloads=_DISTRIBUTIONS,
     )
 
     verified = tmp_path / "verified-distributions"
-    assert verified.joinpath(wheel_name).read_bytes() == downloads[wheel_name]
-    assert verified.joinpath(sdist_name).read_bytes() == downloads[sdist_name]
+    assert verified.joinpath(_WHEEL_NAME).read_bytes() == _DISTRIBUTIONS[_WHEEL_NAME]
+    assert verified.joinpath(_SDIST_NAME).read_bytes() == _DISTRIBUTIONS[_SDIST_NAME]
     assert (tmp_path / "github-output").read_text() == (
-        f"wheel-path=verified-distributions/{wheel_name}\n"
+        f"wheel-path=verified-distributions/{_WHEEL_NAME}\n"
     )
 
 
@@ -243,21 +243,18 @@ def test_testpypi_verifier_rejects_untrusted_remote_state(
     expected_error: str,
 ) -> None:
     """Index metadata, hosts, file sets, and downloaded bytes fail closed."""
-    wheel_name = "pylxpweb-1.2.3-py3-none-any.whl"
-    sdist_name = "pylxpweb-1.2.3.tar.gz"
-    downloads = {wheel_name: b"wheel bytes", sdist_name: b"sdist bytes"}
-    hashes = {name: hashlib.sha256(content).hexdigest() for name, content in downloads.items()}
-    payload = _testpypi_payload(wheel_name, sdist_name, hashes)
+    downloads = _DISTRIBUTIONS.copy()
+    payload = _index_payload(tuple(_DISTRIBUTIONS), file_host="files.test")
     if case == "wrong-project":
         payload["info"]["name"] = "other"
     elif case == "wrong-version":
         payload["info"]["version"] = "9.9.9"
     elif case == "wrong-host":
-        payload["urls"][1]["url"] = f"https://evil.test/{sdist_name}"
+        payload["urls"][1]["url"] = f"https://evil.test/{_SDIST_NAME}"
     elif case == "wrong-index-hash":
         payload["urls"][1]["digests"]["sha256"] = "0" * 64
     elif case == "wrong-download-hash":
-        downloads[sdist_name] = b"different"
+        downloads[_SDIST_NAME] = b"different"
     elif case == "yanked":
         payload["urls"][1]["yanked"] = True
     elif case == "unexpected":
@@ -278,22 +275,7 @@ def test_testpypi_verifier_rejects_untrusted_remote_state(
             monkeypatch,
             payload=payload,
             downloads=downloads,
-            hashes=hashes,
         )
-
-
-def _pypi_payload(filenames: list[str], hashes: dict[str, str]) -> dict[str, Any]:
-    return {
-        "info": {"name": "pylxpweb", "version": "1.2.3"},
-        "urls": [
-            {
-                "filename": filename,
-                "yanked": False,
-                "digests": {"sha256": hashes.get(filename, "0" * 64)},
-            }
-            for filename in filenames
-        ],
-    }
 
 
 def _run_pypi_state_step(
@@ -304,25 +286,7 @@ def _run_pypi_state_step(
     mode: str,
     responses: list[dict[str, Any] | None],
 ) -> tuple[set[str], str, int]:
-    bundle = tmp_path / "release-bundle"
-    dist = bundle / "dist"
-    dist.mkdir(parents=True)
-    files = {
-        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel bytes",
-        "pylxpweb-1.2.3.tar.gz": b"sdist bytes",
-    }
-    hashes = {name: hashlib.sha256(content).hexdigest() for name, content in files.items()}
-    for filename, content in files.items():
-        dist.joinpath(filename).write_bytes(content)
-    bundle.joinpath("SHA256SUMS").write_text(
-        "\n".join(
-            [
-                f"{'0' * 64}  release-source.json",
-                *(f"{hashes[name]}  dist/{name}" for name in sorted(files)),
-            ]
-        )
-        + "\n"
-    )
+    _write_release_bundle(tmp_path)
     output = tmp_path / "github-output"
     upload = tmp_path / "pypi-upload"
     monkeypatch.chdir(tmp_path)
@@ -347,12 +311,7 @@ def _run_pypi_state_step(
         return _Response(json.dumps(payload).encode(), request.full_url)
 
     monkeypatch.setattr("urllib.request.urlopen", urlopen)
-    namespace: dict[str, Any] = {"__builtins__": __builtins__}
-    exec(
-        compile(_python_heredoc("publish-pypi", step_id), step_id, "exec"),
-        namespace,
-        namespace,
-    )
+    _execute_python_heredoc("publish-pypi", step_id)
     staged = {path.name for path in upload.iterdir()} if upload.exists() else set()
     return staged, output.read_text() if output.exists() else "", calls
 
@@ -362,15 +321,8 @@ def test_pypi_preflight_stages_only_absent_distributions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, existing_count: int
 ) -> None:
     """A retry publishes none, one, or both files without production skipping."""
-    filenames = [
-        "pylxpweb-1.2.3-py3-none-any.whl",
-        "pylxpweb-1.2.3.tar.gz",
-    ]
-    hashes = {
-        filenames[0]: hashlib.sha256(b"wheel bytes").hexdigest(),
-        filenames[1]: hashlib.sha256(b"sdist bytes").hexdigest(),
-    }
-    payload = None if existing_count == 0 else _pypi_payload(filenames[:existing_count], hashes)
+    filenames = list(_DISTRIBUTIONS)
+    payload = None if existing_count == 0 else _index_payload(filenames[:existing_count])
 
     staged, output, calls = _run_pypi_state_step(
         tmp_path,
@@ -400,9 +352,7 @@ def test_pypi_preflight_rejects_untrusted_existing_files(
     expected_error: str,
 ) -> None:
     """Existing production files are accepted only as an exact trusted subset."""
-    wheel = "pylxpweb-1.2.3-py3-none-any.whl"
-    hashes = {wheel: hashlib.sha256(b"wheel bytes").hexdigest()}
-    payload = _pypi_payload([wheel], hashes)
+    payload = _index_payload([_WHEEL_NAME])
     if case == "wrong-hash":
         payload["urls"][0]["digests"]["sha256"] = "0" * 64
     elif case == "unexpected":
@@ -430,14 +380,7 @@ def test_pypi_final_verification_retries_until_exact_set(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Index propagation is bounded and must converge to the exact file set."""
-    filenames = [
-        "pylxpweb-1.2.3-py3-none-any.whl",
-        "pylxpweb-1.2.3.tar.gz",
-    ]
-    hashes = {
-        filenames[0]: hashlib.sha256(b"wheel bytes").hexdigest(),
-        filenames[1]: hashlib.sha256(b"sdist bytes").hexdigest(),
-    }
+    filenames = list(_DISTRIBUTIONS)
 
     staged, output, calls = _run_pypi_state_step(
         tmp_path,
@@ -445,8 +388,8 @@ def test_pypi_final_verification_retries_until_exact_set(
         step_id="verify-pypi",
         mode="verify",
         responses=[
-            _pypi_payload(filenames[:1], hashes),
-            _pypi_payload(filenames, hashes),
+            _index_payload(filenames[:1]),
+            _index_payload(filenames),
         ],
     )
 
@@ -471,15 +414,7 @@ def test_pypi_final_verification_rejects_untrusted_state(
     expected_error: str,
 ) -> None:
     """Post-publication verification fails closed on every non-exact state."""
-    filenames = [
-        "pylxpweb-1.2.3-py3-none-any.whl",
-        "pylxpweb-1.2.3.tar.gz",
-    ]
-    hashes = {
-        filenames[0]: hashlib.sha256(b"wheel bytes").hexdigest(),
-        filenames[1]: hashlib.sha256(b"sdist bytes").hexdigest(),
-    }
-    payload = _pypi_payload(filenames, hashes)
+    payload = _index_payload(list(_DISTRIBUTIONS))
     if case == "missing":
         payload["urls"].pop()
     elif case == "wrong-hash":

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -22,7 +22,7 @@ _FULL_SHA_ACTION = re.compile(r"^[^\s@]+@[0-9a-f]{40}$")
 _PACKAGE_INDEX_PUBLISHER = re.compile(
     r"pypa/gh-action-pypi-publish@|"
     r"https://(?:(?:test|upload)\.)?pypi\.org/legacy/|"
-    r"\b(?:twine\s+upload|uv\s+publish)\b",
+    r"\b(?:twine\s+upload|(?:uv|poetry|hatch|flit|pdm)\s+publish)\b",
     re.IGNORECASE,
 )
 _WHEEL_NAME = "pylxpweb-1.2.3-py3-none-any.whl"
@@ -920,6 +920,21 @@ def test_package_index_workflow_audit_detects_a_competing_publisher(tmp_path: Pa
     )
 
     assert _package_index_publisher_workflows(tmp_path) == {"build-executables.yml"}
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["poetry publish", "hatch publish", "flit publish", "pdm publish"],
+)
+def test_package_index_workflow_audit_detects_known_publish_commands(
+    tmp_path: Path, command: str
+) -> None:
+    """The audit recognizes established Python package publisher commands."""
+    tmp_path.joinpath("competing.yml").write_text(
+        f"jobs:\n  publish:\n    steps:\n      - run: {command}\n"
+    )
+
+    assert _package_index_publisher_workflows(tmp_path) == {"competing.yml"}
 
 
 def test_workflow_docs_define_compromise_response_and_keep_settings_gate() -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -10,14 +10,21 @@ import re
 import subprocess
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import pytest
 import yaml
 
 _WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+_WORKFLOWS_PATH = _WORKFLOW_PATH.parent
 _WORKFLOW_DOCS_PATH = Path(__file__).resolve().parents[2] / ".github" / "WORKFLOWS.md"
 _FULL_SHA_ACTION = re.compile(r"^[^\s@]+@[0-9a-f]{40}$")
+_PACKAGE_INDEX_PUBLISHER = re.compile(
+    r"pypa/gh-action-pypi-publish@|"
+    r"https://(?:(?:test|upload)\.)?pypi\.org/legacy/|"
+    r"\b(?:twine\s+upload|uv\s+publish)\b",
+    re.IGNORECASE,
+)
 _WHEEL_NAME = "pylxpweb-1.2.3-py3-none-any.whl"
 _SDIST_NAME = "pylxpweb-1.2.3.tar.gz"
 _DISTRIBUTIONS = {_WHEEL_NAME: b"wheel bytes", _SDIST_NAME: b"sdist bytes"}
@@ -45,6 +52,25 @@ def _steps_by_id(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 def _action_steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
     return [step for job in workflow["jobs"].values() for step in job["steps"] if "uses" in step]
+
+
+def _strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        return [text for item in value.values() for text in _strings(item)]
+    if isinstance(value, list):
+        return [text for item in value for text in _strings(item)]
+    return []
+
+
+def _package_index_publisher_workflows(workflows_path: Path) -> set[str]:
+    publishers = set()
+    for path in sorted([*workflows_path.glob("*.yml"), *workflows_path.glob("*.yaml")]):
+        document = yaml.safe_load(path.read_text())
+        if any(_PACKAGE_INDEX_PUBLISHER.search(text) for text in _strings(document)):
+            publishers.add(path.name)
+    return publishers
 
 
 def _step(workflow: dict[str, Any], job_id: str, step_id: str) -> dict[str, Any]:
@@ -284,7 +310,7 @@ def _run_pypi_state_step(
     *,
     step_id: str,
     mode: str,
-    responses: list[dict[str, Any] | None],
+    responses: list[dict[str, Any] | Exception | None],
 ) -> tuple[set[str], str, int]:
     _write_release_bundle(tmp_path)
     output = tmp_path / "github-output"
@@ -293,7 +319,11 @@ def _run_pypi_state_step(
     monkeypatch.setenv("EXPECTED_PROJECT_NAME", "pylxpweb")
     monkeypatch.setenv("EXPECTED_VERSION", "1.2.3")
     monkeypatch.setenv("GITHUB_OUTPUT", str(output))
-    monkeypatch.setenv("MAX_ATTEMPTS", str(len(responses)))
+    step_env = _step(_workflow(), "publish-pypi", step_id)["env"]
+    monkeypatch.setenv("MAX_ATTEMPTS", step_env["MAX_ATTEMPTS"])
+    for name in ("BACKOFF_SECONDS", "MAX_BACKOFF_SECONDS", "REQUEST_TIMEOUT_SECONDS"):
+        if name in step_env:
+            monkeypatch.setenv(name, step_env[name])
     monkeypatch.setenv("MODE", mode)
     monkeypatch.setenv("PYPI_JSON_BASE_URL", "https://index.test/pypi")
     monkeypatch.setenv("UPLOAD_DIR", str(upload))
@@ -305,7 +335,9 @@ def _run_pypi_state_step(
         nonlocal calls
         del timeout
         calls += 1
-        payload = pending.pop(0)
+        payload = pending.pop(0) if pending else responses[-1]
+        if isinstance(payload, Exception):
+            raise payload
         if payload is None:
             raise HTTPError(request.full_url, 404, "Not Found", {}, None)
         return _Response(json.dumps(payload).encode(), request.full_url)
@@ -335,6 +367,41 @@ def test_pypi_preflight_stages_only_absent_distributions(
     assert staged == set(filenames[existing_count:])
     assert output == f"upload-needed={'true' if staged else 'false'}\n"
     assert calls == 1
+
+
+def test_pypi_preflight_retries_transient_failure_then_accepts_absent_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient index failure is retried before a genuine 404 is accepted."""
+    staged, output, calls = _run_pypi_state_step(
+        tmp_path,
+        monkeypatch,
+        step_id="prepare-pypi",
+        mode="prepare",
+        responses=[URLError("temporary failure"), None],
+    )
+
+    assert staged == set(_DISTRIBUTIONS)
+    assert output == "upload-needed=true\n"
+    assert calls == 2
+
+
+def test_pypi_preflight_exhausts_bounded_transient_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Preflight fails closed after its small retry allowance is exhausted."""
+    with pytest.raises(URLError, match="third failure"):
+        _run_pypi_state_step(
+            tmp_path,
+            monkeypatch,
+            step_id="prepare-pypi",
+            mode="prepare",
+            responses=[
+                URLError("first failure"),
+                URLError("second failure"),
+                URLError("third failure"),
+            ],
+        )
 
 
 @pytest.mark.parametrize(
@@ -788,22 +855,30 @@ def test_publishers_use_trusted_publishing_with_skip_only_on_testpypi() -> None:
         "skip-existing": True,
     }
     assert production_steps["prepare-pypi"]["env"] == {
+        "BACKOFF_SECONDS": "2",
         "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
         "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
-        "MAX_ATTEMPTS": "1",
+        "MAX_ATTEMPTS": "3",
+        "MAX_BACKOFF_SECONDS": "5",
         "MODE": "prepare",
         "PYPI_JSON_BASE_URL": "https://pypi.org/pypi",
+        "REQUEST_TIMEOUT_SECONDS": "10",
         "UPLOAD_DIR": "pypi-upload",
     }
-    assert production_publish["if"] == ("steps.prepare-pypi.outputs.upload-needed == 'true'")
+    assert production_publish["if"] == (
+        "success() && steps.prepare-pypi.outputs.upload-needed == 'true'"
+    )
     assert production_publish["with"] == {"packages-dir": "pypi-upload/"}
     assert "skip-existing" not in production_publish["with"]
     assert production_steps["verify-pypi"]["env"] == {
+        "BACKOFF_SECONDS": "5",
         "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
         "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
-        "MAX_ATTEMPTS": "12",
+        "MAX_ATTEMPTS": "8",
+        "MAX_BACKOFF_SECONDS": "20",
         "MODE": "verify",
         "PYPI_JSON_BASE_URL": "https://pypi.org/pypi",
+        "REQUEST_TIMEOUT_SECONDS": "15",
         "UPLOAD_DIR": "pypi-upload",
     }
     order = [
@@ -816,6 +891,35 @@ def test_publishers_use_trusted_publishing_with_skip_only_on_testpypi() -> None:
     assert [list(production_steps).index(step_id) for step_id in order] == sorted(
         list(production_steps).index(step_id) for step_id in order
     )
+
+
+def test_pypi_final_retry_budget_leaves_five_minutes_for_setup_and_upload() -> None:
+    """Worst-case request and backoff time must fit with meaningful job headroom."""
+    job = _job(_workflow(), "publish-pypi")
+    env = _step(_workflow(), "publish-pypi", "verify-pypi")["env"]
+    attempts = int(env["MAX_ATTEMPTS"])
+    request_timeout = int(env["REQUEST_TIMEOUT_SECONDS"])
+    backoff = int(env["BACKOFF_SECONDS"])
+    backoff_cap = int(env["MAX_BACKOFF_SECONDS"])
+    request_budget = attempts * request_timeout
+    backoff_budget = sum(min(backoff * attempt, backoff_cap) for attempt in range(1, attempts))
+
+    assert attempts >= 2
+    assert request_budget + backoff_budget <= job["timeout-minutes"] * 60 - 5 * 60
+
+
+def test_release_is_the_only_package_index_publisher_workflow() -> None:
+    """No release or tag workflow may compete with the package promotion chain."""
+    assert _package_index_publisher_workflows(_WORKFLOWS_PATH) == {"release.yml"}
+
+
+def test_package_index_workflow_audit_detects_a_competing_publisher(tmp_path: Path) -> None:
+    """The repository audit recognizes a publisher action outside release.yml."""
+    tmp_path.joinpath("build-executables.yml").write_text(
+        "jobs:\n  build:\n    steps:\n      - uses: pypa/gh-action-pypi-publish@" + "a" * 40 + "\n"
+    )
+
+    assert _package_index_publisher_workflows(tmp_path) == {"build-executables.yml"}
 
 
 def test_workflow_docs_define_compromise_response_and_keep_settings_gate() -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1,14 +1,22 @@
-"""Structural contract tests for the package release workflow."""
+"""Executable and structural contract tests for the package release workflow."""
 
 from __future__ import annotations
 
+import hashlib
+import io
+import json
+import os
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError
 
+import pytest
 import yaml
 
 _WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+_WORKFLOW_DOCS_PATH = Path(__file__).resolve().parents[2] / ".github" / "WORKFLOWS.md"
 _FULL_SHA_ACTION = re.compile(r"^[^\s@]+@[0-9a-f]{40}$")
 
 
@@ -31,6 +39,622 @@ def _steps_by_id(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 def _action_steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
     return [step for job in workflow["jobs"].values() for step in job["steps"] if "uses" in step]
+
+
+def _step(workflow: dict[str, Any], job_id: str, step_id: str) -> dict[str, Any]:
+    return _steps_by_id(_job(workflow, job_id))[step_id]
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+
+def _commit(repo: Path, message: str, version: str, marker: str) -> str:
+    repo.joinpath("pyproject.toml").write_text(
+        f'[project]\nname = "pylxpweb"\nversion = "{version}"\n'
+    )
+    repo.joinpath("source.txt").write_text(marker)
+    subprocess.run(["git", "add", "pyproject.toml", "source.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", message], cwd=repo, check=True)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _release_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Release Test"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "release-test@example.com"], cwd=repo, check=True
+    )
+    parent = _commit(repo, "parent", "1.2.2", "parent")
+    commit = _commit(repo, "release", "1.2.3", "release")
+    subprocess.run(["git", "tag", "-a", "v1.2.3", "-m", "release"], cwd=repo, check=True)
+    subprocess.run(["git", "update-ref", "refs/remotes/origin/main", commit], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "-q", "--detach", "v1.2.3"], cwd=repo, check=True)
+    subprocess.run(["git", "branch", "-D", "main"], cwd=repo, check=True)
+    return repo, parent, commit
+
+
+def _run_resolve_source(
+    repo: Path,
+    *,
+    commit: str,
+    event_name: str = "release",
+    event_sha: str | None = None,
+    release_tag: str = "v1.2.3",
+    release_target: str = "main",
+    dispatch_tag: str = "v1.2.3",
+) -> subprocess.CompletedProcess[str]:
+    output = repo / "github-output"
+    output.unlink(missing_ok=True)
+    env = os.environ | {
+        "DISPATCH_TAG": dispatch_tag,
+        "EVENT_NAME": event_name,
+        "EVENT_SHA": event_sha or commit,
+        "GITHUB_OUTPUT": str(output),
+        "RELEASE_DRAFT": "false",
+        "RELEASE_ID": "291",
+        "RELEASE_TAG": release_tag,
+        "RELEASE_TARGET": release_target,
+        "RELEASE_URL": "https://github.test/releases/291",
+    }
+    return subprocess.run(
+        ["bash", "-c", _step(_workflow(), "build", "resolve-source")["run"]],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _python_heredoc(job_id: str, step_id: str) -> str:
+    script: str = _step(_workflow(), job_id, step_id)["run"]
+    match = re.fullmatch(r"python3 - <<'PY'\n(?P<code>.*)\nPY\n?", script, re.DOTALL)
+    assert match is not None, step_id
+    return match.group("code")
+
+
+class _Response(io.BytesIO):
+    def __init__(self, content: bytes, url: str) -> None:
+        super().__init__(content)
+        self._url = url
+
+    def geturl(self) -> str:
+        return self._url
+
+
+def _testpypi_payload(
+    wheel_name: str,
+    sdist_name: str,
+    hashes: dict[str, str],
+) -> dict[str, Any]:
+    return {
+        "info": {"name": "pylxpweb", "version": "1.2.3"},
+        "urls": [
+            {
+                "filename": wheel_name,
+                "url": f"https://files.test/{wheel_name}",
+                "yanked": False,
+                "digests": {"sha256": hashes[wheel_name]},
+            },
+            {
+                "filename": sdist_name,
+                "url": f"https://files.test/{sdist_name}",
+                "yanked": False,
+                "digests": {"sha256": hashes[sdist_name]},
+            },
+        ],
+    }
+
+
+def _run_testpypi_verifier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    payload: dict[str, Any],
+    downloads: dict[str, bytes],
+    hashes: dict[str, str],
+) -> None:
+    bundle = tmp_path / "release-bundle"
+    bundle.mkdir()
+    wheel_name = "pylxpweb-1.2.3-py3-none-any.whl"
+    sdist_name = "pylxpweb-1.2.3.tar.gz"
+    bundle.joinpath("SHA256SUMS").write_text(
+        "\n".join(
+            [
+                f"{'0' * 64}  release-source.json",
+                f"{hashes[wheel_name]}  dist/{wheel_name}",
+                f"{hashes[sdist_name]}  dist/{sdist_name}",
+            ]
+        )
+        + "\n"
+    )
+    output = tmp_path / "github-output"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ALLOWED_DISTRIBUTION_HOST", "files.test")
+    monkeypatch.setenv("ALLOWED_WHEEL_HOST", "files.test")
+    monkeypatch.setenv("EXPECTED_PROJECT_NAME", "pylxpweb")
+    monkeypatch.setenv("EXPECTED_VERSION", "1.2.3")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setenv("MAX_ATTEMPTS", "1")
+    monkeypatch.setenv("TESTPYPI_JSON_BASE_URL", "https://index.test/pypi")
+
+    def urlopen(request: Any, timeout: int) -> _Response:
+        del timeout
+        url = request.full_url
+        if url == "https://index.test/pypi/pylxpweb/1.2.3/json":
+            return _Response(json.dumps(payload).encode(), url)
+        filename = Path(url).name
+        return _Response(downloads[filename], url)
+
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+    namespace: dict[str, Any] = {"__builtins__": __builtins__}
+    exec(
+        compile(_python_heredoc("verify-testpypi", "query-testpypi"), "query-testpypi", "exec"),
+        namespace,
+        namespace,
+    )
+
+
+def test_testpypi_verifier_downloads_and_hashes_both_distributions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Remote verification covers the wheel and sdist while exporting the wheel."""
+    wheel_name = "pylxpweb-1.2.3-py3-none-any.whl"
+    sdist_name = "pylxpweb-1.2.3.tar.gz"
+    downloads = {wheel_name: b"wheel bytes", sdist_name: b"sdist bytes"}
+    hashes = {name: hashlib.sha256(content).hexdigest() for name, content in downloads.items()}
+
+    _run_testpypi_verifier(
+        tmp_path,
+        monkeypatch,
+        payload=_testpypi_payload(wheel_name, sdist_name, hashes),
+        downloads=downloads,
+        hashes=hashes,
+    )
+
+    verified = tmp_path / "verified-distributions"
+    assert verified.joinpath(wheel_name).read_bytes() == downloads[wheel_name]
+    assert verified.joinpath(sdist_name).read_bytes() == downloads[sdist_name]
+    assert (tmp_path / "github-output").read_text() == (
+        f"wheel-path=verified-distributions/{wheel_name}\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_error"),
+    [
+        ("wrong-project", "package index project name does not match"),
+        ("wrong-version", "package index version does not match"),
+        ("wrong-host", "distribution URL is not allowlisted HTTPS"),
+        ("wrong-index-hash", "package index hash does not match"),
+        ("wrong-download-hash", "downloaded distribution hash does not match"),
+        ("yanked", "package index contains yanked file"),
+        ("unexpected", "package index file set does not match"),
+        ("missing", "package index file set does not match"),
+    ],
+)
+def test_testpypi_verifier_rejects_untrusted_remote_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    expected_error: str,
+) -> None:
+    """Index metadata, hosts, file sets, and downloaded bytes fail closed."""
+    wheel_name = "pylxpweb-1.2.3-py3-none-any.whl"
+    sdist_name = "pylxpweb-1.2.3.tar.gz"
+    downloads = {wheel_name: b"wheel bytes", sdist_name: b"sdist bytes"}
+    hashes = {name: hashlib.sha256(content).hexdigest() for name, content in downloads.items()}
+    payload = _testpypi_payload(wheel_name, sdist_name, hashes)
+    if case == "wrong-project":
+        payload["info"]["name"] = "other"
+    elif case == "wrong-version":
+        payload["info"]["version"] = "9.9.9"
+    elif case == "wrong-host":
+        payload["urls"][1]["url"] = f"https://evil.test/{sdist_name}"
+    elif case == "wrong-index-hash":
+        payload["urls"][1]["digests"]["sha256"] = "0" * 64
+    elif case == "wrong-download-hash":
+        downloads[sdist_name] = b"different"
+    elif case == "yanked":
+        payload["urls"][1]["yanked"] = True
+    elif case == "unexpected":
+        payload["urls"].append(
+            {
+                "filename": "unexpected.whl",
+                "url": "https://files.test/unexpected.whl",
+                "yanked": False,
+                "digests": {"sha256": "0" * 64},
+            }
+        )
+    elif case == "missing":
+        payload["urls"].pop()
+
+    with pytest.raises(AssertionError, match=expected_error):
+        _run_testpypi_verifier(
+            tmp_path,
+            monkeypatch,
+            payload=payload,
+            downloads=downloads,
+            hashes=hashes,
+        )
+
+
+def _pypi_payload(filenames: list[str], hashes: dict[str, str]) -> dict[str, Any]:
+    return {
+        "info": {"name": "pylxpweb", "version": "1.2.3"},
+        "urls": [
+            {
+                "filename": filename,
+                "yanked": False,
+                "digests": {"sha256": hashes.get(filename, "0" * 64)},
+            }
+            for filename in filenames
+        ],
+    }
+
+
+def _run_pypi_state_step(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    step_id: str,
+    mode: str,
+    responses: list[dict[str, Any] | None],
+) -> tuple[set[str], str, int]:
+    bundle = tmp_path / "release-bundle"
+    dist = bundle / "dist"
+    dist.mkdir(parents=True)
+    files = {
+        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel bytes",
+        "pylxpweb-1.2.3.tar.gz": b"sdist bytes",
+    }
+    hashes = {name: hashlib.sha256(content).hexdigest() for name, content in files.items()}
+    for filename, content in files.items():
+        dist.joinpath(filename).write_bytes(content)
+    bundle.joinpath("SHA256SUMS").write_text(
+        "\n".join(
+            [
+                f"{'0' * 64}  release-source.json",
+                *(f"{hashes[name]}  dist/{name}" for name in sorted(files)),
+            ]
+        )
+        + "\n"
+    )
+    output = tmp_path / "github-output"
+    upload = tmp_path / "pypi-upload"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("EXPECTED_PROJECT_NAME", "pylxpweb")
+    monkeypatch.setenv("EXPECTED_VERSION", "1.2.3")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setenv("MAX_ATTEMPTS", str(len(responses)))
+    monkeypatch.setenv("MODE", mode)
+    monkeypatch.setenv("PYPI_JSON_BASE_URL", "https://index.test/pypi")
+    monkeypatch.setenv("UPLOAD_DIR", str(upload))
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    pending = list(responses)
+    calls = 0
+
+    def urlopen(request: Any, timeout: int) -> _Response:
+        nonlocal calls
+        del timeout
+        calls += 1
+        payload = pending.pop(0)
+        if payload is None:
+            raise HTTPError(request.full_url, 404, "Not Found", {}, None)
+        return _Response(json.dumps(payload).encode(), request.full_url)
+
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+    namespace: dict[str, Any] = {"__builtins__": __builtins__}
+    exec(
+        compile(_python_heredoc("publish-pypi", step_id), step_id, "exec"),
+        namespace,
+        namespace,
+    )
+    staged = {path.name for path in upload.iterdir()} if upload.exists() else set()
+    return staged, output.read_text() if output.exists() else "", calls
+
+
+@pytest.mark.parametrize("existing_count", [0, 1, 2])
+def test_pypi_preflight_stages_only_absent_distributions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, existing_count: int
+) -> None:
+    """A retry publishes none, one, or both files without production skipping."""
+    filenames = [
+        "pylxpweb-1.2.3-py3-none-any.whl",
+        "pylxpweb-1.2.3.tar.gz",
+    ]
+    hashes = {
+        filenames[0]: hashlib.sha256(b"wheel bytes").hexdigest(),
+        filenames[1]: hashlib.sha256(b"sdist bytes").hexdigest(),
+    }
+    payload = None if existing_count == 0 else _pypi_payload(filenames[:existing_count], hashes)
+
+    staged, output, calls = _run_pypi_state_step(
+        tmp_path,
+        monkeypatch,
+        step_id="prepare-pypi",
+        mode="prepare",
+        responses=[payload],
+    )
+
+    assert staged == set(filenames[existing_count:])
+    assert output == f"upload-needed={'true' if staged else 'false'}\n"
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_error"),
+    [
+        ("wrong-hash", "PyPI hash does not match"),
+        ("unexpected", "PyPI contains unexpected file"),
+        ("yanked", "PyPI contains yanked file"),
+    ],
+)
+def test_pypi_preflight_rejects_untrusted_existing_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    expected_error: str,
+) -> None:
+    """Existing production files are accepted only as an exact trusted subset."""
+    wheel = "pylxpweb-1.2.3-py3-none-any.whl"
+    hashes = {wheel: hashlib.sha256(b"wheel bytes").hexdigest()}
+    payload = _pypi_payload([wheel], hashes)
+    if case == "wrong-hash":
+        payload["urls"][0]["digests"]["sha256"] = "0" * 64
+    elif case == "unexpected":
+        payload["urls"].append(
+            {
+                "filename": "unexpected.whl",
+                "yanked": False,
+                "digests": {"sha256": "0" * 64},
+            }
+        )
+    elif case == "yanked":
+        payload["urls"][0]["yanked"] = True
+
+    with pytest.raises(AssertionError, match=expected_error):
+        _run_pypi_state_step(
+            tmp_path,
+            monkeypatch,
+            step_id="prepare-pypi",
+            mode="prepare",
+            responses=[payload],
+        )
+
+
+def test_pypi_final_verification_retries_until_exact_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Index propagation is bounded and must converge to the exact file set."""
+    filenames = [
+        "pylxpweb-1.2.3-py3-none-any.whl",
+        "pylxpweb-1.2.3.tar.gz",
+    ]
+    hashes = {
+        filenames[0]: hashlib.sha256(b"wheel bytes").hexdigest(),
+        filenames[1]: hashlib.sha256(b"sdist bytes").hexdigest(),
+    }
+
+    staged, output, calls = _run_pypi_state_step(
+        tmp_path,
+        monkeypatch,
+        step_id="verify-pypi",
+        mode="verify",
+        responses=[
+            _pypi_payload(filenames[:1], hashes),
+            _pypi_payload(filenames, hashes),
+        ],
+    )
+
+    assert staged == set()
+    assert output == ""
+    assert calls == 2
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_error"),
+    [
+        ("missing", "PyPI final file set does not match"),
+        ("wrong-hash", "PyPI hash does not match"),
+        ("unexpected", "PyPI contains unexpected file"),
+        ("yanked", "PyPI contains yanked file"),
+    ],
+)
+def test_pypi_final_verification_rejects_untrusted_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    expected_error: str,
+) -> None:
+    """Post-publication verification fails closed on every non-exact state."""
+    filenames = [
+        "pylxpweb-1.2.3-py3-none-any.whl",
+        "pylxpweb-1.2.3.tar.gz",
+    ]
+    hashes = {
+        filenames[0]: hashlib.sha256(b"wheel bytes").hexdigest(),
+        filenames[1]: hashlib.sha256(b"sdist bytes").hexdigest(),
+    }
+    payload = _pypi_payload(filenames, hashes)
+    if case == "missing":
+        payload["urls"].pop()
+    elif case == "wrong-hash":
+        payload["urls"][1]["digests"]["sha256"] = "0" * 64
+    elif case == "unexpected":
+        payload["urls"].append(
+            {
+                "filename": "unexpected.whl",
+                "yanked": False,
+                "digests": {"sha256": "0" * 64},
+            }
+        )
+    elif case == "yanked":
+        payload["urls"][1]["yanked"] = True
+
+    with pytest.raises(AssertionError, match=expected_error):
+        _run_pypi_state_step(
+            tmp_path,
+            monkeypatch,
+            step_id="verify-pypi",
+            mode="verify",
+            responses=[payload],
+        )
+
+
+def test_resolve_source_accepts_remote_branch_release_target(tmp_path: Path) -> None:
+    """A detached release checkout resolves a branch target through origin."""
+    repo, _, commit = _release_repo(tmp_path)
+
+    result = _run_resolve_source(repo, commit=commit)
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", "refs/heads/main"], cwd=repo
+        ).returncode
+        != 0
+    )
+    assert _git(repo, "rev-parse", "refs/remotes/origin/main") == commit
+
+
+def test_resolve_source_accepts_full_commit_release_target(tmp_path: Path) -> None:
+    """GitHub may supply the complete target commit instead of a branch name."""
+    repo, _, commit = _release_repo(tmp_path)
+
+    result = _run_resolve_source(repo, commit=commit, release_target=commit)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_resolve_source_accepts_dispatch_and_rejects_other_events(tmp_path: Path) -> None:
+    """Manual validation is supported, but no other event may enter the build path."""
+    repo, parent, commit = _release_repo(tmp_path)
+
+    dispatch = _run_resolve_source(
+        repo,
+        commit=commit,
+        event_name="workflow_dispatch",
+        event_sha=parent,
+        release_tag="",
+        release_target="--ignored",
+    )
+    unsupported = _run_resolve_source(repo, commit=commit, event_name="push")
+
+    assert dispatch.returncode == 0, dispatch.stderr
+    assert unsupported.returncode != 0
+    assert "unsupported release workflow event" in unsupported.stderr
+
+
+@pytest.mark.parametrize("target", ["main~1", "--help", "deadbeef", "missing"])
+def test_resolve_source_rejects_ambiguous_or_malformed_target(tmp_path: Path, target: str) -> None:
+    """Only a full commit or an exact remote branch name is a valid target."""
+    repo, _, commit = _release_repo(tmp_path)
+
+    result = _run_resolve_source(repo, commit=commit, release_target=target)
+
+    assert result.returncode != 0
+    assert "invalid or unresolved release target" in result.stderr
+
+
+@pytest.mark.parametrize("target_kind", ["branch", "commit"])
+def test_resolve_source_rejects_target_before_release(tmp_path: Path, target_kind: str) -> None:
+    """The release tag must be contained by either supported target form."""
+    repo, parent, commit = _release_repo(tmp_path)
+    target = parent
+    if target_kind == "branch":
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/stable", parent],
+            cwd=repo,
+            check=True,
+        )
+        target = "stable"
+
+    result = _run_resolve_source(repo, commit=commit, release_target=target)
+
+    assert result.returncode != 0
+    assert "release tag is not an ancestor of release target" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_error"),
+    [
+        ("event", "release event commit does not match tag commit"),
+        ("tag-version", "release tag does not match project version"),
+        ("main-ancestry", "release tag is not an ancestor of origin/main"),
+    ],
+)
+def test_resolve_source_rejects_identity_mismatch(
+    tmp_path: Path, mutation: str, expected_error: str
+) -> None:
+    """Event, tag, version, checkout tree, and main ancestry remain bound."""
+    repo, parent, commit = _release_repo(tmp_path)
+    kwargs: dict[str, str] = {}
+    if mutation == "event":
+        kwargs["event_sha"] = parent
+    elif mutation == "tag-version":
+        subprocess.run(["git", "tag", "-a", "v1.2.4", "-m", "wrong"], cwd=repo, check=True)
+        kwargs["release_tag"] = "v1.2.4"
+    elif mutation == "main-ancestry":
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/main", parent], cwd=repo, check=True
+        )
+
+    result = _run_resolve_source(repo, commit=commit, **kwargs)
+
+    assert result.returncode != 0
+    assert expected_error in result.stderr
+
+
+def test_release_bundle_validator_rejects_tree_mismatch(tmp_path: Path) -> None:
+    """Artifact promotion rebinds the machine-readable source tree."""
+    bundle = tmp_path / "release-bundle"
+    dist = bundle / "dist"
+    dist.mkdir(parents=True)
+    wheel = dist / "pylxpweb-1.2.3-py3-none-any.whl"
+    sdist = dist / "pylxpweb-1.2.3.tar.gz"
+    wheel.write_bytes(b"wheel")
+    sdist.write_bytes(b"sdist")
+    source = {
+        "artifact_name": "pylxpweb-release-1.2.3-0123456789ab",
+        "commit": "0123456789abcdef0123456789abcdef01234567",
+        "project_name": "pylxpweb",
+        "tag": "v1.2.3",
+        "tree": "1111111111111111111111111111111111111111",
+        "version": "1.2.3",
+    }
+    bundle.joinpath("release-source.json").write_text(json.dumps(source))
+    hashed = [bundle / "release-source.json", wheel, sdist]
+    bundle.joinpath("SHA256SUMS").write_text(
+        "".join(
+            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
+            f"{path.relative_to(bundle).as_posix()}\n"
+            for path in hashed
+        )
+    )
+    env = os.environ | {
+        "EXPECTED_ARTIFACT_NAME": source["artifact_name"],
+        "EXPECTED_COMMIT": source["commit"],
+        "EXPECTED_PROJECT_NAME": source["project_name"],
+        "EXPECTED_TAG": source["tag"],
+        "EXPECTED_TREE": "2222222222222222222222222222222222222222",
+        "EXPECTED_VERSION": source["version"],
+    }
+
+    result = subprocess.run(
+        ["bash", "-c", _step(_workflow(), "build", "validate-release-bundle")["run"]],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "release source identity does not match" in result.stderr
 
 
 def test_release_triggers_are_published_release_or_main_only_manual_build() -> None:
@@ -144,9 +768,10 @@ def test_build_uploads_one_complete_retained_release_artifact() -> None:
 
 def test_build_uses_locked_tools_without_mutating_bound_source() -> None:
     """Dependency setup must not change source after its commit and tree are bound."""
-    workflow = _workflow()
-    steps = _steps_by_id(_job(workflow, "build"))
+    build = _job(_workflow(), "build")
+    steps = _steps_by_id(build)
 
+    assert build["env"] == {"UV_PYTHON": "3.13"}
     assert steps["sync-build-tools"]["env"] == {"UV_LOCKED": "1"}
     step_ids = list(steps)
     assert step_ids.index("sync-build-tools") < step_ids.index("verify-clean-source")
@@ -198,12 +823,13 @@ def test_testpypi_verification_is_unprivileged_bounded_and_ordered() -> None:
         list(steps).index(step_id) for step_id in order
     )
     assert steps["query-testpypi"]["env"] == {
-        "ALLOWED_WHEEL_HOST": "test-files.pythonhosted.org",
+        "ALLOWED_DISTRIBUTION_HOST": "test-files.pythonhosted.org",
         "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
         "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
         "MAX_ATTEMPTS": "12",
         "TESTPYPI_JSON_BASE_URL": "https://test.pypi.org/pypi",
     }
+    assert steps["create-verification-environment"]["run"] == ("uv venv --python 3.13 .verify-venv")
     assert steps["install-testpypi-wheel"]["env"] == {
         "PYPI_INDEX_URL": "https://pypi.org/simple",
         "WHEEL_PATH": "${{ steps.query-testpypi.outputs.wheel-path }}",
@@ -215,17 +841,65 @@ def test_testpypi_verification_is_unprivileged_bounded_and_ordered() -> None:
 
 
 def test_publishers_use_trusted_publishing_with_skip_only_on_testpypi() -> None:
-    """Production must fail on an existing file instead of silently skipping it."""
+    """Production stages absent files and verifies the final exact remote set."""
     workflow = _workflow()
     test_publish = _steps_by_id(_job(workflow, "publish-testpypi"))["publish-testpypi"]
-    production_publish = _steps_by_id(_job(workflow, "publish-pypi"))["publish-pypi"]
+    production_steps = _steps_by_id(_job(workflow, "publish-pypi"))
+    production_publish = production_steps["publish-pypi"]
 
     assert test_publish["with"] == {
         "packages-dir": "release-bundle/dist/",
         "repository-url": "https://test.pypi.org/legacy/",
         "skip-existing": True,
     }
-    assert production_publish["with"] == {"packages-dir": "release-bundle/dist/"}
+    assert production_steps["prepare-pypi"]["env"] == {
+        "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
+        "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
+        "MAX_ATTEMPTS": "1",
+        "MODE": "prepare",
+        "PYPI_JSON_BASE_URL": "https://pypi.org/pypi",
+        "UPLOAD_DIR": "pypi-upload",
+    }
+    assert production_publish["if"] == ("steps.prepare-pypi.outputs.upload-needed == 'true'")
+    assert production_publish["with"] == {"packages-dir": "pypi-upload/"}
+    assert "skip-existing" not in production_publish["with"]
+    assert production_steps["verify-pypi"]["env"] == {
+        "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
+        "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
+        "MAX_ATTEMPTS": "12",
+        "MODE": "verify",
+        "PYPI_JSON_BASE_URL": "https://pypi.org/pypi",
+        "UPLOAD_DIR": "pypi-upload",
+    }
+    order = [
+        "download-release-artifact",
+        "revalidate-release-bundle",
+        "prepare-pypi",
+        "publish-pypi",
+        "verify-pypi",
+    ]
+    assert [list(production_steps).index(step_id) for step_id in order] == sorted(
+        list(production_steps).index(step_id) for step_id in order
+    )
+
+
+def test_workflow_docs_define_compromise_response_and_keep_settings_gate() -> None:
+    """Recovery guidance must stop publishing and preserve the post-merge gate."""
+    docs = _WORKFLOW_DOCS_PATH.read_text()
+    normalized_docs = " ".join(docs.split())
+
+    for phrase in (
+        "Cancel active release workflow runs and pending environment approvals",
+        "Disable the `pypi` and `testpypi` environments",
+        "remove the corresponding trusted-publisher bindings",
+        "Audit the compromised GitHub identity",
+        "revoke its sessions, tokens, and keys",
+        "Restore environments and trusted-publisher bindings only after recovery",
+        "These are post-merge settings gates",
+        "do not apply or mutate repository, environment, or package-index settings",
+        "No long-lived package-index credential is introduced",
+    ):
+        assert phrase in normalized_docs
 
 
 def test_all_actions_are_immutable_full_sha_pins() -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1,0 +1,262 @@
+"""Structural contract tests for the package release workflow."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+_FULL_SHA_ACTION = re.compile(r"^[^\s@]+@[0-9a-f]{40}$")
+
+
+def _workflow() -> dict[str, Any]:
+    workflow: dict[str, Any] = yaml.safe_load(_WORKFLOW_PATH.read_text())
+    # PyYAML follows YAML 1.1 and resolves the unquoted key ``on`` as True.
+    if True in workflow:
+        workflow["on"] = workflow.pop(True)
+    return workflow
+
+
+def _job(workflow: dict[str, Any], job_id: str) -> dict[str, Any]:
+    job: dict[str, Any] = workflow["jobs"][job_id]
+    return job
+
+
+def _steps_by_id(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {step["id"]: step for step in job["steps"] if "id" in step}
+
+
+def _action_steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    return [step for job in workflow["jobs"].values() for step in job["steps"] if "uses" in step]
+
+
+def test_release_triggers_are_published_release_or_main_only_manual_build() -> None:
+    """A tag push or manual publisher path must not bypass a published release."""
+    workflow = _workflow()
+    triggers = workflow["on"]
+
+    assert set(triggers) == {"release", "workflow_dispatch"}
+    assert triggers["release"] == {"types": ["published"]}
+    assert triggers["workflow_dispatch"]["inputs"] == {
+        "tag": {
+            "description": "Existing v* tag to validate",
+            "required": True,
+            "type": "string",
+        }
+    }
+    assert _job(workflow, "build")["if"] == (
+        "github.event_name == 'release' || github.ref == 'refs/heads/main'"
+    )
+    for job_id in ("publish-testpypi", "verify-testpypi", "publish-pypi"):
+        assert _job(workflow, job_id)["if"] == "github.event_name == 'release'"
+
+
+def test_oidc_is_confined_to_publisher_jobs() -> None:
+    """Compromising build or verification must not yield an OIDC token."""
+    workflow = _workflow()
+
+    assert workflow["permissions"] == {"contents": "read"}
+    for job_id, job in workflow["jobs"].items():
+        permissions = job.get("permissions", {})
+        if job_id in {"publish-testpypi", "publish-pypi"}:
+            assert permissions == {"contents": "read", "id-token": "write"}
+        else:
+            assert "id-token" not in permissions
+
+
+def test_release_jobs_form_a_verified_promotion_chain() -> None:
+    """Production publication must depend on independent TestPyPI verification."""
+    workflow = _workflow()
+
+    assert set(workflow["jobs"]) == {
+        "build",
+        "publish-testpypi",
+        "verify-testpypi",
+        "publish-pypi",
+    }
+    assert _job(workflow, "publish-testpypi")["needs"] == "build"
+    assert _job(workflow, "verify-testpypi")["needs"] == ["build", "publish-testpypi"]
+    assert _job(workflow, "publish-pypi")["needs"] == ["build", "verify-testpypi"]
+    assert _job(workflow, "publish-testpypi")["environment"] == "testpypi"
+    assert "environment" not in _job(workflow, "verify-testpypi")
+    assert _job(workflow, "publish-pypi")["environment"] == "pypi"
+
+
+def test_build_exports_bound_source_and_artifact_identity() -> None:
+    """Every downstream check must consume identity resolved once by build."""
+    workflow = _workflow()
+    build = _job(workflow, "build")
+    source = _steps_by_id(build)["resolve-source"]
+
+    assert build["outputs"] == {
+        key: f"${{{{ steps.resolve-source.outputs.{key} }}}}"
+        for key in ("artifact-name", "commit", "project-name", "tag", "tree", "version")
+    }
+    assert source["env"] == {
+        "DISPATCH_TAG": "${{ inputs.tag }}",
+        "EVENT_NAME": "${{ github.event_name }}",
+        "EVENT_SHA": "${{ github.sha }}",
+        "RELEASE_DRAFT": "${{ github.event.release.draft }}",
+        "RELEASE_ID": "${{ github.event.release.id }}",
+        "RELEASE_TAG": "${{ github.event.release.tag_name }}",
+        "RELEASE_TARGET": "${{ github.event.release.target_commitish }}",
+        "RELEASE_URL": "${{ github.event.release.html_url }}",
+        "REPOSITORY": "${{ github.repository }}",
+    }
+
+
+def test_build_uploads_one_complete_retained_release_artifact() -> None:
+    """Promotion must use one named bundle containing both distributions and manifests."""
+    workflow = _workflow()
+    build = _job(workflow, "build")
+    steps = _steps_by_id(build)
+    expected_order = [
+        "resolve-source",
+        "build-distributions",
+        "check-distributions",
+        "validate-distributions",
+        "write-source-manifest",
+        "write-sha256-manifest",
+        "validate-release-bundle",
+        "upload-release-artifact",
+    ]
+
+    positions = {step_id: index for index, step_id in enumerate(steps)}
+    assert positions.keys() >= set(expected_order)
+    assert [positions[step_id] for step_id in expected_order] == sorted(
+        positions[step_id] for step_id in expected_order
+    )
+    uploads = [
+        step
+        for step in _action_steps(workflow)
+        if step["uses"].startswith("actions/upload-artifact@")
+    ]
+    assert uploads == [steps["upload-release-artifact"]]
+    assert uploads[0]["with"] == {
+        "name": "${{ steps.resolve-source.outputs.artifact-name }}",
+        "path": "release-bundle/",
+        "if-no-files-found": "error",
+        "retention-days": 30,
+    }
+
+
+def test_build_uses_locked_tools_without_mutating_bound_source() -> None:
+    """Dependency setup must not change source after its commit and tree are bound."""
+    workflow = _workflow()
+    steps = _steps_by_id(_job(workflow, "build"))
+
+    assert steps["sync-build-tools"]["env"] == {"UV_LOCKED": "1"}
+    step_ids = list(steps)
+    assert step_ids.index("sync-build-tools") < step_ids.index("verify-clean-source")
+    assert step_ids.index("verify-clean-source") < step_ids.index("build-distributions")
+
+
+def test_every_promotion_downloads_and_revalidates_the_original_artifact() -> None:
+    """Publisher and verifier jobs must never rebuild or select a different bundle."""
+    workflow = _workflow()
+
+    for job_id in ("publish-testpypi", "verify-testpypi", "publish-pypi"):
+        job = _job(workflow, job_id)
+        steps = _steps_by_id(job)
+        assert steps["download-release-artifact"]["with"] == {
+            "name": "${{ needs.build.outputs.artifact-name }}",
+            "path": "release-bundle/",
+        }
+        assert steps["revalidate-release-bundle"]["env"] == {
+            "EXPECTED_ARTIFACT_NAME": "${{ needs.build.outputs.artifact-name }}",
+            "EXPECTED_COMMIT": "${{ needs.build.outputs.commit }}",
+            "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
+            "EXPECTED_TAG": "${{ needs.build.outputs.tag }}",
+            "EXPECTED_TREE": "${{ needs.build.outputs.tree }}",
+            "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
+        }
+        step_ids = list(steps)
+        assert step_ids.index("download-release-artifact") < step_ids.index(
+            "revalidate-release-bundle"
+        )
+        assert "build-distributions" not in steps
+
+
+def test_testpypi_verification_is_unprivileged_bounded_and_ordered() -> None:
+    """Verification must prove remote bytes and an isolated production-index install."""
+    workflow = _workflow()
+    verify = _job(workflow, "verify-testpypi")
+    steps = _steps_by_id(verify)
+    order = [
+        "download-release-artifact",
+        "revalidate-release-bundle",
+        "query-testpypi",
+        "create-verification-environment",
+        "install-testpypi-wheel",
+        "verify-installed-package",
+    ]
+
+    assert verify["permissions"] == {"contents": "read"}
+    assert [list(steps).index(step_id) for step_id in order] == sorted(
+        list(steps).index(step_id) for step_id in order
+    )
+    assert steps["query-testpypi"]["env"] == {
+        "ALLOWED_WHEEL_HOST": "test-files.pythonhosted.org",
+        "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
+        "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
+        "MAX_ATTEMPTS": "12",
+        "TESTPYPI_JSON_BASE_URL": "https://test.pypi.org/pypi",
+    }
+    assert steps["install-testpypi-wheel"]["env"] == {
+        "PYPI_INDEX_URL": "https://pypi.org/simple",
+        "WHEEL_PATH": "${{ steps.query-testpypi.outputs.wheel-path }}",
+    }
+    assert steps["verify-installed-package"]["env"] == {
+        "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
+        "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
+    }
+
+
+def test_publishers_use_trusted_publishing_with_skip_only_on_testpypi() -> None:
+    """Production must fail on an existing file instead of silently skipping it."""
+    workflow = _workflow()
+    test_publish = _steps_by_id(_job(workflow, "publish-testpypi"))["publish-testpypi"]
+    production_publish = _steps_by_id(_job(workflow, "publish-pypi"))["publish-pypi"]
+
+    assert test_publish["with"] == {
+        "packages-dir": "release-bundle/dist/",
+        "repository-url": "https://test.pypi.org/legacy/",
+        "skip-existing": True,
+    }
+    assert production_publish["with"] == {"packages-dir": "release-bundle/dist/"}
+
+
+def test_all_actions_are_immutable_full_sha_pins() -> None:
+    """A mutable action tag must not change executable release code after review."""
+    workflow = _workflow()
+    pins: dict[str, set[str]] = {}
+
+    for step in _action_steps(workflow):
+        assert _FULL_SHA_ACTION.fullmatch(step["uses"]), step["uses"]
+        action, pin = step["uses"].split("@", 1)
+        pins.setdefault(action, set()).add(pin)
+    assert pins == {
+        "actions/checkout": {"3d3c42e5aac5ba805825da76410c181273ba90b1"},
+        "actions/download-artifact": {"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"},
+        "actions/upload-artifact": {"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"},
+        "astral-sh/setup-uv": {"37802adc94f370d6bfd71619e3f0bf239e1f3b78"},
+        "pypa/gh-action-pypi-publish": {"dc37677b2e1c63e2034f94d8a5b11f265b73ba33"},
+    }
+
+
+def test_release_job_conditions_fail_closed_without_always() -> None:
+    """Failed identity, publication, or verification checks must stop promotion."""
+    workflow = _workflow()
+
+    assert {job_id: job.get("if") for job_id, job in workflow["jobs"].items()} == {
+        "build": "github.event_name == 'release' || github.ref == 'refs/heads/main'",
+        "publish-testpypi": "github.event_name == 'release'",
+        "verify-testpypi": "github.event_name == 'release'",
+        "publish-pypi": "github.event_name == 'release'",
+    }
+    assert "always()" not in _WORKFLOW_PATH.read_text()
+    for job in workflow["jobs"].values():
+        assert job.get("if") != "always()"


### PR DESCRIPTION
## Summary

- make GitHub Release `published` the only publication path while retaining a required-tag, main-only manual build validation
- build and attest one source-bound wheel/sdist artifact, promote those same bytes through TestPyPI verification to protected PyPI trusted publishing
- add stable-ID PyYAML contract tests and update workflow operator documentation

## Security and release behavior

- workflow default permission is `contents: read`; only TestPyPI and PyPI publisher jobs receive `id-token: write`
- manual dispatch cannot publish, and there is no tag-push trigger
- the build binds release/tag/project version/commit/tree identity, uses a locked unchanged checkout, emits source and SHA256 manifests, and retains one named artifact for 30 days
- the unprivileged verifier requires the exact non-yanked TestPyPI file/hash set, downloads and rehashes both allowlisted HTTPS distributions, and installs the verified wheel locally with dependencies resolved only from production PyPI
- production requires successful verification, revalidates the original artifact, never rebuilds, recovers partial matching publication by staging only absent files, and never uses `skip-existing`

## Validation

- `uv run pytest tests/unit/test_release_workflow.py -q`: 54 passed
- `uv run pytest -q`: 3364 passed, 4 skipped, 80 deselected
- `uv run ruff check src/ tests/`: passed
- `uv run ruff format --check src/ tests/`: 221 files already formatted
- `uv run mypy --strict src/pylxpweb/`: no issues in 95 source files
- Bash syntax: 19 workflow run blocks validated
- Python syntax: 6 embedded programs compiled
- disposable `v0.10.0b2` live path: tag/version/commit/tree resolution, locked clean sync, one wheel plus one sdist, `twine check`, source manifest, three SHA256 entries, repeated artifact revalidation, and clean local-wheel installation with production PyPI as the only dependency index passed; no publisher calls

## TDD evidence

The executable and structural suite is mutation-sensitive across source resolution, artifact identity, TestPyPI remote verification, partial PyPI recovery, bounded retry budgets, publisher conditions, and competing package-index publishers. Review mutations produced RED before restoration to GREEN, including all documented `poetry publish`, `hatch publish`, `flit publish`, and `pdm publish` detector cases.

## Post-merge settings gate (not applied by this PR)

- `pypi`: require a reviewer, allow deployment tags matching `v*` only, and disable administrator bypass
- `testpypi`: allow deployment tags matching `v*` only
- confirm PyPI and TestPyPI trusted-publisher bindings match `joyfulhouse/pylxpweb`, `.github/workflows/release.yml`, and the respective environment names

Closes #291
