### PR TITLE
docs(changelog): reconcile 0.10.0b3 candidate (blocked by #299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Reviewed-merge release provenance binding**
   ([#296](https://github.com/joyfulhouse/pylxpweb/issues/296), PR
   [#297](https://github.com/joyfulhouse/pylxpweb/pull/297)):
-  releases use the tag-resident workflow at a published tag whose commit is
-  current main's reviewed two-parent merge and whose tree matches the CI-tested
-  PR head. The wheel and sdist are built once in a digest-pinned uv/Python
-  container with a read-only source mount and no network, and separate source
+  the tag-resident workflow requires current main's reviewed two-parent release
+  commit and a tree matching the CI-tested PR head. Its digest-pinned uv/Python
+  container builds from a read-only source mount without network access; source
   and distribution attestations are verified before package-index staging.
 
 ## [0.10.0b2] - 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   characterization coverage for existing Z02T11 decoding. There is no runtime
   behavior change.
 
+- **Build backend pinned to `uv_build==0.9.30`**
+  (PR [#297](https://github.com/joyfulhouse/pylxpweb/pull/297)):
+  source builds require that exact PEP 517 backend, matching the release
+  container's bundled uv version so the offline build cannot resolve a
+  different builder. Runtime dependencies and supported Python versions are
+  unchanged.
+
+### Fixed
+
+- **Aging Modbus TCP sessions are proactively recycled**
+  ([#288](https://github.com/joyfulhouse/pylxpweb/issues/288), PR
+  [#290](https://github.com/joyfulhouse/pylxpweb/pull/290), forward-port PR
+  [#295](https://github.com/joyfulhouse/pylxpweb/pull/295)):
+  `ModbusTransport(..., session_max_age=...)` defaults to 3600 seconds with
+  deterministic ±10% per-transport jitter; callers can choose another interval
+  or `None` to disable age recycling. At each outer public operation boundary,
+  the operation lock permits at most one reconnect and keeps a multi-read or
+  read-modify-write operation on one session generation. Reconnects report
+  `age-recycle`, `error-recycle`, or `disconnected-reconnect`; a failed dial
+  imposes a 60-second cooldown. Terminal `async_shutdown()` closes without
+  waiting on the operation lock and rejects later reuse. HYBRID falls back to
+  HTTP after local failure, then retries and resumes local routing after its
+  configured recovery interval.
+
 ### Security
 
 - **Tag-bound, build-once release artifact promotion**
   ([#291](https://github.com/joyfulhouse/pylxpweb/issues/291), PR
   [#292](https://github.com/joyfulhouse/pylxpweb/pull/292)):
   the release workflow builds the wheel and sdist once, binds them to the
-  source commit/tree and their SHA-256 digests, and requires TestPyPI file/hash
-  plus install/metadata verification before promoting the same artifacts to
-  PyPI from a published release tag. Default permissions are read-only;
+  source commit/tree and their SHA-256 digests, and requires TestPyPI
+  project/version identity, exact filenames and index hashes, downloaded-byte
+  rehashing, and a second index snapshot before promoting the same artifacts
+  to PyPI from a published release tag. Default permissions are read-only;
   trusted-publishing OIDC is limited to the TestPyPI and PyPI publisher jobs
   declared against their respective repository environments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **EG4 slave register documentation and Z02T11 characterization coverage**
   (PR [#283](https://github.com/joyfulhouse/pylxpweb/pull/283)):
-  corrects the documented EG4 slave device-information register observations
-  and adds coverage characterizing the existing Z02T11 decoding. There is no
-  runtime behavior change.
+  corrects EG4 slave device-information register documentation and adds
+  characterization coverage for existing Z02T11 decoding. There is no runtime
+  behavior change.
 
 ## [0.10.0b2] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   container builds from a read-only source mount without network access; source
   and distribution attestations are verified before package-index staging.
 
+- **Provenance-bound PyPI recovery for closed publications**
+  ([#299](https://github.com/joyfulhouse/pylxpweb/issues/299), PR
+  [#303](https://github.com/joyfulhouse/pylxpweb/pull/303)):
+  when the release workflow finds the version already on PyPI, it classifies
+  the closed publication state as exact-complete, partial, mismatched, or
+  uncertain instead of failing opaquely. Recovery rediscovers the run-scoped
+  sealed artifacts and verifies their attestations before publishing only
+  ABSENT files — never rebuilding, republishing exact-complete state, using
+  production `skip-existing`, or broadening publisher authority; evidence gaps
+  and remote conflicts fail closed through UNCERTAIN. An unprivileged terminal
+  verify-pypi job confirms the final index state, and the recovery runbook is
+  documented in `.github/WORKFLOWS.md`.
+
 ## [0.10.0b2] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   characterization coverage for existing Z02T11 decoding. There is no runtime
   behavior change.
 
+### Security
+
+- **Tag-bound, build-once release artifact promotion**
+  ([#291](https://github.com/joyfulhouse/pylxpweb/issues/291), PR
+  [#292](https://github.com/joyfulhouse/pylxpweb/pull/292)):
+  the release workflow builds the wheel and sdist once, binds them to the
+  source commit/tree and their SHA-256 digests, and requires TestPyPI file/hash
+  plus install/metadata verification before promoting the same artifacts to
+  PyPI from a published release tag. Default permissions are read-only; OIDC
+  is limited to the TestPyPI and PyPI publisher jobs declared against their
+  respective repository environments.
+
 ## [0.10.0b2] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR [#297](https://github.com/joyfulhouse/pylxpweb/pull/297)):
   source builds require that exact PEP 517 backend, matching the release
   container's bundled uv version so the offline build cannot resolve a
-  different builder. Runtime dependencies and supported Python versions are
-  unchanged.
+  different builder. The pin was restored after a dependency-bump regression
+  in PR [#304](https://github.com/joyfulhouse/pylxpweb/pull/304). Runtime
+  dependencies and supported Python versions are unchanged.
 
 ### Fixed
 
@@ -78,12 +79,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#299](https://github.com/joyfulhouse/pylxpweb/issues/299), PR
   [#303](https://github.com/joyfulhouse/pylxpweb/pull/303)):
   when the release workflow finds the version already on PyPI, it classifies
-  the closed publication state as exact-complete, partial, mismatched, or
-  uncertain instead of failing opaquely. Recovery rediscovers the run-scoped
-  sealed artifacts and verifies their attestations before publishing only
-  ABSENT files — never rebuilding, republishing exact-complete state, using
+  the closed publication state as exact-complete, partial, mismatch, yanked,
+  extra, competing, or uncertain instead of failing opaquely. Recovery
+  rediscovers the run-scoped sealed artifacts and verifies their attestations,
+  and publishes the full sealed wheel/sdist set only when the version is
+  wholly absent from the index — never topping up a partial publication
+  (partial is terminal), rebuilding, republishing exact-complete state, using
   production `skip-existing`, or broadening publisher authority; evidence gaps
-  and remote conflicts fail closed through UNCERTAIN. An unprivileged terminal
+  and remote conflicts fail closed through uncertain. An unprivileged terminal
   verify-pypi job confirms the final index state, and the recovery runbook is
   documented in `.github/WORKFLOWS.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the release workflow builds the wheel and sdist once, binds them to the
   source commit/tree and their SHA-256 digests, and requires TestPyPI file/hash
   plus install/metadata verification before promoting the same artifacts to
-  PyPI from a published release tag. Default permissions are read-only; OIDC
-  is limited to the TestPyPI and PyPI publisher jobs declared against their
-  respective repository environments.
+  PyPI from a published release tag. Default permissions are read-only;
+  trusted-publishing OIDC is limited to the TestPyPI and PyPI publisher jobs
+  declared against their respective repository environments.
+
+- **Reviewed-merge release provenance binding**
+  ([#296](https://github.com/joyfulhouse/pylxpweb/issues/296), PR
+  [#297](https://github.com/joyfulhouse/pylxpweb/pull/297)):
+  releases use the tag-resident workflow at a published tag whose commit is
+  current main's reviewed two-parent merge and whose tree matches the CI-tested
+  PR head. The wheel and sdist are built once in a digest-pinned uv/Python
+  container with a read-only source mount and no network, and separate source
+  and distribution attestations are verified before package-index staging.
 
 ## [0.10.0b2] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   observer after a change. Existing structural transport protocols remain
   unchanged, and observers remain synchronous callbacks that return `None`.
 
+### Changed
+
+- **EG4 slave register documentation and Z02T11 characterization coverage**
+  (PR [#283](https://github.com/joyfulhouse/pylxpweb/pull/283)):
+  corrects the documented EG4 slave device-information register observations
+  and adds coverage characterizing the existing Z02T11 decoding. There is no
+  runtime behavior change.
+
 ## [0.10.0b2] - 2026-08-15
 
 ### Added


### PR DESCRIPTION
## Summary

- preserve the existing `0.10.0b3` observer-control entry for PR #285
- document PR #283's EG4 slave register-documentation correction and characterization of existing Z02T11 decoding, with no runtime behavior change
- document the Modbus TCP session-lifecycle fix from issue #288 and PRs #290/#295
- document PR #292's actual tag-bound artifact promotion and TestPyPI verification boundary
- document PR #297's provenance controls and exact `uv_build==0.9.30` source-build constraint
- document PR #303's provenance-bound PyPI recovery (issue #299): closed-state classification, run-scoped sealed-artifact rediscovery with attestation verification before ABSENT-only publication, fail-closed UNCERTAIN handling, unprivileged terminal verify-pypi, and the documented recovery runbook
- keep the candidate diff limited to `CHANGELOG.md`

## Current candidate identity

- base: `4c2fb578b99ea73d5a3806ef75487775d9e91667` (`main`, PR #303 squash merge)
- current reviewed candidate head: `5391a40931b4e201b1cd5db421ba7389434130db`
- current reviewed candidate tree: `6e87bd150d1b2ae4d3710f13d1e4c41dc16982a5`
- synchronization merge commit (origin/main → branch): `195d8fb5b0f7246b4ffe9485553e6fefbb56f98d`
- post-synchronization pre-tribunal-r1 head: `f481ffa479dc6265a0d9602df9f1d468d442c061`
- pre-synchronization reviewed head: `4cdb70d4ebc3a00659a0c4ae1e5a412f4ca0fddb` (tree `f0adac9390d86c0078e67a99be8dc36f94011c32`)
- pre-frame-remediation head: `31c00c3bb38840c74837571b0627926c7fb7e4cd`
- pre-audit head: `9e1019e68d61745276d08accb1365094d95b2edb`
- earlier pre-synchronization head: `07751e1fd32eca59d3aae45be707ac1221bea266`

## Prerequisite #299 merged as 4c2fb578; candidate synchronized

Prerequisite issue [#299](https://github.com/joyfulhouse/pylxpweb/issues/299) merged to `main` as PR [#303](https://github.com/joyfulhouse/pylxpweb/pull/303) (squash commit `4c2fb578b99ea73d5a3806ef75487775d9e91667`). This candidate has been synchronized by merging `origin/main` into the branch (normal merge commit, no squash/rebase — reviewed history preserved) and now also documents the #303 recovery controls in the `0.10.0b3` entry.

## Candidate-content evidence frame

- PR #283 corrected EG4 slave device-information register documentation and added tests characterizing existing Z02T11 decoding; decoder behavior did not change.
- PR #285 added the existing runtime observer replacement/detach capability already documented in `0.10.0b3`.
- Issue #288 and PRs #290/#295 added proactive jittered Modbus TCP session recycling, the direct `ModbusTransport(..., session_max_age=...)` configuration and `None` opt-out, operation-boundary reconnect serialization, reconnect reasons/cooldown, terminal `async_shutdown()`, and HYBRID local fallback/recovery routing.
- PR #292 builds and promotes one source/digest-bound wheel/sdist pair. Current TestPyPI verification checks project/version identity, exact filenames/index hashes, downloaded bytes, and a second index snapshot before PyPI; it does not install the TestPyPI wheel or verify installed metadata.
- PR #297 binds the tag-resident workflow to current main's reviewed two-parent release commit and CI-tested PR-head tree, constrains the build container, and verifies separate source/build attestations before package-index staging.
- PR #297 also pins `[build-system].requires` to exactly `uv_build==0.9.30`, matching the offline release container's bundled uv/backend (re-affirmed by PR #304). This affects PEP 517 source-build tooling only; runtime dependencies and supported Python versions are unchanged.
- PR #303 (issue #299) classifies an already-closed PyPI publication as exact-complete, partial, mismatched, or uncertain; recovery rediscovers the run-scoped sealed artifacts and verifies their attestations before publishing only ABSENT files, never rebuilding, republishing exact-complete state, using production `skip-existing`, or broadening publisher authority; evidence gaps and remote conflicts fail closed through UNCERTAIN; an unprivileged terminal verify-pypi job confirms final index state; the recovery runbook lives in `.github/WORKFLOWS.md`.

## Scope

The complete changed-file list vs `main` is exactly:

- `CHANGELOG.md`

`pyproject.toml`, `uv.lock`, source, tests, workflows, settings, and compare links are unchanged from base. Both project and lockfile remain `0.10.0b3`.

## FINAL DELIVERY — CREATE A MERGE COMMIT ONLY

> **Use GitHub “CREATE A MERGE COMMIT” only. NEVER squash or rebase the reviewed final candidate.**

The then-reviewed final PR head must be the final GitHub merge commit's second parent (and therefore an ancestor), and the merge tree must equal that reviewed head tree.

## Validation (at synchronized head `5391a409`)

- [x] `git diff origin/main...HEAD --name-only` — exactly `CHANGELOG.md`
- [x] `UV_PYTHON=3.13 uv lock --check` — resolved 70 packages; lock unchanged
- [x] `UV_PYTHON=3.13 UV_LOCKED=1 uv sync --all-extras` — passed
- [x] `UV_PYTHON=3.13 uv run ruff check src/ tests/` — passed
- [x] `UV_PYTHON=3.13 uv run ruff format --check src/ tests/` — 221 files already formatted
- [x] `UV_PYTHON=3.13 uv run mypy --strict src/pylxpweb/` — no issues in 95 source files
- [x] release-workflow test file at merged head — 144 non-container tests pass; the 5 Docker container tests hit the 60s pytest-timeout on this macOS host (slow digest-pinned amd64 image pull/emulation) and are deferred to Linux CI at this head (file content identical to `main`)
- [x] `git diff --check` — clean
- [x] DCO + omnigent co-author trailers on new commits

No tags, releases, TestPyPI/PyPI publications, merges, repository settings, environment settings, or downstream changes are part of this PR.

Closes https://github.com/joyfulhouse/pylxpweb/issues/293
