### PR TITLE
ci: bind releases to reviewed provenance

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -18,69 +18,70 @@ The workflow has four jobs:
 
 ## Package release (`release.yml`)
 
-The only publishing trigger is a GitHub Release `published` event. Pushing a tag
-does not run this workflow, and a manual dispatch cannot publish to either package
-index.
+The only trigger is a GitHub Release `published` event. Pushing a tag does not run
+the workflow, and there is no branch-form manual release path. GitHub must execute
+the copy of `release.yml` stored in the release tag: `github.workflow_ref` must end
+in `@refs/tags/<tag>` and `github.workflow_sha`, `github.sha`, and the peeled tag
+commit must all be identical.
 
 ### Published-release path
 
-Publishing is a four-job promotion chain:
+Publishing is a linear seven-job promotion chain:
 
-1. `build` resolves the release's existing `v*` tag, peels it to a commit and
-   tree, and checks that the tag version, project metadata, release event, release
-   target, checked-out commit, and `origin/main` ancestry agree. It builds exactly
-   one wheel and one source distribution under Python 3.13 from a locked,
-   unchanged checkout, runs `twine check`, records source identity in
-   `release-source.json`, and records each distribution and the source manifest
-   in `SHA256SUMS`.
-2. `publish-testpypi` downloads and revalidates that one named Actions artifact,
-   then publishes it to TestPyPI with trusted publishing. `skip-existing` is
-   permitted here so an interrupted release can resume at the verification gate.
-3. `verify-testpypi` is unprivileged. It downloads and revalidates the original
-   Actions artifact, polls the exact TestPyPI name and version with bounded
-   retries, requires the exact non-yanked filename and SHA256 set, then downloads
-   and rehashes both the allowlisted HTTPS wheel and source distribution. The job
-   installs the verified local wheel in a clean Python 3.13 environment while
-   resolving dependencies only from production PyPI, then validates installed
-   metadata and import behavior.
-4. `publish-pypi` runs only after verification succeeds. It again downloads and
-   revalidates the original artifact, checks any files already present for the
-   version on PyPI, and accepts only a non-yanked, hash-matching subset of the
-   wheel and source distribution. The preflight retries transient index failures
-   up to three times while treating a genuine version 404 as an empty set. It
-   stages and publishes only absent files from the original artifact. If the
-   complete exact set already exists, it skips the publisher. It never rebuilds
-   and never uses `skip-existing`. After publication, it polls PyPI with bounded
-   retries until the final filenames, yanked states, and hashes exactly match.
-   The final retry budget leaves at least five minutes of the job timeout for
-   setup and upload. An upload race fails the publisher closed and can be retried
-   through the same preflight path.
+1. `bind-build-attest` force-fetches only `origin/main` with `--no-tags`, then
+   peels the event tag and requires the tag commit to be current `main`. The commit
+   must be a two-parent GitHub merge commit associated with exactly one merged
+   pull request. Its first parent is the previous `main`, its second parent is the
+   final pull-request head, the base is `main`, an effective non-self approval
+   covers that exact head, and the head's single `CI Success` result succeeded.
+2. The same job builds once in the official uv/Python 3.13 image pinned by the
+   platform-manifest digest recorded in the workflow. Source and container root
+   are read-only; only the distribution directory, ephemeral `/tmp`, and an empty
+   uv cache are writable. The container has no network. uv and Python versions
+   and the exact bundled `uv_build` backend are asserted before
+   `uv build --offline --no-python-downloads --no-sources` creates exactly one
+   wheel and one source distribution.
+3. Immediately before attestation, the job force-fetches `origin/main` again and
+   requires equality with the bound commit. This is the artifact-sealing
+   linearization point. Separate GitHub source-identity and build-provenance
+   attestations are generated, stored with the bundle, and the sealed artifact is
+   uploaded once.
+4. `prepare-testpypi` has no OIDC permission. It verifies the bundle's exact file
+   set and checksums and uses `gh attestation verify` to bind both attestations to
+   the release workflow, workflow digest, tag ref, source digest, and distribution
+   digests. Only then does it stage the two distributions.
+5. `publish-testpypi` has exactly two action steps: a full-SHA-pinned artifact
+   download and the full-SHA-pinned official PyPA publisher. It has OIDC only for
+   TestPyPI trusted publishing and may skip an already-present TestPyPI file.
+6. `verify-testpypi` is unprivileged. It revalidates the original sealed artifact,
+   polls the exact TestPyPI version, requires exactly the two non-yanked filenames
+   and SHA-256 digests, and downloads and rehashes their allowlisted HTTPS bytes.
+7. `prepare-pypi`, `publish-pypi`, and `verify-pypi` repeat the separation for
+   production: the no-OIDC prepare job revalidates and stages only when the
+   version is absent; the OIDC publisher again contains only the two pinned
+   actions; and the no-OIDC verifier polls and downloads the exact final bytes.
 
-The build artifact is named from the project version and peeled commit and is
-retained for 30 days. The workflow default permission is `contents: read`; only
-the two publisher jobs receive `id-token: write`. Production uses the protected
-`pypi` environment, while TestPyPI uses `testpypi`.
+The sealed artifact is named from the version and merge commit and is retained for
+30 days. Job summaries expose the tag, commit, tree, final PR/head, workflow
+ref/SHA, container digest, distribution names/digests, and attestation verification.
 
-### Manual validation path
-
-Manual dispatch requires an existing `v*` tag:
-
-```bash
-gh workflow run release.yml --ref main -f tag=v0.10.0b3
-```
-
-The dispatch must select `main`. It runs only the source-identity, build, package,
-manifest, and artifact checks. All publication and remote-index verification jobs
-are skipped. Use this path to validate release construction without publishing.
+GitHub build/source attestations establish the GitHub workflow and source identity
+for the local subjects. They are distinct from the PEP 740 attestations that the
+PyPA publishing action generates and sends to PyPI during trusted publication.
 
 ### Required repository settings
 
-Before relying on the published-release path, verify these settings after the
-workflow change merges:
+The workflow cannot create or repair these external controls. Verify them before
+unfreezing publication and again during release review:
 
-- The `pypi` environment requires a reviewer, limits deployment tags to `v*`, and
-  does not allow administrators to bypass protection.
-- The `testpypi` environment limits deployment tags to `v*`.
+- `main` is protected: the final release-candidate PR requires review, dismisses
+  stale approval, requires `CI Success`, requires the branch to be up to date,
+  prevents bypass, and is merged with GitHub's **Create a merge commit** method.
+- A tag ruleset protects `v*` tags from update and deletion except for the narrow,
+  audited recovery operation described below.
+- The `pypi` environment requires an independent reviewer, limits deployments to
+  protected `v*` tags, and disallows administrator bypass.
+- The `testpypi` environment limits deployments to protected `v*` tags.
 - PyPI and TestPyPI trusted-publisher bindings match this repository, the
   `release.yml` workflow, and their respective environment names.
 
@@ -89,19 +90,31 @@ or mutate repository, environment, or package-index settings.
 
 ## Release procedure
 
-1. Prepare the version in a pull request. `project.version` in `pyproject.toml`
-   must be the intended tag without the leading `v`.
-2. Merge the reviewed change to `main` after CI succeeds.
-3. Create the `v*` tag on the intended `main` commit.
-4. Optionally run the manual validation path for that tag.
-5. Publish a GitHub Release for the same tag. Publication starts the package
-   promotion chain.
-6. Review the TestPyPI verification result and approve the protected `pypi`
-   environment when prompted.
+1. Prepare the final version and every release-tree change in one final candidate
+   pull request. `project.version` must equal the intended tag without `v`.
+2. Obtain an effective approval and successful required CI on the exact final head.
+   If the head changes, repeat both gates.
+3. Merge with GitHub **Create a merge commit**. Do not squash or rebase.
+4. Confirm no later commit has reached `main`, then create the protected `v*` tag
+   on that GitHub merge commit and publish the GitHub Release for the same tag.
+5. Review the identity and attestation summaries after TestPyPI verification, then
+   approve the protected `pypi` environment if every value matches the candidate.
 
-If production publication is interrupted, rerun the same release workflow. The
-preflight accepts matching files already published from the original artifact and
-stages only the absent distribution; it never enables production `skip-existing`.
+### Recovery at the sealing boundary
+
+- If `main` moves before artifact sealing, the second equality check fails and no
+  package-index upload occurs. Delete the unpublished or failed GitHub Release and
+  its tag using the audited tag-recovery path. Prepare a new final candidate on
+  current `main`, obtain fresh exact-head review and CI, merge it, and create a new
+  release tag. Do not retarget or recreate the old candidate tag.
+- Movement of `main` after the sealing check does not change the sealed artifact.
+  The bound commit/tree/PR/workflow/container and attestation results remain visible
+  in the summaries. Treat the protected-environment approval as the explicit human
+  decision whether to promote that sealed candidate or reject it and use the new
+  candidate procedure above.
+- If TestPyPI or PyPI contains unexpected or mismatched files, stop. Package-index
+  files are immutable; do not use `skip-existing` in production and do not rebuild
+  under the same version. Investigate before preparing a new version.
 
 ## Package publishing compromise response
 
@@ -145,13 +158,12 @@ the GitHub-hosted release event, protected environments, and trusted publishing.
 
 ## Troubleshooting
 
-- A manual run with skipped `build` selected a ref other than `main`.
 - A source-identity failure means the event tag, project version, commit, tree,
-  release target, or `main` ancestry did not agree. Correct the release inputs; do
-  not weaken the check.
+  tag-resident workflow identity, reviewed merge identity, or freshly fetched
+  `main` did not agree. Correct the release inputs; do not weaken the check.
 - A TestPyPI verification failure means the remote name, version, filenames,
-  yanked state, hashes, downloaded wheel, dependency install, metadata, or import
-  did not match the built artifact.
+  yanked state, hashes, or downloaded distributions did not match the sealed
+  artifact.
 - A PyPI job waiting for approval is enforcing the production environment gate.
 - An OIDC failure requires checking the corresponding trusted-publisher binding;
   do not add long-lived package-index credentials.

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -44,7 +44,8 @@ Publishing is a linear seven-job promotion chain:
    build-relevant untracked changes before the build, and that condition is
    rechecked at sealing while allowing only the generated `release-bundle/`.
    The container has no network. uv and Python versions and the exact bundled
-   `uv_build` backend are asserted before
+   `uv_build` backend are asserted, and `SOURCE_DATE_EPOCH` is set unconditionally
+   from the bound commit timestamp rather than inherited from the runner, before
    `uv build --offline --no-python-downloads --no-sources` creates exactly one
    wheel and one source distribution.
 3. Immediately before attestation, the job force-fetches `origin/main` again and
@@ -64,6 +65,15 @@ Publishing is a linear seven-job promotion chain:
    and SHA-256 digests, and downloads and rehashes their allowlisted HTTPS bytes.
    It then takes a second exact index snapshot so a competing publication during
    download fails closed. Production verification uses the same rule.
+
+The TestPyPI verifier's mechanical worst case is 12 minutes 45 seconds: twelve
+30-second index attempts, 255 seconds of capped backoff, two 60-second downloads,
+and a final 30-second snapshot. Its 20-minute job timeout leaves 7 minutes 15
+seconds for artifact download, checksums, attestation verification, and runner
+overhead. The PyPI verifier's corresponding worst case is 8 minutes 45 seconds
+inside a 15-minute job, leaving 6 minutes 15 seconds. A 10-second socket timeout
+only detects inactivity; a process-level total-transfer deadline separately caps
+each index request at 30 seconds and each distribution download at 60 seconds.
 7. `prepare-pypi`, `publish-pypi`, and `verify-pypi` repeat the separation for
    production: the no-OIDC prepare job revalidates and stages only when the
    version is absent; the OIDC publisher again contains only the two pinned

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -32,13 +32,19 @@ Publishing is a linear seven-job promotion chain:
    peels the event tag and requires the tag commit to be current `main`. The commit
    must be a two-parent GitHub merge commit associated with exactly one merged
    pull request. Its first parent is the previous `main`, its second parent is the
-   final pull-request head, the base is `main`, an effective non-self approval
-   covers that exact head, and the head's single `CI Success` result succeeded.
+   final pull-request head, and the first parent must be an ancestor of that head.
+   The PR base is `main`; GitHub's mutable `pull.base.sha` is not used as historical
+   merge evidence. An effective non-self approval covers the exact head. The
+   head's single `CI Success` check must come from GitHub Actions and resolve to a
+   successful pull-request run of this repository's `.github/workflows/ci.yml`.
 2. The same job builds once in the official uv/Python 3.13 image pinned by the
    platform-manifest digest recorded in the workflow. Source and container root
    are read-only; only the distribution directory, ephemeral `/tmp`, and an empty
-   uv cache are writable. The container has no network. uv and Python versions
-   and the exact bundled `uv_build` backend are asserted before
+   uv cache are writable. The checkout must have no tracked, staged, or
+   build-relevant untracked changes before the build, and that condition is
+   rechecked at sealing while allowing only the generated `release-bundle/`.
+   The container has no network. uv and Python versions and the exact bundled
+   `uv_build` backend are asserted before
    `uv build --offline --no-python-downloads --no-sources` creates exactly one
    wheel and one source distribution.
 3. Immediately before attestation, the job force-fetches `origin/main` again and
@@ -56,13 +62,17 @@ Publishing is a linear seven-job promotion chain:
 6. `verify-testpypi` is unprivileged. It revalidates the original sealed artifact,
    polls the exact TestPyPI version, requires exactly the two non-yanked filenames
    and SHA-256 digests, and downloads and rehashes their allowlisted HTTPS bytes.
+   It then takes a second exact index snapshot so a competing publication during
+   download fails closed. Production verification uses the same rule.
 7. `prepare-pypi`, `publish-pypi`, and `verify-pypi` repeat the separation for
    production: the no-OIDC prepare job revalidates and stages only when the
    version is absent; the OIDC publisher again contains only the two pinned
    actions; and the no-OIDC verifier polls and downloads the exact final bytes.
 
 The sealed artifact is named from the version and merge commit and is retained for
-30 days. Job summaries expose the tag, commit, tree, final PR/head, workflow
+30 days. The two staged upload artifacts use the same 30-day retention so a delayed
+protected-environment approval does not require rebuilding or restaging. Job
+summaries expose the tag, commit, tree, final PR/head, workflow
 ref/SHA, container digest, distribution names/digests, and attestation verification.
 
 GitHub build/source attestations establish the GitHub workflow and source identity
@@ -84,6 +94,9 @@ unfreezing publication and again during release review:
 - The `testpypi` environment limits deployments to protected `v*` tags.
 - PyPI and TestPyPI trusted-publisher bindings match this repository, the
   `release.yml` workflow, and their respective environment names.
+- The repository remains public. Checkout credentials are deliberately not
+  persisted, and both source-binding fetches rely on anonymous read-only access to
+  `origin/main`; a visibility change therefore fails closed before any build.
 
 These are post-merge settings gates. The workflow and this document do not apply
 or mutate repository, environment, or package-index settings.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
 
           gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
             "repos/$REPOSITORY/commits/$head/check-runs" > "$api_dir/checks.json"
-          mapfile -t ci_identity < <(
+          ci_run_id=$(
             python3 - "$api_dir/checks.json" "$head" "$REPOSITORY" <<'PY'
           import json
           import pathlib
@@ -222,7 +222,7 @@ jobs:
           PY
           )
           gh api -H "Accept: application/vnd.github+json" \
-            "repos/$REPOSITORY/actions/runs/${ci_identity[0]}" > "$api_dir/ci-run.json"
+            "repos/$REPOSITORY/actions/runs/$ci_run_id" > "$api_dir/ci-run.json"
           python3 - "$api_dir/ci-run.json" "$head" "$REPOSITORY" <<'PY'
           import json
           import pathlib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,66 +3,61 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: Existing v* tag to validate
-        required: true
-        type: string
 
 concurrency:
-  group: release-publish-${{ github.event.release.tag_name || inputs.tag }}
+  group: release-publish-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 permissions:
   contents: read
 
+env:
+  BUILD_IMAGE: ghcr.io/astral-sh/uv:0.9.30-python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca
+
 jobs:
-  build:
-    name: Build and attest release artifact
-    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
+  bind-build-attest:
+    name: Bind, build once, and attest
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    env:
-      UV_PYTHON: '3.13'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     outputs:
-      artifact-name: ${{ steps.resolve-source.outputs.artifact-name }}
-      commit: ${{ steps.resolve-source.outputs.commit }}
-      project-name: ${{ steps.resolve-source.outputs.project-name }}
-      tag: ${{ steps.resolve-source.outputs.tag }}
-      tree: ${{ steps.resolve-source.outputs.tree }}
-      version: ${{ steps.resolve-source.outputs.version }}
+      artifact-name: ${{ steps.bind-source.outputs.artifact-name }}
+      commit: ${{ steps.bind-source.outputs.commit }}
+      head: ${{ steps.bind-source.outputs.head }}
+      pr: ${{ steps.bind-source.outputs.pr }}
+      project-name: ${{ steps.bind-source.outputs.project-name }}
+      tag: ${{ steps.bind-source.outputs.tag }}
+      tree: ${{ steps.bind-source.outputs.tree }}
+      version: ${{ steps.bind-source.outputs.version }}
+      workflow-ref: ${{ steps.bind-source.outputs.workflow-ref }}
+      workflow-sha: ${{ steps.bind-source.outputs.workflow-sha }}
     steps:
       - id: checkout-source
-        name: Check out the requested tag
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        name: Check out the release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          fetch-depth: 2
+          fetch-tags: false
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
 
-      - id: setup-uv
-        name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-
-      - id: setup-python
-        name: Set up Python
-        run: uv python install 3.13
-
-      - id: resolve-source
-        name: Resolve and bind release source identity
+      - id: bind-source
+        name: Bind the event, workflow, merge, review, and CI identity
         env:
-          DISPATCH_TAG: ${{ inputs.tag }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_DRAFT: ${{ github.event.release.draft }}
-          RELEASE_ID: ${{ github.event.release.id }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
 
@@ -71,27 +66,26 @@ jobs:
             exit 1
           }
 
-          if [[ "$EVENT_NAME" == "release" ]]; then
-            tag="$RELEASE_TAG"
-            [[ "$RELEASE_DRAFT" == "false" ]] || die "release must be published"
-            [[ "$RELEASE_ID" =~ ^[0-9]+$ ]] || die "release ID is malformed"
-            [[ -n "$RELEASE_URL" ]] || die "release URL is missing"
-          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            tag="$DISPATCH_TAG"
-          else
-            die "unsupported release workflow event"
-          fi
+          [[ "$EVENT_NAME" == "release" ]] || die "event must be a release"
+          [[ "$RELEASE_DRAFT" == "false" ]] || die "release must be published"
+          tag="$RELEASE_TAG"
+          [[ "$tag" =~ ^v[0-9] ]] || die "release tag is malformed"
+          expected_workflow_ref="$REPOSITORY/.github/workflows/release.yml@refs/tags/$tag"
+          [[ "$WORKFLOW_REF" == "$expected_workflow_ref" ]] || \
+            die "workflow ref must be the release tag"
 
-          [[ "$tag" == v?* ]] || die "release tag must start with v"
+          git fetch --no-tags --force origin \
+            "+refs/heads/main:refs/remotes/origin/main"
           git show-ref --verify --quiet "refs/tags/$tag" || die "release tag does not exist"
-
           tag_object=$(git rev-parse "refs/tags/$tag")
           commit=$(git rev-parse "refs/tags/$tag^{commit}")
           tree=$(git rev-parse "refs/tags/$tag^{tree}")
-          [[ "$(git rev-parse HEAD)" == "$commit" ]] || die "checked-out commit does not match tag commit"
-          [[ "$(git rev-parse HEAD^{tree})" == "$tree" ]] || die "checked-out tree does not match tag tree"
-          git merge-base --is-ancestor "$commit" refs/remotes/origin/main || \
-            die "release tag is not an ancestor of origin/main"
+          [[ "$commit" == "$EVENT_SHA" ]] || die "event commit does not match tag commit"
+          [[ "$commit" == "$WORKFLOW_SHA" ]] || die "workflow SHA does not match tag commit"
+          [[ "$commit" == "$(git rev-parse HEAD)" ]] || die "checkout does not match tag commit"
+          [[ "$tree" == "$(git rev-parse 'HEAD^{tree}')" ]] || die "checkout tree mismatch"
+          [[ "$commit" == "$(git rev-parse 'refs/remotes/origin/main^{commit}')" ]] || \
+            die "release commit is not current main"
 
           project_name=$(python3 -c \
             'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["name"])')
@@ -100,63 +94,202 @@ jobs:
           [[ "$project_name" == "pylxpweb" ]] || die "unexpected project name"
           [[ "$tag" == "v$version" ]] || die "release tag does not match project version"
 
-          if [[ "$EVENT_NAME" == "release" ]]; then
-            [[ "$EVENT_SHA" == "$commit" ]] || die "release event commit does not match tag commit"
-            if [[ "$RELEASE_TARGET" =~ ^[0-9a-fA-F]{40}$ ]]; then
-              target_commit=$(git rev-parse --verify "$RELEASE_TARGET^{commit}") || \
-                die "invalid or unresolved release target"
-            elif git check-ref-format "refs/remotes/origin/$RELEASE_TARGET" >/dev/null 2>&1; then
-              target_ref="refs/remotes/origin/$RELEASE_TARGET"
-              git show-ref --verify --quiet "$target_ref" || \
-                die "invalid or unresolved release target"
-              target_commit=$(git rev-parse --verify "$target_ref^{commit}") || \
-                die "invalid or unresolved release target"
-            else
-              die "invalid or unresolved release target"
-            fi
-            git merge-base --is-ancestor "$commit" "$target_commit" || \
-              die "release tag is not an ancestor of release target"
-          fi
+          read -r -a lineage <<< "$(git rev-list --parents -n 1 "$commit")"
+          [[ "${#lineage[@]}" == 3 ]] || die "tag commit must have exactly two parents"
+          first_parent="${lineage[1]}"
+          second_parent="${lineage[2]}"
+
+          api_dir=$(mktemp -d)
+          trap 'rm -rf "$api_dir"' EXIT
+          gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/commits/$commit/pulls" > "$api_dir/pulls.json"
+          python3 - "$api_dir/pulls.json" "$commit" "$first_parent" "$second_parent" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          pulls = [pull for page in pages for pull in page]
+          commit, first_parent, second_parent = sys.argv[2:]
+          assert len(pulls) == 1, "tag commit must have exactly one associated PR"
+          pull = pulls[0]
+          assert pull["state"] == "closed" and pull["merged_at"], "PR is not merged"
+          assert pull["merge_commit_sha"] == commit, "PR merge commit mismatch"
+          assert pull["base"]["ref"] == "main", "PR base is not main"
+          assert pull["base"]["sha"] == first_parent, "PR base is not first parent"
+          assert pull["head"]["sha"] == second_parent, "PR head is not second parent"
+          print(pull["number"])
+          print(pull["head"]["sha"])
+          print(pull["user"]["login"])
+          PY
+          mapfile -t pr_identity < <(
+            python3 - "$api_dir/pulls.json" <<'PY'
+          import json
+          import pathlib
+          import sys
+          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          pull = [pull for page in pages for pull in page][0]
+          print(pull["number"])
+          print(pull["head"]["sha"])
+          print(pull["user"]["login"])
+          PY
+          )
+          pr="${pr_identity[0]}"
+          head="${pr_identity[1]}"
+          author="${pr_identity[2]}"
+
+          gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/pulls/$pr/reviews" > "$api_dir/reviews.json"
+          python3 - "$api_dir/reviews.json" > "$api_dir/reviewers.txt" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          reviews = [review for page in pages for review in page]
+          effective = {}
+          for review in sorted(
+              reviews,
+              key=lambda item: (item.get("submitted_at") or "", item.get("id", 0)),
+          ):
+              if review["state"] in {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}:
+                  effective[review["user"]["login"]] = review
+          for login, review in sorted(effective.items()):
+              if review["state"] in {"APPROVED", "CHANGES_REQUESTED"}:
+                  print(login)
+          PY
+          : > "$api_dir/permissions.tsv"
+          while IFS= read -r reviewer; do
+            permission=$(gh api -H "Accept: application/vnd.github+json" \
+              "repos/$REPOSITORY/collaborators/$reviewer/permission" --jq .permission)
+            printf '%s\t%s\n' "$reviewer" "$permission" >> "$api_dir/permissions.tsv"
+          done < "$api_dir/reviewers.txt"
+          python3 - "$api_dir/reviews.json" "$api_dir/permissions.tsv" \
+            "$head" "$author" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          reviews = [review for page in pages for review in page]
+          permissions = dict(
+              line.split("\t", 1)
+              for line in pathlib.Path(sys.argv[2]).read_text().splitlines()
+          )
+          head, author = sys.argv[3:]
+          effective = {}
+          for review in sorted(
+              reviews,
+              key=lambda item: (item.get("submitted_at") or "", item.get("id", 0)),
+          ):
+              if review["state"] in {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}:
+                  effective[review["user"]["login"]] = review
+          eligible = {
+              login: review
+              for login, review in effective.items()
+              if permissions.get(login) in {"write", "maintain", "admin"}
+          }
+          assert not any(
+              review["state"] == "CHANGES_REQUESTED" for review in eligible.values()
+          ), "an eligible reviewer still requests changes"
+          assert any(
+              login != author
+              and review["state"] == "APPROVED"
+              and review["commit_id"] == head
+              for login, review in eligible.items()
+          ), "no effective eligible non-self approval covers the exact PR head"
+          PY
+
+          gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/commits/$head/check-runs" > "$api_dir/checks.json"
+          python3 - "$api_dir/checks.json" "$head" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          checks = [check for page in pages for check in page["check_runs"]]
+          head = sys.argv[2]
+          required = [check for check in checks if check["name"] == "CI Success"]
+          assert len(required) == 1, "required CI result is missing or ambiguous"
+          assert required[0]["head_sha"] == head, "required CI covers the wrong head"
+          assert required[0]["conclusion"] == "success", "required CI did not succeed"
+          PY
 
           artifact_name="pylxpweb-release-$version-${commit:0:12}"
           {
             echo "artifact-name=$artifact_name"
             echo "commit=$commit"
+            echo "first-parent=$first_parent"
+            echo "head=$head"
+            echo "pr=$pr"
             echo "project-name=$project_name"
             echo "tag=$tag"
             echo "tag-object=$tag_object"
             echo "tree=$tree"
             echo "version=$version"
+            echo "workflow-ref=$WORKFLOW_REF"
+            echo "workflow-sha=$WORKFLOW_SHA"
           } >> "$GITHUB_OUTPUT"
 
-      - id: sync-build-tools
-        name: Install locked build tools
-        env:
-          UV_LOCKED: '1'
-        run: uv sync --all-extras
-
-      - id: verify-clean-source
-        name: Verify dependency setup preserved bound source
-        run: git diff --exit-code
-
       - id: build-distributions
-        name: Build wheel and source distribution once
+        name: Build once in the pinned offline container
+        env:
+          EXPECTED_COMMIT: ${{ steps.bind-source.outputs.commit }}
+          OUTPUT_DIR: ${{ github.workspace }}/release-bundle/dist
         run: |
-          uv build --out-dir release-bundle/dist
-          rm -f release-bundle/dist/.gitignore
-
-      - id: check-distributions
-        name: Check built distributions
-        run: uv run twine check release-bundle/dist/*
+          set -euo pipefail
+          rm -rf "$OUTPUT_DIR"
+          mkdir -p "$OUTPUT_DIR"
+          epoch=$(git show -s --format=%ct "$EXPECTED_COMMIT")
+          docker pull "$BUILD_IMAGE"
+          docker run --rm \
+            --platform linux/amd64 \
+            --network none \
+            --read-only \
+            --user "$(id -u):$(id -g)" \
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+            --tmpfs /cache:rw,noexec,nosuid,nodev,size=64m \
+            -e HOME=/tmp \
+            -e UV_CACHE_DIR=/cache \
+            -e SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$epoch}" \
+            -v "$GITHUB_WORKSPACE:/src:ro" \
+            -v "$OUTPUT_DIR:/out:rw" \
+            -w /src \
+            "$BUILD_IMAGE" \
+            sh -euc '
+              test "$(uv --version)" = "uv 0.9.30"
+              case "$(python --version)" in "Python 3.13"*) ;; *) exit 1 ;; esac
+              python - <<"PY"
+          import tomllib
+          with open("pyproject.toml", "rb") as file:
+              build = tomllib.load(file)["build-system"]
+          assert build["build-backend"] == "uv_build"
+          assert build["requires"] == ["uv_build==0.9.30"]
+          PY
+              python - <<"PY"
+          import socket
+          try:
+              socket.create_connection(("1.1.1.1", 443), timeout=1)
+          except OSError:
+              pass
+          else:
+              raise AssertionError("build container unexpectedly has network access")
+          PY
+              uv build --offline --no-python-downloads --no-sources \
+                --python /usr/local/bin/python --out-dir /out /src
+            '
+          rm -f "$OUTPUT_DIR/.gitignore"
 
       - id: validate-distributions
-        name: Validate distribution count and metadata
+        name: Validate the exact distribution set and metadata
         env:
-          EXPECTED_PROJECT_NAME: ${{ steps.resolve-source.outputs.project-name }}
-          EXPECTED_VERSION: ${{ steps.resolve-source.outputs.version }}
+          EXPECTED_PROJECT_NAME: ${{ steps.bind-source.outputs.project-name }}
+          EXPECTED_VERSION: ${{ steps.bind-source.outputs.version }}
         run: |
           python3 - <<'PY'
           import email
+          import hashlib
           import os
           import pathlib
           import tarfile
@@ -165,210 +298,312 @@ jobs:
           dist = pathlib.Path("release-bundle/dist")
           wheels = list(dist.glob("*.whl"))
           sdists = list(dist.glob("*.tar.gz"))
-          files = [path for path in dist.iterdir() if path.is_file()]
+          files = sorted(path for path in dist.iterdir() if path.is_file())
           assert len(wheels) == 1, wheels
           assert len(sdists) == 1, sdists
           assert len(files) == 2, files
-
           with zipfile.ZipFile(wheels[0]) as archive:
               members = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
               assert len(members) == 1, members
               wheel_metadata = email.message_from_bytes(archive.read(members[0]))
-
           with tarfile.open(sdists[0], "r:gz") as archive:
-              members = [member for member in archive.getmembers() if member.name.count("/") == 1 and member.name.endswith("/PKG-INFO")]
+              members = [
+                  member for member in archive.getmembers()
+                  if member.name.count("/") == 1 and member.name.endswith("/PKG-INFO")
+              ]
               assert len(members) == 1, members
               extracted = archive.extractfile(members[0])
               assert extracted is not None
               sdist_metadata = email.message_from_binary_file(extracted)
-
           for metadata in (wheel_metadata, sdist_metadata):
               assert metadata["Name"] == os.environ["EXPECTED_PROJECT_NAME"]
               assert metadata["Version"] == os.environ["EXPECTED_VERSION"]
+          manifest = pathlib.Path("release-bundle/DIST_SHA256SUMS")
+          manifest.write_text("".join(
+              f"{hashlib.sha256(path.read_bytes()).hexdigest()}  dist/{path.name}\n"
+              for path in files
+          ))
+          with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              for kind, path in (("wheel", wheels[0]), ("sdist", sdists[0])):
+                  print(f"{kind}-name={path.name}", file=output)
+                  print(f"{kind}-sha256={hashlib.sha256(path.read_bytes()).hexdigest()}", file=output)
           PY
 
       - id: write-source-manifest
-        name: Write machine-readable source manifest
+        name: Record the bound source identity
         env:
-          ARTIFACT_NAME: ${{ steps.resolve-source.outputs.artifact-name }}
-          COMMIT: ${{ steps.resolve-source.outputs.commit }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_SHA: ${{ github.sha }}
-          PROJECT_NAME: ${{ steps.resolve-source.outputs.project-name }}
-          RELEASE_ID: ${{ github.event.release.id }}
-          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-          REPOSITORY: ${{ github.repository }}
-          TAG: ${{ steps.resolve-source.outputs.tag }}
-          TAG_OBJECT: ${{ steps.resolve-source.outputs.tag-object }}
-          TREE: ${{ steps.resolve-source.outputs.tree }}
-          VERSION: ${{ steps.resolve-source.outputs.version }}
+          ARTIFACT_NAME: ${{ steps.bind-source.outputs.artifact-name }}
+          COMMIT: ${{ steps.bind-source.outputs.commit }}
+          CONTAINER_IMAGE: ${{ env.BUILD_IMAGE }}
+          HEAD: ${{ steps.bind-source.outputs.head }}
+          PR: ${{ steps.bind-source.outputs.pr }}
+          PROJECT_NAME: ${{ steps.bind-source.outputs.project-name }}
+          TAG: ${{ steps.bind-source.outputs.tag }}
+          TREE: ${{ steps.bind-source.outputs.tree }}
+          VERSION: ${{ steps.bind-source.outputs.version }}
+          WORKFLOW_REF: ${{ steps.bind-source.outputs.workflow-ref }}
+          WORKFLOW_SHA: ${{ steps.bind-source.outputs.workflow-sha }}
         run: |
           python3 - <<'PY'
           import json
           import os
           import pathlib
-
           keys = (
-              "ARTIFACT_NAME",
-              "COMMIT",
-              "EVENT_NAME",
-              "EVENT_SHA",
-              "PROJECT_NAME",
-              "RELEASE_ID",
-              "RELEASE_TARGET",
-              "RELEASE_URL",
-              "REPOSITORY",
-              "TAG",
-              "TAG_OBJECT",
-              "TREE",
-              "VERSION",
+              "ARTIFACT_NAME", "COMMIT", "CONTAINER_IMAGE", "HEAD", "PR",
+              "PROJECT_NAME", "TAG", "TREE", "VERSION", "WORKFLOW_REF", "WORKFLOW_SHA",
           )
           manifest = {key.lower(): os.environ[key] for key in keys}
-          manifest["schema_version"] = 1
-          path = pathlib.Path("release-bundle/release-source.json")
-          path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+          manifest["pr"] = int(manifest["pr"])
+          manifest["schema_version"] = 2
+          pathlib.Path("release-bundle/release-source.json").write_text(
+              json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+          )
           PY
 
-      - id: write-sha256-manifest
-        name: Write per-file SHA256 manifest
-        run: |
-          python3 - <<'PY'
-          import hashlib
-          import pathlib
-
-          bundle = pathlib.Path("release-bundle")
-          files = sorted([bundle / "release-source.json", *bundle.joinpath("dist").iterdir()])
-          lines = []
-          for path in files:
-              digest = hashlib.sha256(path.read_bytes()).hexdigest()
-              lines.append(f"{digest}  {path.relative_to(bundle).as_posix()}")
-          bundle.joinpath("SHA256SUMS").write_text("\n".join(lines) + "\n")
-          PY
-
-      - id: validate-release-bundle
-        name: Validate complete release bundle
+      - id: seal-source
+        name: Seal only while the candidate is still current main
         env:
-          EXPECTED_ARTIFACT_NAME: ${{ steps.resolve-source.outputs.artifact-name }}
-          EXPECTED_COMMIT: ${{ steps.resolve-source.outputs.commit }}
-          EXPECTED_PROJECT_NAME: ${{ steps.resolve-source.outputs.project-name }}
-          EXPECTED_TAG: ${{ steps.resolve-source.outputs.tag }}
-          EXPECTED_TREE: ${{ steps.resolve-source.outputs.tree }}
-          EXPECTED_VERSION: ${{ steps.resolve-source.outputs.version }}
-        run: &validate-release-bundle |
+          EXPECTED_COMMIT: ${{ steps.bind-source.outputs.commit }}
+        run: |
           set -euo pipefail
-          (cd release-bundle && sha256sum --check SHA256SUMS)
-          python3 - <<'PY'
-          import json
-          import os
-          import pathlib
+          git fetch --no-tags --force origin \
+            "+refs/heads/main:refs/remotes/origin/main"
+          [[ "$(git rev-parse 'refs/remotes/origin/main^{commit}')" == "$EXPECTED_COMMIT" ]] || {
+            echo "release commit is not current main at artifact sealing" >&2
+            exit 1
+          }
 
-          bundle = pathlib.Path("release-bundle")
-          source = json.loads(bundle.joinpath("release-source.json").read_text())
-          expected = {
-              "artifact_name": os.environ["EXPECTED_ARTIFACT_NAME"],
-              "commit": os.environ["EXPECTED_COMMIT"],
-              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
-              "tag": os.environ["EXPECTED_TAG"],
-              "tree": os.environ["EXPECTED_TREE"],
-              "version": os.environ["EXPECTED_VERSION"],
-          }
-          assert {key: source[key] for key in expected} == expected, \
-              "release source identity does not match"
-          wheels = list(bundle.glob("dist/*.whl"))
-          sdists = list(bundle.glob("dist/*.tar.gz"))
-          assert len(wheels) == 1, wheels
-          assert len(sdists) == 1, sdists
-          manifest_paths = {
-              line.split("  ", 1)[1]
-              for line in bundle.joinpath("SHA256SUMS").read_text().splitlines()
-          }
-          expected_hashed = {
-              "release-source.json",
-              wheels[0].relative_to(bundle).as_posix(),
-              sdists[0].relative_to(bundle).as_posix(),
-          }
-          assert manifest_paths == expected_hashed
-          all_files = {
-              path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
-          }
-          assert all_files == expected_hashed | {"SHA256SUMS"}
-          PY
+      - id: attest-source
+        name: Attest the bound source identity
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: release-bundle/release-source.json
+
+      - id: attest-build
+        name: Attest the wheel and sdist build provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: release-bundle/DIST_SHA256SUMS
+
+      - id: assemble-sealed-bundle
+        name: Assemble the sealed release artifact
+        env:
+          BUILD_BUNDLE: ${{ steps.attest-build.outputs.bundle-path }}
+          SOURCE_BUNDLE: ${{ steps.attest-source.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          mkdir release-bundle/attestations
+          cp "$SOURCE_BUNDLE" release-bundle/attestations/source.jsonl
+          cp "$BUILD_BUNDLE" release-bundle/attestations/build.jsonl
+          (
+            cd release-bundle
+            sha256sum release-source.json DIST_SHA256SUMS dist/* > SHA256SUMS
+          )
+
+      - id: release-summary
+        name: Write reviewer-facing release identity summary
+        env:
+          COMMIT: ${{ steps.bind-source.outputs.commit }}
+          HEAD: ${{ steps.bind-source.outputs.head }}
+          PR: ${{ steps.bind-source.outputs.pr }}
+          TAG: ${{ steps.bind-source.outputs.tag }}
+          TREE: ${{ steps.bind-source.outputs.tree }}
+          WHEEL_NAME: ${{ steps.validate-distributions.outputs.wheel-name }}
+          WHEEL_SHA256: ${{ steps.validate-distributions.outputs.wheel-sha256 }}
+          SDIST_NAME: ${{ steps.validate-distributions.outputs.sdist-name }}
+          SDIST_SHA256: ${{ steps.validate-distributions.outputs.sdist-sha256 }}
+          WORKFLOW_REF: ${{ steps.bind-source.outputs.workflow-ref }}
+          WORKFLOW_SHA: ${{ steps.bind-source.outputs.workflow-sha }}
+        run: |
+          {
+            echo "## Sealed release candidate"
+            echo "- Tag: \`$TAG\`"
+            echo "- Commit: \`$COMMIT\`"
+            echo "- Tree: \`$TREE\`"
+            echo "- Final PR/head: \`#$PR\` / \`$HEAD\`"
+            echo "- Workflow ref/SHA: \`$WORKFLOW_REF\` / \`$WORKFLOW_SHA\`"
+            echo "- Container: \`$BUILD_IMAGE\`"
+            echo "- Wheel: \`$WHEEL_NAME\` — \`sha256:$WHEEL_SHA256\`"
+            echo "- Sdist: \`$SDIST_NAME\` — \`sha256:$SDIST_SHA256\`"
+            echo "- Source and build attestations: generated separately; cryptographic verification is required in both prepare jobs."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - id: upload-release-artifact
-        name: Upload immutable release artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        name: Upload the sealed release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
-          name: ${{ steps.resolve-source.outputs.artifact-name }}
+          name: ${{ steps.bind-source.outputs.artifact-name }}
           path: release-bundle/
           if-no-files-found: error
           retention-days: 30
 
+  prepare-testpypi:
+    name: Verify and stage for TestPyPI
+    needs: bind-build-attest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      staging-artifact: ${{ steps.stage.outputs.artifact-name }}
+    steps:
+      - id: download-release-artifact
+        name: Download the sealed release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: ${{ needs.bind-build-attest.outputs.artifact-name }}
+          path: release-bundle/
+
+      - id: verify-release-bundle
+        name: Verify checksums, identity, and attestations
+        env: &bundle-identity
+          ARTIFACT_NAME: ${{ needs.bind-build-attest.outputs.artifact-name }}
+          EXPECTED_COMMIT: ${{ needs.bind-build-attest.outputs.commit }}
+          EXPECTED_CONTAINER_IMAGE: ${{ env.BUILD_IMAGE }}
+          EXPECTED_HEAD: ${{ needs.bind-build-attest.outputs.head }}
+          EXPECTED_PR: ${{ needs.bind-build-attest.outputs.pr }}
+          EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
+          EXPECTED_TAG: ${{ needs.bind-build-attest.outputs.tag }}
+          EXPECTED_TREE: ${{ needs.bind-build-attest.outputs.tree }}
+          EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
+          EXPECTED_WORKFLOW_REF: ${{ needs.bind-build-attest.outputs.workflow-ref }}
+          EXPECTED_WORKFLOW_SHA: ${{ needs.bind-build-attest.outputs.workflow-sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: &verify-release-bundle |
+          set -euo pipefail
+          (cd release-bundle && sha256sum --check SHA256SUMS)
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          import pathlib
+          bundle = pathlib.Path("release-bundle")
+          source = json.loads(bundle.joinpath("release-source.json").read_text())
+          expected = {
+              "artifact_name": os.environ["ARTIFACT_NAME"],
+              "commit": os.environ["EXPECTED_COMMIT"],
+              "container_image": os.environ["EXPECTED_CONTAINER_IMAGE"],
+              "head": os.environ["EXPECTED_HEAD"],
+              "pr": int(os.environ["EXPECTED_PR"]),
+              "project_name": os.environ["EXPECTED_PROJECT_NAME"],
+              "tag": os.environ["EXPECTED_TAG"],
+              "tree": os.environ["EXPECTED_TREE"],
+              "version": os.environ["EXPECTED_VERSION"],
+              "workflow_ref": os.environ["EXPECTED_WORKFLOW_REF"],
+              "workflow_sha": os.environ["EXPECTED_WORKFLOW_SHA"],
+          }
+          assert {key: source[key] for key in expected} == expected
+          assert source["schema_version"] == 2
+          wheels = list(bundle.glob("dist/*.whl"))
+          sdists = list(bundle.glob("dist/*.tar.gz"))
+          assert len(wheels) == len(sdists) == 1
+          dist_files = sorted([wheels[0], sdists[0]])
+          dist_hashes = {}
+          for line in bundle.joinpath("DIST_SHA256SUMS").read_text().splitlines():
+              digest, name = line.split("  ", 1)
+              dist_hashes[name] = digest
+          assert set(dist_hashes) == {
+              path.relative_to(bundle).as_posix() for path in dist_files
+          }
+          assert all(
+              hashlib.sha256(path.read_bytes()).hexdigest()
+              == dist_hashes[path.relative_to(bundle).as_posix()]
+              for path in dist_files
+          )
+          expected_files = {
+              "SHA256SUMS", "DIST_SHA256SUMS", "release-source.json",
+              "attestations/source.jsonl", "attestations/build.jsonl",
+              *(path.relative_to(bundle).as_posix() for path in dist_files),
+          }
+          actual_files = {
+              path.relative_to(bundle).as_posix()
+              for path in bundle.rglob("*") if path.is_file()
+          }
+          assert actual_files == expected_files
+          PY
+          signer="$REPOSITORY/.github/workflows/release.yml"
+          common=(
+            --repo "$REPOSITORY"
+            --signer-workflow "$signer"
+            --signer-digest "$EXPECTED_WORKFLOW_SHA"
+            --source-ref "refs/tags/$EXPECTED_TAG"
+            --source-digest "$EXPECTED_COMMIT"
+          )
+          gh attestation verify release-bundle/release-source.json \
+            --bundle release-bundle/attestations/source.jsonl "${common[@]}"
+          while read -r _ path; do
+            gh attestation verify "release-bundle/$path" \
+              --bundle release-bundle/attestations/build.jsonl "${common[@]}"
+          done < release-bundle/DIST_SHA256SUMS
+          {
+            echo "## Attestation verification"
+            echo "Source and both distribution attestations verified for \`$EXPECTED_WORKFLOW_REF\`, signer digest \`$EXPECTED_WORKFLOW_SHA\`, source ref \`refs/tags/$EXPECTED_TAG\`, and source digest \`$EXPECTED_COMMIT\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - id: stage
+        name: Stage the verified distributions
+        env:
+          COMMIT: ${{ needs.bind-build-attest.outputs.commit }}
+        run: |
+          set -euo pipefail
+          mkdir testpypi-upload
+          cp release-bundle/dist/* testpypi-upload/
+          echo "artifact-name=pylxpweb-testpypi-${COMMIT}" >> "$GITHUB_OUTPUT"
+
+      - id: upload-staging-artifact
+        name: Upload the TestPyPI staging artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: ${{ steps.stage.outputs.artifact-name }}
+          path: testpypi-upload/
+          if-no-files-found: error
+          retention-days: 1
+
   publish-testpypi:
-    name: Publish original artifact to TestPyPI
-    if: github.event_name == 'release'
-    needs: build
+    name: Publish staged artifact to TestPyPI
+    needs: prepare-testpypi
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: testpypi
-    permissions: &publisher-permissions
+    permissions:
       contents: read
       id-token: write
     steps:
-      - &download-release-artifact
-        id: download-release-artifact
-        name: Download original release artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
-          name: ${{ needs.build.outputs.artifact-name }}
-          path: release-bundle/
-
-      - &revalidate-release-artifact
-        id: revalidate-release-bundle
-        name: Revalidate original release artifact
-        env:
-          EXPECTED_ARTIFACT_NAME: ${{ needs.build.outputs.artifact-name }}
-          EXPECTED_COMMIT: ${{ needs.build.outputs.commit }}
-          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
-          EXPECTED_TAG: ${{ needs.build.outputs.tag }}
-          EXPECTED_TREE: ${{ needs.build.outputs.tree }}
-          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-        run: *validate-release-bundle
-
-      - id: publish-testpypi
-        name: Publish to TestPyPI with trusted publishing
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+          name: ${{ needs.prepare-testpypi.outputs.staging-artifact }}
+          path: upload/
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          packages-dir: release-bundle/dist/
+          packages-dir: upload/
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
 
   verify-testpypi:
-    name: Verify TestPyPI artifact and isolated install
-    if: github.event_name == 'release'
-    needs: [build, publish-testpypi]
+    name: Verify TestPyPI publication
+    needs: [bind-build-attest, publish-testpypi]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
     steps:
-      - *download-release-artifact
-
-      - *revalidate-release-artifact
-
-      - id: setup-uv
-        name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-
-      - id: query-testpypi
-        name: Verify TestPyPI JSON and download both distributions
+      - id: download-release-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: ${{ needs.bind-build-attest.outputs.artifact-name }}
+          path: release-bundle/
+      - id: verify-release-bundle
+        env: *bundle-identity
+        run: *verify-release-bundle
+      - id: verify-testpypi-files
+        name: Poll TestPyPI and verify the exact remote bytes
         env:
-          ALLOWED_DISTRIBUTION_HOST: test-files.pythonhosted.org
-          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
-          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
+          EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
+          EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
+          INDEX_JSON_BASE: https://test.pypi.org/pypi
+          ALLOWED_FILE_HOST: test-files.pythonhosted.org
           MAX_ATTEMPTS: '12'
-          TESTPYPI_JSON_BASE_URL: https://test.pypi.org/pypi
-        run: |
+        run: &verify-index |
           python3 - <<'PY'
           import hashlib
           import json
@@ -379,253 +614,142 @@ jobs:
           import urllib.request
 
           bundle = pathlib.Path("release-bundle")
-          hashes = {}
-          for line in bundle.joinpath("SHA256SUMS").read_text().splitlines():
+          expected = {}
+          for line in bundle.joinpath("DIST_SHA256SUMS").read_text().splitlines():
               digest, path = line.split("  ", 1)
-              manifest_path = pathlib.PurePosixPath(path)
-              if manifest_path.parts[0] == "dist":
-                  hashes[manifest_path.name] = digest
-
-          assert len(hashes) == 2, "release artifact must contain exactly two distributions"
-          assert sum(name.endswith(".whl") for name in hashes) == 1, "release artifact must contain one wheel"
-          assert sum(name.endswith(".tar.gz") for name in hashes) == 1, "release artifact must contain one sdist"
-
+              expected[pathlib.PurePosixPath(path).name] = digest
+          assert len(expected) == 2
           project = os.environ["EXPECTED_PROJECT_NAME"]
           version = os.environ["EXPECTED_VERSION"]
-          url = f'{os.environ["TESTPYPI_JSON_BASE_URL"]}/{project}/{version}/json'
+          request = urllib.request.Request(
+              f'{os.environ["INDEX_JSON_BASE"]}/{project}/{version}/json',
+              headers={"User-Agent": "pylxpweb-release-verifier"},
+          )
           attempts = int(os.environ["MAX_ATTEMPTS"])
-          request = urllib.request.Request(url, headers={"User-Agent": "pylxpweb-release-verifier"})
-
           for attempt in range(1, attempts + 1):
               try:
                   with urllib.request.urlopen(request, timeout=30) as response:
                       payload = json.load(response)
-                  assert payload["info"]["name"] == project, "package index project name does not match"
-                  assert payload["info"]["version"] == version, "package index version does not match"
+                  assert payload["info"]["name"] == project
+                  assert payload["info"]["version"] == version
                   releases = payload["urls"]
-                  filenames = {release["filename"] for release in releases}
-                  assert len(releases) == len(hashes) and filenames == set(hashes), \
-                      "package index file set does not match"
-                  assert all(release["yanked"] is False for release in releases), \
-                      "package index contains yanked file"
+                  assert {item["filename"] for item in releases} == set(expected)
+                  assert len(releases) == 2
+                  assert all(not item["yanked"] for item in releases)
                   assert all(
-                      release["digests"]["sha256"] == hashes[release["filename"]]
-                      for release in releases
-                  ), "package index hash does not match"
-                  for release in releases:
-                      parsed = urllib.parse.urlparse(release["url"])
-                      assert (
-                          parsed.scheme == "https"
-                          and parsed.hostname == os.environ["ALLOWED_DISTRIBUTION_HOST"]
-                      ), "distribution URL is not allowlisted HTTPS"
+                      item["digests"]["sha256"] == expected[item["filename"]]
+                      for item in releases
+                  )
                   break
               except (AssertionError, KeyError, OSError, TypeError, ValueError):
                   if attempt == attempts:
                       raise
-                  time.sleep(min(5 * attempt, 30))
-
-          verified = pathlib.Path("verified-distributions")
-          verified.mkdir()
-          wheel_path = None
-          for release in releases:
-              download_request = urllib.request.Request(
-                  release["url"], headers={"User-Agent": "pylxpweb-release-verifier"}
-              )
-              with urllib.request.urlopen(download_request, timeout=60) as response:
-                  final_url = urllib.parse.urlparse(response.geturl())
-                  assert (
-                      final_url.scheme == "https"
-                      and final_url.hostname == os.environ["ALLOWED_DISTRIBUTION_HOST"]
-                  ), "distribution URL is not allowlisted HTTPS"
+                  time.sleep(min(attempt * 5, 30))
+          for item in releases:
+              parsed = urllib.parse.urlparse(item["url"])
+              assert parsed.scheme == "https"
+              assert parsed.hostname == os.environ["ALLOWED_FILE_HOST"]
+              with urllib.request.urlopen(item["url"], timeout=60) as response:
+                  final = urllib.parse.urlparse(response.geturl())
                   content = response.read()
-              filename = release["filename"]
-              assert hashlib.sha256(content).hexdigest() == hashes[filename], \
-                  "downloaded distribution hash does not match"
-              path = verified / filename
-              path.write_bytes(content)
-              if filename.endswith(".whl"):
-                  wheel_path = path
-          assert wheel_path is not None, "verified wheel is missing"
-          with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
-              print(f"wheel-path={wheel_path}", file=output)
+              assert final.scheme == "https"
+              assert final.hostname == os.environ["ALLOWED_FILE_HOST"]
+              assert hashlib.sha256(content).hexdigest() == expected[item["filename"]]
           PY
 
-      - id: create-verification-environment
-        name: Create clean verification environment
-        run: uv venv --python 3.13 .verify-venv
-
-      - id: install-testpypi-wheel
-        name: Install downloaded wheel with dependencies from production PyPI only
+  prepare-pypi:
+    name: Verify and stage for PyPI
+    needs: [bind-build-attest, verify-testpypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      staging-artifact: ${{ steps.stage.outputs.artifact-name }}
+    steps:
+      - id: download-release-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: ${{ needs.bind-build-attest.outputs.artifact-name }}
+          path: release-bundle/
+      - id: verify-release-bundle
+        env: *bundle-identity
+        run: *verify-release-bundle
+      - id: verify-pypi-absence
+        name: Fail closed if the production version already exists
         env:
-          PYPI_INDEX_URL: https://pypi.org/simple
-          WHEEL_PATH: ${{ steps.query-testpypi.outputs.wheel-path }}
+          EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
+          EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
         run: |
-          env \
-            -u PIP_EXTRA_INDEX_URL \
-            -u PIP_INDEX_URL \
-            -u UV_DEFAULT_INDEX \
-            -u UV_EXTRA_INDEX_URL \
-            -u UV_INDEX \
-            -u UV_INDEX_URL \
-            uv --no-config pip install \
-              --python .verify-venv/bin/python \
-              --default-index "$PYPI_INDEX_URL" \
-              --index-strategy first-index \
-              --strict \
-              "$WHEEL_PATH"
-
-      - id: verify-installed-package
-        name: Validate installed metadata and import
-        env:
-          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
-          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          cd "$RUNNER_TEMP"
-          "$GITHUB_WORKSPACE/.verify-venv/bin/python" - <<'PY'
-          import importlib.metadata
+          python3 - <<'PY'
           import os
-          import pathlib
-          import sys
-
-          import pylxpweb
-
-          distribution = importlib.metadata.distribution(os.environ["EXPECTED_PROJECT_NAME"])
-          assert distribution.metadata["Name"] == os.environ["EXPECTED_PROJECT_NAME"]
-          assert distribution.version == os.environ["EXPECTED_VERSION"]
-          assert pylxpweb.__version__ == os.environ["EXPECTED_VERSION"]
-          package_path = pathlib.Path(pylxpweb.__file__).resolve()
-          package_path.relative_to(pathlib.Path(sys.prefix).resolve())
+          import urllib.error
+          import urllib.request
+          url = f'https://pypi.org/pypi/{os.environ["EXPECTED_PROJECT_NAME"]}/{os.environ["EXPECTED_VERSION"]}/json'
+          try:
+              urllib.request.urlopen(url, timeout=30)
+          except urllib.error.HTTPError as error:
+              assert error.code == 404, error
+          else:
+              raise AssertionError("production version already exists")
           PY
+      - id: stage
+        name: Stage the verified distributions
+        env:
+          COMMIT: ${{ needs.bind-build-attest.outputs.commit }}
+        run: |
+          set -euo pipefail
+          mkdir pypi-upload
+          cp release-bundle/dist/* pypi-upload/
+          echo "artifact-name=pylxpweb-pypi-${COMMIT}" >> "$GITHUB_OUTPUT"
+      - id: upload-staging-artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: ${{ steps.stage.outputs.artifact-name }}
+          path: pypi-upload/
+          if-no-files-found: error
+          retention-days: 1
 
   publish-pypi:
-    name: Publish verified original artifact to PyPI
-    if: github.event_name == 'release'
-    needs: [build, verify-testpypi]
+    name: Publish staged artifact to PyPI
+    needs: prepare-pypi
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi
-    permissions: *publisher-permissions
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - *download-release-artifact
-
-      - *revalidate-release-artifact
-
-      - id: prepare-pypi
-        name: Validate existing PyPI files and stage absent distributions
-        env:
-          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
-          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-          BACKOFF_SECONDS: '2'
-          MAX_ATTEMPTS: '3'
-          MAX_BACKOFF_SECONDS: '5'
-          MODE: prepare
-          PYPI_JSON_BASE_URL: https://pypi.org/pypi
-          REQUEST_TIMEOUT_SECONDS: '10'
-          UPLOAD_DIR: pypi-upload
-        run: &verify-pypi-state |
-          python3 - <<'PY'
-          import hashlib
-          import json
-          import os
-          import pathlib
-          import shutil
-          import time
-          import urllib.error
-          import urllib.request
-
-          bundle = pathlib.Path("release-bundle")
-          hashes = {}
-          paths = {}
-          for line in bundle.joinpath("SHA256SUMS").read_text().splitlines():
-              digest, path = line.split("  ", 1)
-              manifest_path = pathlib.PurePosixPath(path)
-              if manifest_path.parts[0] == "dist":
-                  hashes[manifest_path.name] = digest
-                  paths[manifest_path.name] = bundle.joinpath(*manifest_path.parts)
-
-          assert len(hashes) == 2, "release artifact must contain exactly two distributions"
-          assert sum(name.endswith(".whl") for name in hashes) == 1, "release artifact must contain one wheel"
-          assert sum(name.endswith(".tar.gz") for name in hashes) == 1, "release artifact must contain one sdist"
-          for filename, path in paths.items():
-              assert path.is_file(), f"release artifact is missing {filename}"
-              assert hashlib.sha256(path.read_bytes()).hexdigest() == hashes[filename], \
-                  f"release artifact hash does not match for {filename}"
-
-          project = os.environ["EXPECTED_PROJECT_NAME"]
-          version = os.environ["EXPECTED_VERSION"]
-          mode = os.environ["MODE"]
-          assert mode in {"prepare", "verify"}, "invalid PyPI verification mode"
-          attempts = int(os.environ["MAX_ATTEMPTS"])
-          backoff_seconds = int(os.environ["BACKOFF_SECONDS"])
-          max_backoff_seconds = int(os.environ["MAX_BACKOFF_SECONDS"])
-          request_timeout_seconds = int(os.environ["REQUEST_TIMEOUT_SECONDS"])
-          url = f'{os.environ["PYPI_JSON_BASE_URL"]}/{project}/{version}/json'
-          request = urllib.request.Request(url, headers={"User-Agent": "pylxpweb-release-verifier"})
-
-          for attempt in range(1, attempts + 1):
-              try:
-                  try:
-                      with urllib.request.urlopen(
-                          request, timeout=request_timeout_seconds
-                      ) as response:
-                          payload = json.load(response)
-                  except urllib.error.HTTPError as error:
-                      if error.code != 404:
-                          raise
-                      payload = None
-
-                  if payload is None:
-                      releases = []
-                  else:
-                      assert payload["info"]["name"] == project, "PyPI project name does not match"
-                      assert payload["info"]["version"] == version, "PyPI version does not match"
-                      releases = payload["urls"]
-
-                  filenames = [release["filename"] for release in releases]
-                  filename_set = set(filenames)
-                  assert len(filenames) == len(filename_set), "PyPI contains duplicate filenames"
-                  assert filename_set <= set(hashes), "PyPI contains unexpected file"
-                  assert all(release["yanked"] is False for release in releases), \
-                      "PyPI contains yanked file"
-                  assert all(
-                      release["digests"]["sha256"] == hashes[release["filename"]]
-                      for release in releases
-                  ), "PyPI hash does not match"
-                  if mode == "verify":
-                      assert filename_set == set(hashes), "PyPI final file set does not match"
-                  break
-              except (AssertionError, KeyError, OSError, TypeError, ValueError):
-                  if attempt == attempts:
-                      raise
-                  time.sleep(min(backoff_seconds * attempt, max_backoff_seconds))
-
-          if mode == "prepare":
-              upload_dir = pathlib.Path(os.environ["UPLOAD_DIR"])
-              upload_dir.mkdir()
-              absent = set(hashes) - filename_set
-              for filename in sorted(absent):
-                  shutil.copyfile(paths[filename], upload_dir / filename)
-              with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
-                  print(f"upload-needed={'true' if absent else 'false'}", file=output)
-          PY
-
-      - id: publish-pypi
-        name: Publish to PyPI with trusted publishing
-        if: success() && steps.prepare-pypi.outputs.upload-needed == 'true'
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
-          packages-dir: pypi-upload/
+          name: ${{ needs.prepare-pypi.outputs.staging-artifact }}
+          path: upload/
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          packages-dir: upload/
 
-      - id: verify-pypi
-        name: Verify final exact PyPI distribution set
+  verify-pypi:
+    name: Verify PyPI publication
+    needs: [bind-build-attest, publish-pypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - id: download-release-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: ${{ needs.bind-build-attest.outputs.artifact-name }}
+          path: release-bundle/
+      - id: verify-release-bundle
+        env: *bundle-identity
+        run: *verify-release-bundle
+      - id: verify-pypi-files
+        name: Poll PyPI and verify the exact remote bytes
         env:
-          EXPECTED_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
-          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
-          BACKOFF_SECONDS: '5'
+          EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
+          EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
+          INDEX_JSON_BASE: https://pypi.org/pypi
+          ALLOWED_FILE_HOST: files.pythonhosted.org
           MAX_ATTEMPTS: '8'
-          MAX_BACKOFF_SECONDS: '20'
-          MODE: verify
-          PYPI_JSON_BASE_URL: https://pypi.org/pypi
-          REQUEST_TIMEOUT_SECONDS: '15'
-          UPLOAD_DIR: pypi-upload
-        run: *verify-pypi-state
+        run: *verify-index

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,7 @@ jobs:
             --tmpfs /cache:rw,noexec,nosuid,nodev,size=64m \
             -e HOME=/tmp \
             -e UV_CACHE_DIR=/cache \
-            -e SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$epoch}" \
+            -e SOURCE_DATE_EPOCH="$epoch" \
             -v "$GITHUB_WORKSPACE:/src:ro" \
             -v "$OUTPUT_DIR:/out:rw" \
             -w /src \
@@ -626,7 +626,7 @@ jobs:
     name: Verify TestPyPI publication
     needs: [bind-build-attest, publish-testpypi]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -645,15 +645,19 @@ jobs:
           EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
           INDEX_JSON_BASE: https://test.pypi.org/pypi
           ALLOWED_FILE_HOST: test-files.pythonhosted.org
+          DOWNLOAD_TOTAL_SECONDS: '60'
+          INDEX_TOTAL_SECONDS: '30'
           MAX_ATTEMPTS: '12'
           REQUIRED_FILE_SCHEME: https
           RETRY_BASE_SECONDS: '5'
+          SOCKET_TIMEOUT_SECONDS: '10'
         run: &verify-index |
           python3 - <<'PY'
           import hashlib
           import json
           import os
           import pathlib
+          import signal
           import time
           import urllib.parse
           import urllib.request
@@ -670,6 +674,17 @@ jobs:
               f'{os.environ["INDEX_JSON_BASE"]}/{project}/{version}/json',
               headers={"User-Agent": "pylxpweb-release-verifier"},
           )
+          def timeout_handler(_signum, _frame):
+              raise TimeoutError("total HTTP transfer deadline exceeded")
+          signal.signal(signal.SIGALRM, timeout_handler)
+          socket_timeout = float(os.environ["SOCKET_TIMEOUT_SECONDS"])
+          def fetch(url, total_seconds):
+              signal.setitimer(signal.ITIMER_REAL, total_seconds)
+              try:
+                  with urllib.request.urlopen(url, timeout=socket_timeout) as response:
+                      return response.geturl(), response.read()
+              finally:
+                  signal.setitimer(signal.ITIMER_REAL, 0)
           def validate(payload):
               assert payload["info"]["name"] == project
               assert payload["info"]["version"] == version
@@ -684,10 +699,12 @@ jobs:
               return releases
           attempts = int(os.environ["MAX_ATTEMPTS"])
           retry_base = int(os.environ["RETRY_BASE_SECONDS"])
+          index_total = float(os.environ["INDEX_TOTAL_SECONDS"])
+          download_total = float(os.environ["DOWNLOAD_TOTAL_SECONDS"])
           for attempt in range(1, attempts + 1):
               try:
-                  with urllib.request.urlopen(request, timeout=30) as response:
-                      payload = json.load(response)
+                  _, content = fetch(request, index_total)
+                  payload = json.loads(content)
                   releases = validate(payload)
                   break
               except (AssertionError, KeyError, OSError, TypeError, ValueError):
@@ -698,14 +715,13 @@ jobs:
               parsed = urllib.parse.urlparse(item["url"])
               assert parsed.scheme == os.environ["REQUIRED_FILE_SCHEME"]
               assert parsed.hostname == os.environ["ALLOWED_FILE_HOST"]
-              with urllib.request.urlopen(item["url"], timeout=60) as response:
-                  final = urllib.parse.urlparse(response.geturl())
-                  content = response.read()
+              final_url, content = fetch(item["url"], download_total)
+              final = urllib.parse.urlparse(final_url)
               assert final.scheme == os.environ["REQUIRED_FILE_SCHEME"]
               assert final.hostname == os.environ["ALLOWED_FILE_HOST"]
               assert hashlib.sha256(content).hexdigest() == expected[item["filename"]]
-          with urllib.request.urlopen(request, timeout=30) as response:
-              validate(json.load(response))
+          _, content = fetch(request, index_total)
+          validate(json.loads(content))
           PY
 
   prepare-pypi:
@@ -803,7 +819,10 @@ jobs:
           EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
           INDEX_JSON_BASE: https://pypi.org/pypi
           ALLOWED_FILE_HOST: files.pythonhosted.org
+          DOWNLOAD_TOTAL_SECONDS: '60'
+          INDEX_TOTAL_SECONDS: '30'
           MAX_ATTEMPTS: '8'
           REQUIRED_FILE_SCHEME: https
           RETRY_BASE_SECONDS: '5'
+          SOCKET_TIMEOUT_SECONDS: '10'
         run: *verify-index

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
           git fetch --no-tags --force origin \
             "+refs/heads/main:refs/remotes/origin/main"
           git show-ref --verify --quiet "refs/tags/$tag" || die "release tag does not exist"
-          tag_object=$(git rev-parse "refs/tags/$tag")
           commit=$(git rev-parse "refs/tags/$tag^{commit}")
           tree=$(git rev-parse "refs/tags/$tag^{tree}")
           [[ "$commit" == "$EVENT_SHA" ]] || die "event commit does not match tag commit"
@@ -103,7 +102,8 @@ jobs:
           trap 'rm -rf "$api_dir"' EXIT
           gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
             "repos/$REPOSITORY/commits/$commit/pulls" > "$api_dir/pulls.json"
-          python3 - "$api_dir/pulls.json" "$commit" "$first_parent" "$second_parent" <<'PY'
+          mapfile -t pr_identity < <(
+            python3 - "$api_dir/pulls.json" "$commit" "$first_parent" "$second_parent" <<'PY'
           import json
           import pathlib
           import sys
@@ -122,17 +122,6 @@ jobs:
           print(pull["head"]["sha"])
           print(pull["user"]["login"])
           PY
-          mapfile -t pr_identity < <(
-            python3 - "$api_dir/pulls.json" <<'PY'
-          import json
-          import pathlib
-          import sys
-          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          pull = [pull for page in pages for pull in page][0]
-          print(pull["number"])
-          print(pull["head"]["sha"])
-          print(pull["user"]["login"])
-          PY
           )
           pr="${pr_identity[0]}"
           head="${pr_identity[1]}"
@@ -140,7 +129,8 @@ jobs:
 
           gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
             "repos/$REPOSITORY/pulls/$pr/reviews" > "$api_dir/reviews.json"
-          python3 - "$api_dir/reviews.json" > "$api_dir/reviewers.txt" <<'PY'
+          python3 - "$api_dir/reviews.json" "$api_dir/effective-reviews.json" \
+            > "$api_dir/reviewers.txt" <<'PY'
           import json
           import pathlib
           import sys
@@ -154,6 +144,7 @@ jobs:
           ):
               if review["state"] in {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}:
                   effective[review["user"]["login"]] = review
+          pathlib.Path(sys.argv[2]).write_text(json.dumps(effective))
           for login, review in sorted(effective.items()):
               if review["state"] in {"APPROVED", "CHANGES_REQUESTED"}:
                   print(login)
@@ -164,26 +155,18 @@ jobs:
               "repos/$REPOSITORY/collaborators/$reviewer/permission" --jq .permission)
             printf '%s\t%s\n' "$reviewer" "$permission" >> "$api_dir/permissions.tsv"
           done < "$api_dir/reviewers.txt"
-          python3 - "$api_dir/reviews.json" "$api_dir/permissions.tsv" \
+          python3 - "$api_dir/effective-reviews.json" "$api_dir/permissions.tsv" \
             "$head" "$author" <<'PY'
           import json
           import pathlib
           import sys
 
-          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          reviews = [review for page in pages for review in page]
+          effective = json.loads(pathlib.Path(sys.argv[1]).read_text())
           permissions = dict(
               line.split("\t", 1)
               for line in pathlib.Path(sys.argv[2]).read_text().splitlines()
           )
           head, author = sys.argv[3:]
-          effective = {}
-          for review in sorted(
-              reviews,
-              key=lambda item: (item.get("submitted_at") or "", item.get("id", 0)),
-          ):
-              if review["state"] in {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}:
-                  effective[review["user"]["login"]] = review
           eligible = {
               login: review
               for login, review in effective.items()
@@ -220,12 +203,10 @@ jobs:
           {
             echo "artifact-name=$artifact_name"
             echo "commit=$commit"
-            echo "first-parent=$first_parent"
             echo "head=$head"
             echo "pr=$pr"
             echo "project-name=$project_name"
             echo "tag=$tag"
-            echo "tag-object=$tag_object"
             echo "tree=$tree"
             echo "version=$version"
             echo "workflow-ref=$WORKFLOW_REF"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
+      actions: read
       contents: read
       pull-requests: read
       checks: read
@@ -74,8 +75,12 @@ jobs:
           [[ "$WORKFLOW_REF" == "$expected_workflow_ref" ]] || \
             die "workflow ref must be the release tag"
 
-          git fetch --no-tags --force origin \
-            "+refs/heads/main:refs/remotes/origin/main"
+          main_refspec="+refs/heads/main:refs/remotes/origin/main"
+          if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+            git fetch --no-tags --force --unshallow origin "$main_refspec"
+          else
+            git fetch --no-tags --force origin "$main_refspec"
+          fi
           git show-ref --verify --quiet "refs/tags/$tag" || die "release tag does not exist"
           commit=$(git rev-parse "refs/tags/$tag^{commit}")
           tree=$(git rev-parse "refs/tags/$tag^{tree}")
@@ -97,6 +102,10 @@ jobs:
           [[ "${#lineage[@]}" == 3 ]] || die "tag commit must have exactly two parents"
           first_parent="${lineage[1]}"
           second_parent="${lineage[2]}"
+          git merge-base --is-ancestor "$first_parent" "$second_parent" || \
+            die "release candidate was not up to date with its merge base"
+          [[ "$tree" == "$(git rev-parse "$second_parent^{tree}")" ]] || \
+            die "merge tree does not match the CI-tested PR head tree"
 
           api_dir=$(mktemp -d)
           trap 'rm -rf "$api_dir"' EXIT
@@ -116,7 +125,6 @@ jobs:
           assert pull["state"] == "closed" and pull["merged_at"], "PR is not merged"
           assert pull["merge_commit_sha"] == commit, "PR merge commit mismatch"
           assert pull["base"]["ref"] == "main", "PR base is not main"
-          assert pull["base"]["sha"] == first_parent, "PR base is not first parent"
           assert pull["head"]["sha"] == second_parent, "PR head is not second parent"
           print(pull["number"])
           print(pull["head"]["sha"])
@@ -185,18 +193,48 @@ jobs:
 
           gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
             "repos/$REPOSITORY/commits/$head/check-runs" > "$api_dir/checks.json"
-          python3 - "$api_dir/checks.json" "$head" <<'PY'
+          mapfile -t ci_identity < <(
+            python3 - "$api_dir/checks.json" "$head" "$REPOSITORY" <<'PY'
+          import json
+          import pathlib
+          import re
+          import sys
+          import urllib.parse
+
+          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          checks = [check for page in pages for check in page["check_runs"]]
+          head, repository = sys.argv[2:]
+          required = [check for check in checks if check["name"] == "CI Success"]
+          assert len(required) == 1, "required CI result is missing or ambiguous"
+          check = required[0]
+          assert check["head_sha"] == head, "required CI covers the wrong head"
+          assert check["conclusion"] == "success", "required CI did not succeed"
+          assert check["app"]["slug"] == "github-actions", "required CI app mismatch"
+          assert check["app"]["owner"]["login"] == "github", "required CI owner mismatch"
+          details = urllib.parse.urlparse(check["details_url"])
+          assert details.scheme == "https" and details.hostname == "github.com"
+          match = re.fullmatch(
+              rf"/{re.escape(repository)}/actions/runs/([0-9]+)/job/[0-9]+",
+              details.path,
+          )
+          assert match, "required CI details URL mismatch"
+          print(match.group(1))
+          PY
+          )
+          gh api -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/actions/runs/${ci_identity[0]}" > "$api_dir/ci-run.json"
+          python3 - "$api_dir/ci-run.json" "$head" "$REPOSITORY" <<'PY'
           import json
           import pathlib
           import sys
 
-          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          checks = [check for page in pages for check in page["check_runs"]]
-          head = sys.argv[2]
-          required = [check for check in checks if check["name"] == "CI Success"]
-          assert len(required) == 1, "required CI result is missing or ambiguous"
-          assert required[0]["head_sha"] == head, "required CI covers the wrong head"
-          assert required[0]["conclusion"] == "success", "required CI did not succeed"
+          run = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          head, repository = sys.argv[2:]
+          assert run["repository"]["full_name"] == repository, "CI repository mismatch"
+          assert run["path"] == ".github/workflows/ci.yml", "CI workflow path mismatch"
+          assert run["head_sha"] == head, "CI workflow run covers the wrong head"
+          assert run["event"] == "pull_request", "CI workflow event mismatch"
+          assert run["conclusion"] == "success", "CI workflow run did not succeed"
           PY
 
           artifact_name="pylxpweb-release-$version-${commit:0:12}"
@@ -212,6 +250,19 @@ jobs:
             echo "workflow-ref=$WORKFLOW_REF"
             echo "workflow-sha=$WORKFLOW_SHA"
           } >> "$GITHUB_OUTPUT"
+
+      - id: assert-clean-source
+        name: Require the checkout bytes to equal the bound tree
+        run: |
+          set -euo pipefail
+          git diff --quiet HEAD -- || {
+            echo "tracked or staged source tree changes are forbidden" >&2
+            exit 1
+          }
+          [[ -z "$(git ls-files --others --exclude-standard)" ]] || {
+            echo "untracked build inputs outside the source tree are forbidden" >&2
+            exit 1
+          }
 
       - id: build-distributions
         name: Build once in the pinned offline container
@@ -347,6 +398,16 @@ jobs:
           EXPECTED_COMMIT: ${{ steps.bind-source.outputs.commit }}
         run: |
           set -euo pipefail
+          git diff --quiet HEAD -- || {
+            echo "tracked or staged source tree changes are forbidden at sealing" >&2
+            exit 1
+          }
+          unexpected_untracked=$(git ls-files --others --exclude-standard | \
+            grep -Ev '^release-bundle/' || true)
+          [[ -z "$unexpected_untracked" ]] || {
+            echo "untracked build inputs outside the source tree are forbidden at sealing" >&2
+            exit 1
+          }
           git fetch --no-tags --force origin \
             "+refs/heads/main:refs/remotes/origin/main"
           [[ "$(git rev-parse 'refs/remotes/origin/main^{commit}')" == "$EXPECTED_COMMIT" ]] || {
@@ -449,6 +510,7 @@ jobs:
           EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
           EXPECTED_WORKFLOW_REF: ${{ needs.bind-build-attest.outputs.workflow-ref }}
           EXPECTED_WORKFLOW_SHA: ${{ needs.bind-build-attest.outputs.workflow-sha }}
+          GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
         run: &verify-release-bundle |
           set -euo pipefail
@@ -538,7 +600,7 @@ jobs:
           name: ${{ steps.stage.outputs.artifact-name }}
           path: testpypi-upload/
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 30
 
   publish-testpypi:
     name: Publish staged artifact to TestPyPI
@@ -584,6 +646,8 @@ jobs:
           INDEX_JSON_BASE: https://test.pypi.org/pypi
           ALLOWED_FILE_HOST: test-files.pythonhosted.org
           MAX_ATTEMPTS: '12'
+          REQUIRED_FILE_SCHEME: https
+          RETRY_BASE_SECONDS: '5'
         run: &verify-index |
           python3 - <<'PY'
           import hashlib
@@ -606,36 +670,42 @@ jobs:
               f'{os.environ["INDEX_JSON_BASE"]}/{project}/{version}/json',
               headers={"User-Agent": "pylxpweb-release-verifier"},
           )
+          def validate(payload):
+              assert payload["info"]["name"] == project
+              assert payload["info"]["version"] == version
+              releases = payload["urls"]
+              assert {item["filename"] for item in releases} == set(expected)
+              assert len(releases) == 2
+              assert all(not item["yanked"] for item in releases)
+              assert all(
+                  item["digests"]["sha256"] == expected[item["filename"]]
+                  for item in releases
+              )
+              return releases
           attempts = int(os.environ["MAX_ATTEMPTS"])
+          retry_base = int(os.environ["RETRY_BASE_SECONDS"])
           for attempt in range(1, attempts + 1):
               try:
                   with urllib.request.urlopen(request, timeout=30) as response:
                       payload = json.load(response)
-                  assert payload["info"]["name"] == project
-                  assert payload["info"]["version"] == version
-                  releases = payload["urls"]
-                  assert {item["filename"] for item in releases} == set(expected)
-                  assert len(releases) == 2
-                  assert all(not item["yanked"] for item in releases)
-                  assert all(
-                      item["digests"]["sha256"] == expected[item["filename"]]
-                      for item in releases
-                  )
+                  releases = validate(payload)
                   break
               except (AssertionError, KeyError, OSError, TypeError, ValueError):
                   if attempt == attempts:
                       raise
-                  time.sleep(min(attempt * 5, 30))
+                  time.sleep(min(attempt * retry_base, 30))
           for item in releases:
               parsed = urllib.parse.urlparse(item["url"])
-              assert parsed.scheme == "https"
+              assert parsed.scheme == os.environ["REQUIRED_FILE_SCHEME"]
               assert parsed.hostname == os.environ["ALLOWED_FILE_HOST"]
               with urllib.request.urlopen(item["url"], timeout=60) as response:
                   final = urllib.parse.urlparse(response.geturl())
                   content = response.read()
-              assert final.scheme == "https"
+              assert final.scheme == os.environ["REQUIRED_FILE_SCHEME"]
               assert final.hostname == os.environ["ALLOWED_FILE_HOST"]
               assert hashlib.sha256(content).hexdigest() == expected[item["filename"]]
+          with urllib.request.urlopen(request, timeout=30) as response:
+              validate(json.load(response))
           PY
 
   prepare-pypi:
@@ -661,12 +731,13 @@ jobs:
         env:
           EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
           EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
+          PYPI_JSON_BASE: https://pypi.org/pypi
         run: |
           python3 - <<'PY'
           import os
           import urllib.error
           import urllib.request
-          url = f'https://pypi.org/pypi/{os.environ["EXPECTED_PROJECT_NAME"]}/{os.environ["EXPECTED_VERSION"]}/json'
+          url = f'{os.environ["PYPI_JSON_BASE"]}/{os.environ["EXPECTED_PROJECT_NAME"]}/{os.environ["EXPECTED_VERSION"]}/json'
           try:
               urllib.request.urlopen(url, timeout=30)
           except urllib.error.HTTPError as error:
@@ -689,7 +760,7 @@ jobs:
           name: ${{ steps.stage.outputs.artifact-name }}
           path: pypi-upload/
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 30
 
   publish-pypi:
     name: Publish staged artifact to PyPI
@@ -733,4 +804,6 @@ jobs:
           INDEX_JSON_BASE: https://pypi.org/pypi
           ALLOWED_FILE_HOST: files.pythonhosted.org
           MAX_ATTEMPTS: '8'
+          REQUIRED_FILE_SCHEME: https
+          RETRY_BASE_SECONDS: '5'
         run: *verify-index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ pylxpweb-collect = "pylxpweb.cli.collect_device_data:main"
 pylxpweb-modbus-diag = "pylxpweb.cli.modbus_diag:main"
 
 [build-system]
-requires = ["uv_build>=0.9.10,<0.13.0"]
+requires = ["uv_build==0.9.30"]
 build-backend = "uv_build"
 
 [tool.ruff]

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -38,12 +38,10 @@ def package_index_server() -> Iterator[tuple[str, dict[str, Any]]]:
         "index_calls": 0,
         "index_responses": [],
         "redirected_files": {},
-        "requests": [],
     }
 
     class Handler(http.server.BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
-            state["requests"].append(self.path)
             if self.path.startswith("/pypi/"):
                 responses = state["index_responses"]
                 index = min(state["index_calls"], len(responses) - 1)
@@ -135,12 +133,9 @@ def _package_index_publisher_workflows(workflows_path: Path) -> set[str]:
 def _index_payload(
     base_url: str,
     files: dict[str, bytes],
-    *,
-    project: str = "pylxpweb",
-    version: str = "1.2.3",
 ) -> dict[str, Any]:
     return {
-        "info": {"name": project, "version": version},
+        "info": {"name": "pylxpweb", "version": "1.2.3"},
         "urls": [
             {
                 "digests": {"sha256": hashlib.sha256(content).hexdigest()},
@@ -153,7 +148,13 @@ def _index_payload(
     }
 
 
-def _write_dist_manifest(tmp_path: Path, files: dict[str, bytes]) -> None:
+def _prepare_index_case(
+    tmp_path: Path, base_url: str, state: dict[str, Any]
+) -> tuple[dict[str, bytes], dict[str, Any]]:
+    files = {
+        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel",
+        "pylxpweb-1.2.3.tar.gz": b"sdist",
+    }
     bundle = tmp_path / "release-bundle"
     bundle.mkdir(exist_ok=True)
     bundle.joinpath("DIST_SHA256SUMS").write_text(
@@ -162,6 +163,8 @@ def _write_dist_manifest(tmp_path: Path, files: dict[str, bytes]) -> None:
             for name, content in files.items()
         )
     )
+    state["files"] = dict(files)
+    return files, _index_payload(base_url, files)
 
 
 def _run_index_verifier(
@@ -169,15 +172,13 @@ def _run_index_verifier(
     base_url: str,
     *,
     job_id: str = "verify-testpypi",
-    allowed_host: str = "127.0.0.1",
-    attempts: int = 3,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ | {
-        "ALLOWED_FILE_HOST": allowed_host,
+        "ALLOWED_FILE_HOST": "127.0.0.1",
         "EXPECTED_PROJECT_NAME": "pylxpweb",
         "EXPECTED_VERSION": "1.2.3",
         "INDEX_JSON_BASE": f"{base_url}/pypi",
-        "MAX_ATTEMPTS": str(attempts),
+        "MAX_ATTEMPTS": "3",
         "REQUIRED_FILE_SCHEME": "http",
         "RETRY_BASE_SECONDS": "0",
     }
@@ -993,13 +994,7 @@ def test_index_verifier_retries_then_accepts_exact_remote_bytes(
 ) -> None:
     """The YAML-derived verifier handles transient index lag and exact bytes."""
     base_url, state = package_index_server
-    files = {
-        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel",
-        "pylxpweb-1.2.3.tar.gz": b"sdist",
-    }
-    _write_dist_manifest(tmp_path, files)
-    state["files"] = files
-    payload = _index_payload(base_url, files)
+    _, payload = _prepare_index_case(tmp_path, base_url, state)
     state["index_responses"] = [503, payload]
     result = _run_index_verifier(tmp_path, base_url, job_id=job_id)
     assert result.returncode == 0, result.stderr
@@ -1030,13 +1025,7 @@ def test_index_verifier_rejects_remote_identity_and_byte_mutations(
 ) -> None:
     """Weakening any remote-index check admits a different published artifact set."""
     base_url, state = package_index_server
-    files = {
-        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel",
-        "pylxpweb-1.2.3.tar.gz": b"sdist",
-    }
-    _write_dist_manifest(tmp_path, files)
-    state["files"] = dict(files)
-    payload = _index_payload(base_url, files)
+    files, payload = _prepare_index_case(tmp_path, base_url, state)
     if mutation == "wrong-project":
         payload["info"]["name"] = "lookalike"
     elif mutation == "wrong-version":
@@ -1082,13 +1071,7 @@ def test_index_verifier_rejects_competing_publication_race(
 ) -> None:
     """A second index snapshot catches a file added while exact bytes are downloaded."""
     base_url, state = package_index_server
-    files = {
-        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel",
-        "pylxpweb-1.2.3.tar.gz": b"sdist",
-    }
-    _write_dist_manifest(tmp_path, files)
-    state["files"] = files
-    exact = _index_payload(base_url, files)
+    _, exact = _prepare_index_case(tmp_path, base_url, state)
     raced = json.loads(json.dumps(exact))
     raced["urls"].append(
         {

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import http.server
 import json
 import os
 import re
 import shutil
 import subprocess
+import threading
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +28,72 @@ _PACKAGE_INDEX_PUBLISHER = re.compile(
     r"\b(?:twine\s+upload|(?:uv|poetry|hatch|flit|pdm)\s+publish)\b",
     re.IGNORECASE,
 )
+
+
+@pytest.fixture
+def package_index_server() -> Iterator[tuple[str, dict[str, Any]]]:
+    """Serve mutable package-index responses for the exact workflow scripts."""
+    state: dict[str, Any] = {
+        "files": {},
+        "index_calls": 0,
+        "index_responses": [],
+        "redirected_files": {},
+        "requests": [],
+    }
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
+            state["requests"].append(self.path)
+            if self.path.startswith("/pypi/"):
+                responses = state["index_responses"]
+                index = min(state["index_calls"], len(responses) - 1)
+                state["index_calls"] += 1
+                response = responses[index]
+                if isinstance(response, int):
+                    self.send_error(response)
+                    return
+                body = json.dumps(response).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if self.path.startswith("/files/"):
+                name = self.path.removeprefix("/files/")
+                response = state["files"][name]
+                if isinstance(response, dict) and "redirect" in response:
+                    self.send_response(302)
+                    self.send_header("Location", response["redirect"])
+                    self.end_headers()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+                return
+            if self.path.startswith("/redirected/"):
+                name = self.path.removeprefix("/redirected/")
+                response = state["redirected_files"][name]
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+                return
+            self.send_error(404)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", state
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
 
 
 def _workflow() -> dict[str, Any]:
@@ -61,6 +130,65 @@ def _package_index_publisher_workflows(workflows_path: Path) -> set[str]:
         if any(_PACKAGE_INDEX_PUBLISHER.search(text) for text in _strings(document)):
             publishers.add(path.name)
     return publishers
+
+
+def _index_payload(
+    base_url: str,
+    files: dict[str, bytes],
+    *,
+    project: str = "pylxpweb",
+    version: str = "1.2.3",
+) -> dict[str, Any]:
+    return {
+        "info": {"name": project, "version": version},
+        "urls": [
+            {
+                "digests": {"sha256": hashlib.sha256(content).hexdigest()},
+                "filename": name,
+                "url": f"{base_url}/files/{name}",
+                "yanked": False,
+            }
+            for name, content in files.items()
+        ],
+    }
+
+
+def _write_dist_manifest(tmp_path: Path, files: dict[str, bytes]) -> None:
+    bundle = tmp_path / "release-bundle"
+    bundle.mkdir(exist_ok=True)
+    bundle.joinpath("DIST_SHA256SUMS").write_text(
+        "".join(
+            f"{hashlib.sha256(content).hexdigest()}  dist/{name}\n"
+            for name, content in files.items()
+        )
+    )
+
+
+def _run_index_verifier(
+    tmp_path: Path,
+    base_url: str,
+    *,
+    job_id: str = "verify-testpypi",
+    allowed_host: str = "127.0.0.1",
+    attempts: int = 3,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ | {
+        "ALLOWED_FILE_HOST": allowed_host,
+        "EXPECTED_PROJECT_NAME": "pylxpweb",
+        "EXPECTED_VERSION": "1.2.3",
+        "INDEX_JSON_BASE": f"{base_url}/pypi",
+        "MAX_ATTEMPTS": str(attempts),
+        "REQUIRED_FILE_SCHEME": "http",
+        "RETRY_BASE_SECONDS": "0",
+    }
+    return subprocess.run(
+        ["bash", "-c", _step(job_id, f"verify-{job_id.removeprefix('verify-')}-files")["run"]],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -106,6 +234,9 @@ if len(sys.argv) >= 2 and sys.argv[1] == "api":
     raise SystemExit(0)
 
 if sys.argv[1:3] == ["attestation", "verify"]:
+    if not os.environ.get("GH_TOKEN"):
+        print("GH_TOKEN is required", file=sys.stderr)
+        raise SystemExit(4)
     bundle = pathlib.Path(sys.argv[sys.argv.index("--bundle") + 1])
     expected = os.environ.get("EXPECTED_ATTESTATION_CONTENT")
     if expected is not None and bundle.read_text() != expected:
@@ -121,7 +252,9 @@ raise SystemExit(2)
     gh.chmod(0o755)
 
 
-def _release_repo(tmp_path: Path, *, lightweight: bool = False) -> dict[str, Any]:
+def _release_repo(
+    tmp_path: Path, *, lightweight: bool = False, stale_candidate: bool = False
+) -> dict[str, Any]:
     remote = tmp_path / "origin.git"
     repo = tmp_path / "repo"
     subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True)
@@ -141,12 +274,17 @@ def _release_repo(tmp_path: Path, *, lightweight: bool = False) -> dict[str, Any
     subprocess.run(["git", "checkout", "-qb", "release-candidate"], cwd=repo, check=True)
     head = _commit(repo, "release candidate", "release")
     subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    if stale_candidate:
+        repo.joinpath("new-main.txt").write_text("newer-main")
+        subprocess.run(["git", "add", "new-main.txt"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "newer main"], cwd=repo, check=True)
     subprocess.run(
         ["git", "merge", "-q", "--no-ff", "release-candidate", "-m", "merge candidate"],
         cwd=repo,
         check=True,
     )
     merge = _git(repo, "rev-parse", "HEAD")
+    first_parent = _git(repo, "rev-parse", "HEAD^1")
     tag_args = ["git", "-c", "tag.forceSignAnnotated=false", "tag", "v1.2.3"]
     if not lightweight:
         tag_args = ["git", "tag", "-a", "v1.2.3", "-m", "release"]
@@ -167,7 +305,7 @@ def _release_repo(tmp_path: Path, *, lightweight: bool = False) -> dict[str, Any
                 "merged_at": "2026-08-16T12:00:00Z",
                 "merge_commit_sha": merge,
                 "head": {"sha": head},
-                "base": {"ref": "main", "sha": parent},
+                "base": {"ref": "main", "sha": first_parent},
                 "user": {"login": "author"},
             }
         ],
@@ -181,7 +319,24 @@ def _release_repo(tmp_path: Path, *, lightweight: bool = False) -> dict[str, Any
         ],
         f"repos/{repository}/collaborators/reviewer/permission": {"permission": "write"},
         f"repos/{repository}/commits/{head}/check-runs": {
-            "check_runs": [{"name": "CI Success", "head_sha": head, "conclusion": "success"}]
+            "check_runs": [
+                {
+                    "name": "CI Success",
+                    "head_sha": head,
+                    "conclusion": "success",
+                    "details_url": (
+                        f"https://github.com/{repository}/actions/runs/12345/job/67890"
+                    ),
+                    "app": {"slug": "github-actions", "owner": {"login": "github"}},
+                }
+            ]
+        },
+        f"repos/{repository}/actions/runs/12345": {
+            "conclusion": "success",
+            "event": "pull_request",
+            "head_sha": head,
+            "path": ".github/workflows/ci.yml",
+            "repository": {"full_name": repository},
         },
     }
     return {
@@ -189,6 +344,7 @@ def _release_repo(tmp_path: Path, *, lightweight: bool = False) -> dict[str, Any
         "remote": remote,
         "stale": stale,
         "parent": parent,
+        "first_parent": first_parent,
         "head": head,
         "merge": merge,
         "fixtures": fixtures,
@@ -318,6 +474,64 @@ def test_binding_rejects_old_ancestor_or_main_movement(tmp_path: Path) -> None:
     assert "current main" in result.stderr.lower()
 
 
+def test_binding_rejects_stale_candidate_merged_onto_newer_main(tmp_path: Path) -> None:
+    """A successful old-head CI result cannot cover an untested combined merge tree."""
+    case = _release_repo(tmp_path, stale_candidate=True)
+    result = _run_binding(case, tmp_path)
+    assert result.returncode != 0
+    assert "up to date" in result.stderr.lower()
+
+
+def test_binding_rejects_merge_tree_not_tested_on_exact_pr_head(tmp_path: Path) -> None:
+    """An up-to-date two-parent commit cannot add bytes absent from the CI-tested head."""
+    case = _release_repo(tmp_path)
+    repo: Path = case["repo"]
+    old_merge = case["merge"]
+    repo.joinpath("injected.txt").write_text("not reviewed\n")
+    subprocess.run(["git", "add", "injected.txt"], cwd=repo, check=True)
+    tree = _git(repo, "write-tree")
+    altered = subprocess.check_output(
+        [
+            "git",
+            "commit-tree",
+            tree,
+            "-p",
+            case["first_parent"],
+            "-p",
+            case["head"],
+            "-m",
+            "altered merge tree",
+        ],
+        cwd=repo,
+        text=True,
+    ).strip()
+    subprocess.run(["git", "tag", "-f", "v1.2.3", altered], cwd=repo, check=True)
+    subprocess.run(["git", "branch", "-f", "main", altered], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "push", "-q", "--force", "origin", "main", "v1.2.3"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "checkout", "-q", "--detach", altered], cwd=repo, check=True)
+    pull_key = f"repos/joyfulhouse/pylxpweb/commits/{old_merge}/pulls"
+    pull = case["fixtures"].pop(pull_key)
+    pull[0]["merge_commit_sha"] = altered
+    case["fixtures"][f"repos/joyfulhouse/pylxpweb/commits/{altered}/pulls"] = pull
+    case["merge"] = altered
+    result = _run_binding(case, tmp_path)
+    assert result.returncode != 0
+    assert "merge tree" in result.stderr.lower()
+
+
+def test_binding_does_not_treat_mutable_pr_base_sha_as_merge_parent(tmp_path: Path) -> None:
+    """GitHub updates closed PR base.sha after merge; git parentage owns merge-time base."""
+    case = _release_repo(tmp_path)
+    pull_key = f"repos/joyfulhouse/pylxpweb/commits/{case['merge']}/pulls"
+    case["fixtures"][pull_key][0]["base"]["sha"] = case["merge"]
+    result = _run_binding(case, tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
 @pytest.mark.parametrize(
     "mutation",
     [
@@ -327,7 +541,6 @@ def test_binding_rejects_old_ancestor_or_main_movement(tmp_path: Path) -> None:
         "wrong-pr",
         "wrong-merge-sha",
         "wrong-base",
-        "wrong-base-sha",
         "wrong-head",
     ],
 )
@@ -384,8 +597,6 @@ def test_binding_rejects_invalid_merge_and_associated_pr(tmp_path: Path, mutatio
         pull["merge_commit_sha"] = case["head"]
     elif mutation == "wrong-base":
         pull["base"]["ref"] = "release"
-    elif mutation == "wrong-base-sha":
-        pull["base"]["sha"] = case["head"]
     elif mutation == "wrong-head":
         pull["head"]["sha"] = case["parent"]
     result = _run_binding(case, tmp_path)
@@ -440,6 +651,47 @@ def test_binding_rejects_ineffective_review_or_required_ci(tmp_path: Path, mutat
     assert result.returncode != 0
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "collision",
+        "wrong-app",
+        "wrong-owner",
+        "wrong-workflow",
+        "wrong-run-head",
+        "wrong-event",
+    ],
+)
+def test_binding_rejects_same_name_ci_from_untrusted_producer(
+    tmp_path: Path, mutation: str
+) -> None:
+    """A same-name check must resolve to this repository's exact PR CI workflow run."""
+    case = _release_repo(tmp_path)
+    check_key = f"repos/joyfulhouse/pylxpweb/commits/{case['head']}/check-runs"
+    check = case["fixtures"][check_key]["check_runs"][0]
+    run = case["fixtures"]["repos/joyfulhouse/pylxpweb/actions/runs/12345"]
+    if mutation == "collision":
+        check_key = f"repos/joyfulhouse/pylxpweb/commits/{case['head']}/check-runs"
+        case["fixtures"][check_key]["check_runs"].append(
+            {
+                **check,
+                "app": {"slug": "attacker-ci", "owner": {"login": "attacker"}},
+            }
+        )
+    elif mutation == "wrong-app":
+        check["app"]["slug"] = "attacker-ci"
+    elif mutation == "wrong-owner":
+        check["app"]["owner"]["login"] = "attacker"
+    elif mutation == "wrong-workflow":
+        run["path"] = ".github/workflows/lookalike.yml"
+    elif mutation == "wrong-run-head":
+        run["head_sha"] = case["parent"]
+    elif mutation == "wrong-event":
+        run["event"] = "push"
+    result = _run_binding(case, tmp_path)
+    assert result.returncode != 0
+
+
 def test_binding_reads_all_review_pages_before_deciding(tmp_path: Path) -> None:
     """Dropping pagination can miss a later blocking review after page one."""
     case = _release_repo(tmp_path)
@@ -469,6 +721,58 @@ def test_binding_reads_all_review_pages_before_deciding(tmp_path: Path) -> None:
     }
     result = _run_binding(case, tmp_path)
     assert result.returncode != 0
+
+
+@pytest.mark.parametrize("step_id", ["assert-clean-source", "seal-source"])
+@pytest.mark.parametrize("mutation", ["tracked", "staged", "untracked"])
+def test_source_tree_checks_reject_mutable_build_inputs(
+    tmp_path: Path, step_id: str, mutation: str
+) -> None:
+    """Removing either cleanliness check permits bytes outside the recorded HEAD tree."""
+    case = _release_repo(tmp_path)
+    repo: Path = case["repo"]
+    if step_id == "seal-source":
+        assert _run_binding(case, tmp_path).returncode == 0
+        output = repo / "release-bundle" / "dist"
+        output.mkdir(parents=True)
+        output.joinpath("expected.whl").write_bytes(b"expected output")
+    if mutation in {"tracked", "staged"}:
+        repo.joinpath("source.txt").write_text("mutated")
+        if mutation == "staged":
+            subprocess.run(["git", "add", "source.txt"], cwd=repo, check=True)
+    else:
+        repo.joinpath("build-input.py").write_text("MUTATED = True\n")
+    env = os.environ | {"EXPECTED_COMMIT": case["merge"]}
+    result = subprocess.run(
+        ["bash", "-c", _step("bind-build-attest", step_id)["run"]],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "source tree" in result.stderr.lower()
+
+
+def test_sealing_allows_only_the_expected_release_bundle(tmp_path: Path) -> None:
+    """The generated sealed bundle is output, not an untracked build input."""
+    case = _release_repo(tmp_path)
+    assert _run_binding(case, tmp_path).returncode == 0
+    repo: Path = case["repo"]
+    output = repo / "release-bundle" / "dist"
+    output.mkdir(parents=True)
+    output.joinpath("expected.whl").write_bytes(b"expected output")
+    env = os.environ | {"EXPECTED_COMMIT": case["merge"]}
+    result = subprocess.run(
+        ["bash", "-c", _step("bind-build-attest", "seal-source")["run"]],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_sealing_rechecks_fresh_main_immediately_before_attestation(tmp_path: Path) -> None:
@@ -520,8 +824,13 @@ def test_release_job_graph_and_permissions_are_fail_closed() -> None:
         assert all("uses" in step and "run" not in step for step in job["steps"])
         assert "actions/download-artifact@" in job["steps"][0]["uses"]
         assert "pypa/gh-action-pypi-publish@" in job["steps"][1]["uses"]
+    assert "skip-existing" not in _job("publish-pypi")["steps"][1].get("with", {})
+    assert _job("bind-build-attest")["permissions"]["actions"] == "read"
     for job_id in set(expected) - {"bind-build-attest", "publish-testpypi", "publish-pypi"}:
         assert _job(job_id).get("permissions", {}).get("id-token") != "write"
+    for job_id in ("prepare-testpypi", "prepare-pypi"):
+        upload = _step(job_id, "upload-staging-artifact")
+        assert upload["with"]["retention-days"] == 30
 
 
 def test_release_trigger_and_workflow_identity_are_tag_only() -> None:
@@ -531,6 +840,8 @@ def test_release_trigger_and_workflow_identity_are_tag_only() -> None:
     checkout = _step("bind-build-attest", "checkout-source")
     assert checkout["with"]["ref"] == "${{ github.event.release.tag_name }}"
     assert checkout["with"]["fetch-tags"] is False
+    assert checkout["with"]["persist-credentials"] is False
+    assert "repository remains public" in (_ROOT / ".github" / "WORKFLOWS.md").read_text().lower()
 
 
 def test_build_uses_verified_digest_pinned_offline_read_only_container() -> None:
@@ -580,7 +891,9 @@ def test_build_attests_source_and_distributions_separately_with_full_sha_actions
 def test_preparation_verifies_attestation_identity_before_staging() -> None:
     """Dropping signer/source constraints permits a valid attestation from the wrong run."""
     for job_id in ("prepare-testpypi", "prepare-pypi"):
-        run = _step(job_id, "verify-release-bundle")["run"]
+        step = _step(job_id, "verify-release-bundle")
+        run = step["run"]
+        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
         for option in (
             "--signer-workflow",
             "--signer-digest",
@@ -656,7 +969,11 @@ def test_bundle_validation_rejects_artifact_and_attestation_tampering(tmp_path: 
         "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
         "REPOSITORY": "joyfulhouse/pylxpweb",
     }
+    env.pop("GH_TOKEN", None)
     run = _step("prepare-testpypi", "verify-release-bundle")["run"]
+    missing_auth = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
+    assert missing_auth.returncode != 0
+    env["GH_TOKEN"] = "scoped-test-token"
     good = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
     assert good.returncode == 0
     wheel.write_bytes(b"tampered")
@@ -666,6 +983,158 @@ def test_bundle_validation_rejects_artifact_and_attestation_tampering(tmp_path: 
     env["EXPECTED_ATTESTATION_CONTENT"] = "not-the-bundle"
     tampered_attestation = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
     assert tampered_attestation.returncode != 0
+
+
+@pytest.mark.parametrize("job_id", ["verify-testpypi", "verify-pypi"])
+def test_index_verifier_retries_then_accepts_exact_remote_bytes(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+    job_id: str,
+) -> None:
+    """The YAML-derived verifier handles transient index lag and exact bytes."""
+    base_url, state = package_index_server
+    files = {
+        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel",
+        "pylxpweb-1.2.3.tar.gz": b"sdist",
+    }
+    _write_dist_manifest(tmp_path, files)
+    state["files"] = files
+    payload = _index_payload(base_url, files)
+    state["index_responses"] = [503, payload]
+    result = _run_index_verifier(tmp_path, base_url, job_id=job_id)
+    assert result.returncode == 0, result.stderr
+    assert state["index_calls"] >= 2
+
+
+@pytest.mark.parametrize("job_id", ["verify-testpypi", "verify-pypi"])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "wrong-project",
+        "wrong-version",
+        "advertised-host",
+        "redirect-host",
+        "missing-file",
+        "unexpected-file",
+        "yanked-file",
+        "index-hash",
+        "downloaded-bytes",
+        "exhausted-retries",
+    ],
+)
+def test_index_verifier_rejects_remote_identity_and_byte_mutations(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+    job_id: str,
+    mutation: str,
+) -> None:
+    """Weakening any remote-index check admits a different published artifact set."""
+    base_url, state = package_index_server
+    files = {
+        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel",
+        "pylxpweb-1.2.3.tar.gz": b"sdist",
+    }
+    _write_dist_manifest(tmp_path, files)
+    state["files"] = dict(files)
+    payload = _index_payload(base_url, files)
+    if mutation == "wrong-project":
+        payload["info"]["name"] = "lookalike"
+    elif mutation == "wrong-version":
+        payload["info"]["version"] = "9.9.9"
+    elif mutation == "advertised-host":
+        payload["urls"][0]["url"] = payload["urls"][0]["url"].replace("127.0.0.1", "localhost")
+    elif mutation == "redirect-host":
+        name = payload["urls"][0]["filename"]
+        state["redirected_files"][name] = files[name]
+        state["files"][name] = {
+            "redirect": f"{base_url.replace('127.0.0.1', 'localhost')}/redirected/{name}"
+        }
+    elif mutation == "missing-file":
+        payload["urls"] = payload["urls"][:1]
+    elif mutation == "unexpected-file":
+        payload["urls"].append(
+            {
+                "digests": {"sha256": hashlib.sha256(b"other").hexdigest()},
+                "filename": "pylxpweb-1.2.3.zip",
+                "url": f"{base_url}/files/pylxpweb-1.2.3.zip",
+                "yanked": False,
+            }
+        )
+    elif mutation == "yanked-file":
+        payload["urls"][0]["yanked"] = True
+    elif mutation == "index-hash":
+        payload["urls"][0]["digests"]["sha256"] = "0" * 64
+    elif mutation == "downloaded-bytes":
+        state["files"][payload["urls"][0]["filename"]] = b"tampered"
+    elif mutation == "exhausted-retries":
+        state["index_responses"] = [503, 503, 503]
+    if not state["index_responses"]:
+        state["index_responses"] = [payload]
+    result = _run_index_verifier(tmp_path, base_url, job_id=job_id)
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize("job_id", ["verify-testpypi", "verify-pypi"])
+def test_index_verifier_rejects_competing_publication_race(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+    job_id: str,
+) -> None:
+    """A second index snapshot catches a file added while exact bytes are downloaded."""
+    base_url, state = package_index_server
+    files = {
+        "pylxpweb-1.2.3-py3-none-any.whl": b"wheel",
+        "pylxpweb-1.2.3.tar.gz": b"sdist",
+    }
+    _write_dist_manifest(tmp_path, files)
+    state["files"] = files
+    exact = _index_payload(base_url, files)
+    raced = json.loads(json.dumps(exact))
+    raced["urls"].append(
+        {
+            "digests": {"sha256": hashlib.sha256(b"competitor").hexdigest()},
+            "filename": "pylxpweb-1.2.3.zip",
+            "url": f"{base_url}/files/pylxpweb-1.2.3.zip",
+            "yanked": False,
+        }
+    )
+    state["index_responses"] = [exact, raced]
+    result = _run_index_verifier(tmp_path, base_url, job_id=job_id)
+    assert result.returncode != 0
+    assert state["index_calls"] == 2
+
+
+@pytest.mark.parametrize(
+    ("response", "expected_success"),
+    [(404, True), ("existing", False), (503, False)],
+    ids=["absent", "pre-existing", "unexpected-error"],
+)
+def test_pypi_absence_check_uses_controlled_index_and_fails_closed(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+    response: int | str,
+    expected_success: bool,
+) -> None:
+    """The exact prepare path accepts only a 404 and rejects an occupied version."""
+    base_url, state = package_index_server
+    state["index_responses"] = [
+        _index_payload(base_url, {}) if response == "existing" else response
+    ]
+    env = os.environ | {
+        "EXPECTED_PROJECT_NAME": "pylxpweb",
+        "EXPECTED_VERSION": "1.2.3",
+        "PYPI_JSON_BASE": f"{base_url}/pypi",
+    }
+    result = subprocess.run(
+        ["bash", "-c", _step("prepare-pypi", "verify-pypi-absence")["run"]],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert state["index_calls"] == 1
+    assert (result.returncode == 0) is expected_success
 
 
 def test_all_release_actions_are_immutable_full_sha_pins() -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import subprocess
 import threading
+import time
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -64,6 +65,19 @@ def package_index_server() -> Iterator[tuple[str, dict[str, Any]]]:
                     self.send_response(302)
                     self.send_header("Location", response["redirect"])
                     self.end_headers()
+                    return
+                if isinstance(response, dict) and "drip" in response:
+                    content = response["drip"]
+                    self.send_response(200)
+                    self.send_header("Content-Length", str(len(content)))
+                    self.end_headers()
+                    try:
+                        for byte in content:
+                            self.wfile.write(bytes([byte]))
+                            self.wfile.flush()
+                            time.sleep(response["delay"])
+                    except BrokenPipeError:
+                        pass
                     return
                 self.send_response(200)
                 self.send_header("Content-Length", str(len(response)))
@@ -172,16 +186,21 @@ def _run_index_verifier(
     base_url: str,
     *,
     job_id: str = "verify-testpypi",
+    env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ | {
         "ALLOWED_FILE_HOST": "127.0.0.1",
+        "DOWNLOAD_TOTAL_SECONDS": "2",
         "EXPECTED_PROJECT_NAME": "pylxpweb",
         "EXPECTED_VERSION": "1.2.3",
+        "INDEX_TOTAL_SECONDS": "2",
         "INDEX_JSON_BASE": f"{base_url}/pypi",
         "MAX_ATTEMPTS": "3",
         "REQUIRED_FILE_SCHEME": "http",
         "RETRY_BASE_SECONDS": "0",
+        "SOCKET_TIMEOUT_SECONDS": "1",
     }
+    env.update(env_overrides or {})
     return subprocess.run(
         ["bash", "-c", _step(job_id, f"verify-{job_id.removeprefix('verify-')}-files")["run"]],
         cwd=tmp_path,
@@ -238,11 +257,41 @@ if sys.argv[1:3] == ["attestation", "verify"]:
     if not os.environ.get("GH_TOKEN"):
         print("GH_TOKEN is required", file=sys.stderr)
         raise SystemExit(4)
+    subject = sys.argv[3]
     bundle = pathlib.Path(sys.argv[sys.argv.index("--bundle") + 1])
+    expected_options = {
+        "--repo": os.environ["REPOSITORY"],
+        "--signer-workflow": (
+            f'{os.environ["REPOSITORY"]}/.github/workflows/release.yml'
+        ),
+        "--signer-digest": os.environ["EXPECTED_WORKFLOW_SHA"],
+        "--source-ref": f'refs/tags/{os.environ["EXPECTED_TAG"]}',
+        "--source-digest": os.environ["EXPECTED_COMMIT"],
+    }
+    for option, expected_value in expected_options.items():
+        if option not in sys.argv or sys.argv[sys.argv.index(option) + 1] != expected_value:
+            print(f"attestation identity mismatch: {option}", file=sys.stderr)
+            raise SystemExit(1)
+    source_subject = "release-bundle/release-source.json"
+    dist_subjects = {
+        f"release-bundle/{line.split('  ', 1)[1]}"
+        for line in pathlib.Path("release-bundle/DIST_SHA256SUMS").read_text().splitlines()
+    }
+    if subject == source_subject:
+        expected_bundle = pathlib.Path("release-bundle/attestations/source.jsonl")
+    elif subject in dist_subjects:
+        expected_bundle = pathlib.Path("release-bundle/attestations/build.jsonl")
+    else:
+        print(f"unexpected attestation subject: {subject}", file=sys.stderr)
+        raise SystemExit(1)
+    if bundle != expected_bundle:
+        print(f"wrong attestation bundle for {subject}", file=sys.stderr)
+        raise SystemExit(1)
     expected = os.environ.get("EXPECTED_ATTESTATION_CONTENT")
     if expected is not None and bundle.read_text() != expected:
         raise SystemExit(1)
-    pathlib.Path(os.environ["GH_CALLS"]).write_text(" ".join(sys.argv[1:]) + "\n")
+    with pathlib.Path(os.environ["GH_CALLS"]).open("a") as calls:
+        calls.write(" ".join(sys.argv[1:]) + "\n")
     print("verified")
     raise SystemExit(0)
 
@@ -977,6 +1026,38 @@ def test_bundle_validation_rejects_artifact_and_attestation_tampering(tmp_path: 
     env["GH_TOKEN"] = "scoped-test-token"
     good = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
     assert good.returncode == 0
+    calls = (tmp_path / "gh-calls").read_text().splitlines()
+    assert len(calls) == 3
+    assert {call.split()[2] for call in calls} == {
+        "release-bundle/release-source.json",
+        f"release-bundle/dist/{wheel.name}",
+        f"release-bundle/dist/{sdist.name}",
+    }
+    identity_mutations = {
+        "repository": ('--repo "$REPOSITORY"', '--repo "attacker/repository"'),
+        "workflow": (
+            'signer="$REPOSITORY/.github/workflows/release.yml"',
+            'signer="attacker/repository/.github/workflows/release.yml"',
+        ),
+        "workflow digest": (
+            '--signer-digest "$EXPECTED_WORKFLOW_SHA"',
+            f'--signer-digest "{"0" * 40}"',
+        ),
+        "tag": ('--source-ref "refs/tags/$EXPECTED_TAG"', '--source-ref "refs/tags/v9.9.9"'),
+        "commit": (
+            '--source-digest "$EXPECTED_COMMIT"',
+            f'--source-digest "{"f" * 40}"',
+        ),
+        "subject": (
+            "gh attestation verify release-bundle/release-source.json",
+            "gh attestation verify release-bundle/DIST_SHA256SUMS",
+        ),
+    }
+    for label, (expected, replacement) in identity_mutations.items():
+        assert expected in run, label
+        mutated = run.replace(expected, replacement, 1)
+        result = subprocess.run(["bash", "-c", mutated], cwd=tmp_path, env=env, check=False)
+        assert result.returncode != 0, label
     wheel.write_bytes(b"tampered")
     tampered_artifact = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
     assert tampered_artifact.returncode != 0
@@ -1087,6 +1168,50 @@ def test_index_verifier_rejects_competing_publication_race(
     assert state["index_calls"] == 2
 
 
+@pytest.mark.parametrize("job_id", ["verify-testpypi", "verify-pypi"])
+def test_index_verifier_worst_case_fits_job_timeout_with_five_minute_headroom(
+    job_id: str,
+) -> None:
+    """Polling, transfers, final snapshot, and non-index verification fit mechanically."""
+    job = _job(job_id)
+    step = _step(job_id, f"verify-{job_id.removeprefix('verify-')}-files")
+    env = step["env"]
+    attempts = int(env["MAX_ATTEMPTS"])
+    retry_base = int(env["RETRY_BASE_SECONDS"])
+    index_total = int(env["INDEX_TOTAL_SECONDS"])
+    download_total = int(env["DOWNLOAD_TOTAL_SECONDS"])
+    socket_timeout = int(env["SOCKET_TIMEOUT_SECONDS"])
+    backoff = sum(min(attempt * retry_base, 30) for attempt in range(1, attempts))
+    verifier_worst_case = attempts * index_total + backoff + 2 * download_total + index_total
+    headroom = int(job["timeout-minutes"]) * 60 - verifier_worst_case
+    assert headroom >= 300
+    assert socket_timeout < index_total
+    assert socket_timeout < download_total
+    assert "signal.setitimer" in step["run"]
+
+
+def test_index_verifier_enforces_total_deadline_despite_socket_activity(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+) -> None:
+    """A drip-fed body cannot evade the total-transfer deadline via socket activity."""
+    base_url, state = package_index_server
+    files, payload = _prepare_index_case(tmp_path, base_url, state)
+    wheel_name = next(name for name in files if name.endswith(".whl"))
+    state["files"][wheel_name] = {"drip": files[wheel_name], "delay": 0.1}
+    state["index_responses"] = [payload]
+    result = _run_index_verifier(
+        tmp_path,
+        base_url,
+        env_overrides={
+            "DOWNLOAD_TOTAL_SECONDS": "0.2",
+            "INDEX_TOTAL_SECONDS": "2",
+            "SOCKET_TIMEOUT_SECONDS": "1",
+        },
+    )
+    assert result.returncode != 0
+
+
 @pytest.mark.parametrize(
     ("response", "expected_success"),
     [(404, True), ("existing", False), (503, False)],
@@ -1167,6 +1292,13 @@ def test_build_produces_exactly_two_bit_reproducible_distributions(tmp_path: Pat
         pytest.skip("Docker CLI is unavailable")
     subprocess.run(["docker", "info"], capture_output=True, check=True)
     script = _step("bind-build-attest", "build-distributions")["run"]
+    commit_epoch = _git(_ROOT, "show", "-s", "--format=%ct", "HEAD")
+    build_command = "  uv build --offline"
+    assert script.count(build_command) == 1
+    script = script.replace(
+        build_command,
+        f'  test "$SOURCE_DATE_EPOCH" = "{commit_epoch}"\n{build_command}',
+    )
     image = _workflow()["env"]["BUILD_IMAGE"]
     subprocess.run(["docker", "pull", image], check=True)
     source = tmp_path / "source"
@@ -1176,7 +1308,7 @@ def test_build_produces_exactly_two_bit_reproducible_distributions(tmp_path: Pat
         ignore=shutil.ignore_patterns(".git", ".venv", ".release-test-output-*"),
     )
     outputs: list[dict[str, str]] = []
-    for index in (1, 2):
+    for index, ambient_epoch in enumerate(("1", "2000000000"), start=1):
         output = tmp_path / f"output-{index}"
         output.mkdir()
         env = os.environ | {
@@ -1184,7 +1316,7 @@ def test_build_produces_exactly_two_bit_reproducible_distributions(tmp_path: Pat
             "EXPECTED_COMMIT": _git(_ROOT, "rev-parse", "HEAD"),
             "GITHUB_WORKSPACE": str(source),
             "OUTPUT_DIR": str(output),
-            "SOURCE_DATE_EPOCH": "1755302400",
+            "SOURCE_DATE_EPOCH": ambient_epoch,
         }
         result = subprocess.run(["bash", "-c", script], env=env, text=True, capture_output=True)
         assert result.returncode == 0, result.stderr

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1,36 +1,30 @@
-"""Executable and structural contract tests for the package release workflow."""
+"""Production-shaped contract tests for the package release workflow."""
 
 from __future__ import annotations
 
 import hashlib
-import io
 import json
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError, URLError
 
 import pytest
 import yaml
 
-_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW_PATH = _ROOT / ".github" / "workflows" / "release.yml"
 _WORKFLOWS_PATH = _WORKFLOW_PATH.parent
-_WORKFLOW_DOCS_PATH = Path(__file__).resolve().parents[2] / ".github" / "WORKFLOWS.md"
 _FULL_SHA_ACTION = re.compile(r"^[^\s@]+@[0-9a-f]{40}$")
+_TEST_WORKFLOW_REF = "joyfulhouse/pylxpweb/.github/workflows/release.yml@refs/tags/v1.2.3"
 _PACKAGE_INDEX_PUBLISHER = re.compile(
     r"pypa/gh-action-pypi-publish@|"
     r"https://(?:(?:test|upload)\.)?pypi\.org/legacy/|"
     r"\b(?:twine\s+upload|(?:uv|poetry|hatch|flit|pdm)\s+publish)\b",
     re.IGNORECASE,
 )
-_WHEEL_NAME = "pylxpweb-1.2.3-py3-none-any.whl"
-_SDIST_NAME = "pylxpweb-1.2.3.tar.gz"
-_DISTRIBUTIONS = {_WHEEL_NAME: b"wheel bytes", _SDIST_NAME: b"sdist bytes"}
-_DISTRIBUTION_HASHES = {
-    name: hashlib.sha256(content).hexdigest() for name, content in _DISTRIBUTIONS.items()
-}
 
 
 def _workflow() -> dict[str, Any]:
@@ -41,17 +35,13 @@ def _workflow() -> dict[str, Any]:
     return workflow
 
 
-def _job(workflow: dict[str, Any], job_id: str) -> dict[str, Any]:
-    job: dict[str, Any] = workflow["jobs"][job_id]
+def _job(job_id: str) -> dict[str, Any]:
+    job: dict[str, Any] = _workflow()["jobs"][job_id]
     return job
 
 
-def _steps_by_id(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    return {step["id"]: step for step in job["steps"] if "id" in step}
-
-
-def _action_steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
-    return [step for job in workflow["jobs"].values() for step in job["steps"] if "uses" in step]
+def _step(job_id: str, step_id: str) -> dict[str, Any]:
+    return next(step for step in _job(job_id)["steps"] if step.get("id") == step_id)
 
 
 def _strings(value: Any) -> list[str]:
@@ -73,66 +63,165 @@ def _package_index_publisher_workflows(workflows_path: Path) -> set[str]:
     return publishers
 
 
-def _step(workflow: dict[str, Any], job_id: str, step_id: str) -> dict[str, Any]:
-    return _steps_by_id(_job(workflow, job_id))[step_id]
-
-
 def _git(repo: Path, *args: str) -> str:
     return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
 
 
-def _commit(repo: Path, message: str, version: str, marker: str) -> str:
-    repo.joinpath("pyproject.toml").write_text(
-        f'[project]\nname = "pylxpweb"\nversion = "{version}"\n'
-    )
+def _commit(repo: Path, message: str, marker: str) -> str:
     repo.joinpath("source.txt").write_text(marker)
-    subprocess.run(["git", "add", "pyproject.toml", "source.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
     subprocess.run(["git", "commit", "-qm", message], cwd=repo, check=True)
     return _git(repo, "rev-parse", "HEAD")
 
 
-def _release_repo(tmp_path: Path) -> tuple[Path, str, str]:
+def _write_fake_gh(bin_dir: Path) -> None:
+    gh = bin_dir / "gh"
+    gh.write_text(
+        r"""#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+if len(sys.argv) >= 2 and sys.argv[1] == "api":
+    endpoint = next(arg for arg in sys.argv[2:] if arg.startswith("repos/"))
+    fixtures = json.loads(pathlib.Path(os.environ["GH_FIXTURES"]).read_text())
+    if endpoint not in fixtures:
+        print(f"unexpected endpoint: {endpoint}", file=sys.stderr)
+        raise SystemExit(2)
+    value = fixtures[endpoint]
+    if "--jq" in sys.argv:
+        print(value[sys.argv[sys.argv.index("--jq") + 1].removeprefix(".")])
+        raise SystemExit(0)
+    if "--slurp" in sys.argv:
+        if isinstance(value, list):
+            pages = [value[index : index + 30] for index in range(0, len(value), 30)]
+            if "--paginate" not in sys.argv:
+                pages = pages[:1]
+        else:
+            pages = [value]
+        print(json.dumps(pages))
+    else:
+        print(json.dumps(value))
+    raise SystemExit(0)
+
+if sys.argv[1:3] == ["attestation", "verify"]:
+    bundle = pathlib.Path(sys.argv[sys.argv.index("--bundle") + 1])
+    expected = os.environ.get("EXPECTED_ATTESTATION_CONTENT")
+    if expected is not None and bundle.read_text() != expected:
+        raise SystemExit(1)
+    pathlib.Path(os.environ["GH_CALLS"]).write_text(" ".join(sys.argv[1:]) + "\n")
+    print("verified")
+    raise SystemExit(0)
+
+print("unsupported fake gh invocation", file=sys.stderr)
+raise SystemExit(2)
+"""
+    )
+    gh.chmod(0o755)
+
+
+def _release_repo(tmp_path: Path, *, lightweight: bool = False) -> dict[str, Any]:
+    remote = tmp_path / "origin.git"
     repo = tmp_path / "repo"
-    repo.mkdir()
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
     subprocess.run(["git", "config", "user.name", "Release Test"], cwd=repo, check=True)
     subprocess.run(
         ["git", "config", "user.email", "release-test@example.com"], cwd=repo, check=True
     )
-    parent = _commit(repo, "parent", "1.2.2", "parent")
-    commit = _commit(repo, "release", "1.2.3", "release")
-    subprocess.run(["git", "tag", "-a", "v1.2.3", "-m", "release"], cwd=repo, check=True)
-    subprocess.run(["git", "update-ref", "refs/remotes/origin/main", commit], cwd=repo, check=True)
+    subprocess.run(["git", "config", "tag.gpgSign", "false"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "tag.forceSignAnnotated", "false"], cwd=repo, check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=repo, check=True)
+    repo.joinpath("pyproject.toml").write_text('[project]\nname = "pylxpweb"\nversion = "1.2.3"\n')
+    workflow = repo / ".github" / "workflows" / "release.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("name: Publish to PyPI\n")
+    parent = _commit(repo, "parent", "parent")
+    subprocess.run(["git", "checkout", "-qb", "release-candidate"], cwd=repo, check=True)
+    head = _commit(repo, "release candidate", "release")
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "merge", "-q", "--no-ff", "release-candidate", "-m", "merge candidate"],
+        cwd=repo,
+        check=True,
+    )
+    merge = _git(repo, "rev-parse", "HEAD")
+    tag_args = ["git", "-c", "tag.forceSignAnnotated=false", "tag", "v1.2.3"]
+    if not lightweight:
+        tag_args = ["git", "tag", "-a", "v1.2.3", "-m", "release"]
+    subprocess.run(tag_args, cwd=repo, check=True)
+    subprocess.run(["git", "push", "-q", "origin", "main", "v1.2.3"], cwd=repo, check=True)
     subprocess.run(["git", "checkout", "-q", "--detach", "v1.2.3"], cwd=repo, check=True)
-    subprocess.run(["git", "branch", "-D", "main"], cwd=repo, check=True)
-    return repo, parent, commit
-
-
-def _run_resolve_source(
-    repo: Path,
-    *,
-    commit: str,
-    event_name: str = "release",
-    event_sha: str | None = None,
-    release_tag: str = "v1.2.3",
-    release_target: str = "main",
-    dispatch_tag: str = "v1.2.3",
-) -> subprocess.CompletedProcess[str]:
-    output = repo / "github-output"
-    output.unlink(missing_ok=True)
-    env = os.environ | {
-        "DISPATCH_TAG": dispatch_tag,
-        "EVENT_NAME": event_name,
-        "EVENT_SHA": event_sha or commit,
-        "GITHUB_OUTPUT": str(output),
-        "RELEASE_DRAFT": "false",
-        "RELEASE_ID": "291",
-        "RELEASE_TAG": release_tag,
-        "RELEASE_TARGET": release_target,
-        "RELEASE_URL": "https://github.test/releases/291",
+    # Seed a divergent tracking ref: the production binder must force-replace it.
+    subprocess.run(["git", "checkout", "-qb", "stale-ref", parent], cwd=repo, check=True)
+    stale = _commit(repo, "divergent stale ref", "stale")
+    subprocess.run(["git", "checkout", "-q", "--detach", "v1.2.3"], cwd=repo, check=True)
+    subprocess.run(["git", "update-ref", "refs/remotes/origin/main", stale], cwd=repo, check=True)
+    repository = "joyfulhouse/pylxpweb"
+    fixtures: dict[str, Any] = {
+        f"repos/{repository}/commits/{merge}/pulls": [
+            {
+                "number": 17,
+                "state": "closed",
+                "merged_at": "2026-08-16T12:00:00Z",
+                "merge_commit_sha": merge,
+                "head": {"sha": head},
+                "base": {"ref": "main", "sha": parent},
+                "user": {"login": "author"},
+            }
+        ],
+        f"repos/{repository}/pulls/17/reviews": [
+            {
+                "state": "APPROVED",
+                "commit_id": head,
+                "submitted_at": "2026-08-16T11:00:00Z",
+                "user": {"login": "reviewer"},
+            }
+        ],
+        f"repos/{repository}/collaborators/reviewer/permission": {"permission": "write"},
+        f"repos/{repository}/commits/{head}/check-runs": {
+            "check_runs": [{"name": "CI Success", "head_sha": head, "conclusion": "success"}]
+        },
     }
+    return {
+        "repo": repo,
+        "remote": remote,
+        "stale": stale,
+        "parent": parent,
+        "head": head,
+        "merge": merge,
+        "fixtures": fixtures,
+    }
+
+
+def _run_binding(
+    case: dict[str, Any], tmp_path: Path, **env_overrides: str
+) -> subprocess.CompletedProcess[str]:
+    repo: Path = case["repo"]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    _write_fake_gh(bin_dir)
+    fixtures_path = tmp_path / "gh-fixtures.json"
+    fixtures_path.write_text(json.dumps(case["fixtures"]))
+    output = tmp_path / "github-output"
+    summary = tmp_path / "github-summary"
+    env = os.environ | {
+        "EVENT_NAME": "release",
+        "EVENT_SHA": case["merge"],
+        "GITHUB_OUTPUT": str(output),
+        "GITHUB_STEP_SUMMARY": str(summary),
+        "GH_FIXTURES": str(fixtures_path),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "RELEASE_DRAFT": "false",
+        "RELEASE_TAG": "v1.2.3",
+        "REPOSITORY": "joyfulhouse/pylxpweb",
+        "WORKFLOW_REF": "joyfulhouse/pylxpweb/.github/workflows/release.yml@refs/tags/v1.2.3",
+        "WORKFLOW_SHA": case["merge"],
+    }
+    env.update(env_overrides)
     return subprocess.run(
-        ["bash", "-c", _step(_workflow(), "build", "resolve-source")["run"]],
+        ["bash", "-c", _step("bind-build-attest", "bind-source")["run"]],
         cwd=repo,
         env=env,
         text=True,
@@ -141,771 +230,454 @@ def _run_resolve_source(
     )
 
 
-def _python_heredoc(job_id: str, step_id: str) -> str:
-    script: str = _step(_workflow(), job_id, step_id)["run"]
-    match = re.fullmatch(r"python3 - <<'PY'\n(?P<code>.*)\nPY\n?", script, re.DOTALL)
-    assert match is not None, step_id
-    return match.group("code")
-
-
-def _execute_python_heredoc(job_id: str, step_id: str) -> None:
-    namespace: dict[str, Any] = {"__builtins__": __builtins__}
-    exec(
-        compile(_python_heredoc(job_id, step_id), step_id, "exec"),
-        namespace,
-        namespace,
-    )
-
-
-class _Response(io.BytesIO):
-    def __init__(self, content: bytes, url: str) -> None:
-        super().__init__(content)
-        self._url = url
-
-    def geturl(self) -> str:
-        return self._url
-
-
-def _index_payload(
-    filenames: list[str] | tuple[str, ...],
-    *,
-    file_host: str | None = None,
-) -> dict[str, Any]:
-    releases = []
-    for filename in filenames:
-        release = {
-            "filename": filename,
-            "yanked": False,
-            "digests": {"sha256": _DISTRIBUTION_HASHES.get(filename, "0" * 64)},
-        }
-        if file_host is not None:
-            release["url"] = f"https://{file_host}/{filename}"
-        releases.append(release)
-    return {"info": {"name": "pylxpweb", "version": "1.2.3"}, "urls": releases}
-
-
-def _write_release_bundle(tmp_path: Path) -> None:
-    bundle = tmp_path / "release-bundle"
-    dist = bundle / "dist"
-    dist.mkdir(parents=True)
-    for filename, content in _DISTRIBUTIONS.items():
-        dist.joinpath(filename).write_bytes(content)
-    bundle.joinpath("SHA256SUMS").write_text(
-        "\n".join(
-            [
-                f"{'0' * 64}  release-source.json",
-                *(f"{_DISTRIBUTION_HASHES[name]}  dist/{name}" for name in sorted(_DISTRIBUTIONS)),
-            ]
-        )
-        + "\n"
-    )
-
-
-def _run_testpypi_verifier(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    payload: dict[str, Any],
-    downloads: dict[str, bytes],
+@pytest.mark.parametrize("lightweight", [False, True], ids=["annotated", "lightweight"])
+def test_binding_accepts_exact_reviewed_merge_and_peels_tag(
+    tmp_path: Path, lightweight: bool
 ) -> None:
-    _write_release_bundle(tmp_path)
-    output = tmp_path / "github-output"
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("ALLOWED_DISTRIBUTION_HOST", "files.test")
-    monkeypatch.setenv("EXPECTED_PROJECT_NAME", "pylxpweb")
-    monkeypatch.setenv("EXPECTED_VERSION", "1.2.3")
-    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
-    monkeypatch.setenv("MAX_ATTEMPTS", "1")
-    monkeypatch.setenv("TESTPYPI_JSON_BASE_URL", "https://index.test/pypi")
-
-    def urlopen(request: Any, timeout: int) -> _Response:
-        del timeout
-        url = request.full_url
-        if url == "https://index.test/pypi/pylxpweb/1.2.3/json":
-            return _Response(json.dumps(payload).encode(), url)
-        filename = Path(url).name
-        return _Response(downloads[filename], url)
-
-    monkeypatch.setattr("urllib.request.urlopen", urlopen)
-    _execute_python_heredoc("verify-testpypi", "query-testpypi")
+    """Changing tag peeling or exact merge binding rejects a valid release."""
+    case = _release_repo(tmp_path, lightweight=lightweight)
+    result = _run_binding(case, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert _git(case["repo"], "rev-parse", "refs/remotes/origin/main") == case["merge"]
 
 
-def test_testpypi_verifier_downloads_and_hashes_both_distributions(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Remote verification covers the wheel and sdist while exporting the wheel."""
-    _run_testpypi_verifier(
-        tmp_path,
-        monkeypatch,
-        payload=_index_payload(tuple(_DISTRIBUTIONS), file_host="files.test"),
-        downloads=_DISTRIBUTIONS,
-    )
-
-    verified = tmp_path / "verified-distributions"
-    assert verified.joinpath(_WHEEL_NAME).read_bytes() == _DISTRIBUTIONS[_WHEEL_NAME]
-    assert verified.joinpath(_SDIST_NAME).read_bytes() == _DISTRIBUTIONS[_SDIST_NAME]
-    assert (tmp_path / "github-output").read_text() == (
-        f"wheel-path=verified-distributions/{_WHEEL_NAME}\n"
-    )
+def test_binding_force_replaces_stale_origin_main(tmp_path: Path) -> None:
+    """Removing --force/--no-tags leaves a stale tracking ref trusted or unresolved."""
+    case = _release_repo(tmp_path)
+    assert _git(case["repo"], "rev-parse", "refs/remotes/origin/main") == case["stale"]
+    result = _run_binding(case, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert _git(case["repo"], "rev-parse", "refs/remotes/origin/main") == case["merge"]
 
 
-@pytest.mark.parametrize(
-    ("case", "expected_error"),
-    [
-        ("wrong-project", "package index project name does not match"),
-        ("wrong-version", "package index version does not match"),
-        ("wrong-host", "distribution URL is not allowlisted HTTPS"),
-        ("wrong-index-hash", "package index hash does not match"),
-        ("wrong-download-hash", "downloaded distribution hash does not match"),
-        ("yanked", "package index contains yanked file"),
-        ("unexpected", "package index file set does not match"),
-        ("missing", "package index file set does not match"),
-    ],
-)
-def test_testpypi_verifier_rejects_untrusted_remote_state(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    case: str,
-    expected_error: str,
-) -> None:
-    """Index metadata, hosts, file sets, and downloaded bytes fail closed."""
-    downloads = _DISTRIBUTIONS.copy()
-    payload = _index_payload(tuple(_DISTRIBUTIONS), file_host="files.test")
-    if case == "wrong-project":
-        payload["info"]["name"] = "other"
-    elif case == "wrong-version":
-        payload["info"]["version"] = "9.9.9"
-    elif case == "wrong-host":
-        payload["urls"][1]["url"] = f"https://evil.test/{_SDIST_NAME}"
-    elif case == "wrong-index-hash":
-        payload["urls"][1]["digests"]["sha256"] = "0" * 64
-    elif case == "wrong-download-hash":
-        downloads[_SDIST_NAME] = b"different"
-    elif case == "yanked":
-        payload["urls"][1]["yanked"] = True
-    elif case == "unexpected":
-        payload["urls"].append(
-            {
-                "filename": "unexpected.whl",
-                "url": "https://files.test/unexpected.whl",
-                "yanked": False,
-                "digests": {"sha256": "0" * 64},
-            }
-        )
-    elif case == "missing":
-        payload["urls"].pop()
-
-    with pytest.raises(AssertionError, match=expected_error):
-        _run_testpypi_verifier(
-            tmp_path,
-            monkeypatch,
-            payload=payload,
-            downloads=downloads,
-        )
-
-
-def _run_pypi_state_step(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    step_id: str,
-    mode: str,
-    responses: list[dict[str, Any] | Exception | None],
-) -> tuple[set[str], str, int]:
-    _write_release_bundle(tmp_path)
-    output = tmp_path / "github-output"
-    upload = tmp_path / "pypi-upload"
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("EXPECTED_PROJECT_NAME", "pylxpweb")
-    monkeypatch.setenv("EXPECTED_VERSION", "1.2.3")
-    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
-    step_env = _step(_workflow(), "publish-pypi", step_id)["env"]
-    monkeypatch.setenv("MAX_ATTEMPTS", step_env["MAX_ATTEMPTS"])
-    for name in ("BACKOFF_SECONDS", "MAX_BACKOFF_SECONDS", "REQUEST_TIMEOUT_SECONDS"):
-        if name in step_env:
-            monkeypatch.setenv(name, step_env[name])
-    monkeypatch.setenv("MODE", mode)
-    monkeypatch.setenv("PYPI_JSON_BASE_URL", "https://index.test/pypi")
-    monkeypatch.setenv("UPLOAD_DIR", str(upload))
-    monkeypatch.setattr("time.sleep", lambda _: None)
-    pending = list(responses)
-    calls = 0
-
-    def urlopen(request: Any, timeout: int) -> _Response:
-        nonlocal calls
-        del timeout
-        calls += 1
-        payload = pending.pop(0) if pending else responses[-1]
-        if isinstance(payload, Exception):
-            raise payload
-        if payload is None:
-            raise HTTPError(request.full_url, 404, "Not Found", {}, None)
-        return _Response(json.dumps(payload).encode(), request.full_url)
-
-    monkeypatch.setattr("urllib.request.urlopen", urlopen)
-    _execute_python_heredoc("publish-pypi", step_id)
-    staged = {path.name for path in upload.iterdir()} if upload.exists() else set()
-    return staged, output.read_text() if output.exists() else "", calls
-
-
-@pytest.mark.parametrize("existing_count", [0, 1, 2])
-def test_pypi_preflight_stages_only_absent_distributions(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, existing_count: int
-) -> None:
-    """A retry publishes none, one, or both files without production skipping."""
-    filenames = list(_DISTRIBUTIONS)
-    payload = None if existing_count == 0 else _index_payload(filenames[:existing_count])
-
-    staged, output, calls = _run_pypi_state_step(
-        tmp_path,
-        monkeypatch,
-        step_id="prepare-pypi",
-        mode="prepare",
-        responses=[payload],
-    )
-
-    assert staged == set(filenames[existing_count:])
-    assert output == f"upload-needed={'true' if staged else 'false'}\n"
-    assert calls == 1
-
-
-def test_pypi_preflight_retries_transient_failure_then_accepts_absent_version(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A transient index failure is retried before a genuine 404 is accepted."""
-    staged, output, calls = _run_pypi_state_step(
-        tmp_path,
-        monkeypatch,
-        step_id="prepare-pypi",
-        mode="prepare",
-        responses=[URLError("temporary failure"), None],
-    )
-
-    assert staged == set(_DISTRIBUTIONS)
-    assert output == "upload-needed=true\n"
-    assert calls == 2
-
-
-def test_pypi_preflight_exhausts_bounded_transient_retries(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Preflight fails closed after its small retry allowance is exhausted."""
-    with pytest.raises(URLError, match="third failure"):
-        _run_pypi_state_step(
-            tmp_path,
-            monkeypatch,
-            step_id="prepare-pypi",
-            mode="prepare",
-            responses=[
-                URLError("first failure"),
-                URLError("second failure"),
-                URLError("third failure"),
-            ],
-        )
-
-
-@pytest.mark.parametrize(
-    ("case", "expected_error"),
-    [
-        ("wrong-hash", "PyPI hash does not match"),
-        ("unexpected", "PyPI contains unexpected file"),
-        ("yanked", "PyPI contains yanked file"),
-    ],
-)
-def test_pypi_preflight_rejects_untrusted_existing_files(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    case: str,
-    expected_error: str,
-) -> None:
-    """Existing production files are accepted only as an exact trusted subset."""
-    payload = _index_payload([_WHEEL_NAME])
-    if case == "wrong-hash":
-        payload["urls"][0]["digests"]["sha256"] = "0" * 64
-    elif case == "unexpected":
-        payload["urls"].append(
-            {
-                "filename": "unexpected.whl",
-                "yanked": False,
-                "digests": {"sha256": "0" * 64},
-            }
-        )
-    elif case == "yanked":
-        payload["urls"][0]["yanked"] = True
-
-    with pytest.raises(AssertionError, match=expected_error):
-        _run_pypi_state_step(
-            tmp_path,
-            monkeypatch,
-            step_id="prepare-pypi",
-            mode="prepare",
-            responses=[payload],
-        )
-
-
-def test_pypi_final_verification_retries_until_exact_set(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Index propagation is bounded and must converge to the exact file set."""
-    filenames = list(_DISTRIBUTIONS)
-
-    staged, output, calls = _run_pypi_state_step(
-        tmp_path,
-        monkeypatch,
-        step_id="verify-pypi",
-        mode="verify",
-        responses=[
-            _index_payload(filenames[:1]),
-            _index_payload(filenames),
+def test_checkout_depth_exposes_both_merge_parents(tmp_path: Path) -> None:
+    """A one-commit Actions checkout makes a valid merge look parentless."""
+    case = _release_repo(tmp_path / "source")
+    checkout = tmp_path / "checkout"
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "-q",
+            "--no-local",
+            "--depth",
+            str(_step("bind-build-attest", "checkout-source")["with"]["fetch-depth"]),
+            "--branch",
+            "v1.2.3",
+            str(case["remote"]),
+            str(checkout),
         ],
+        check=True,
     )
-
-    assert staged == set()
-    assert output == ""
-    assert calls == 2
+    case["repo"] = checkout
+    result = _run_binding(case, tmp_path)
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize(
-    ("case", "expected_error"),
+    ("override", "message"),
     [
-        ("missing", "PyPI final file set does not match"),
-        ("wrong-hash", "PyPI hash does not match"),
-        ("unexpected", "PyPI contains unexpected file"),
-        ("yanked", "PyPI contains yanked file"),
+        ({"EVENT_SHA": "0" * 40}, "event"),
+        ({"WORKFLOW_SHA": "1" * 40}, "workflow SHA"),
+        (
+            {"WORKFLOW_REF": "joyfulhouse/pylxpweb/.github/workflows/release.yml@refs/heads/main"},
+            "workflow ref",
+        ),
+        ({"RELEASE_TAG": "v9.9.9"}, "tag"),
     ],
 )
-def test_pypi_final_verification_rejects_untrusted_state(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    case: str,
-    expected_error: str,
+def test_binding_rejects_event_workflow_and_version_identity_mismatch(
+    tmp_path: Path, override: dict[str, str], message: str
 ) -> None:
-    """Post-publication verification fails closed on every non-exact state."""
-    payload = _index_payload(list(_DISTRIBUTIONS))
-    if case == "missing":
-        payload["urls"].pop()
-    elif case == "wrong-hash":
-        payload["urls"][1]["digests"]["sha256"] = "0" * 64
-    elif case == "unexpected":
-        payload["urls"].append(
-            {
-                "filename": "unexpected.whl",
-                "yanked": False,
-                "digests": {"sha256": "0" * 64},
-            }
+    """Weakening any event/workflow/tag equality permits an unreviewed identity."""
+    case = _release_repo(tmp_path)
+    if override.get("RELEASE_TAG") == "v9.9.9":
+        override["WORKFLOW_REF"] = (
+            "joyfulhouse/pylxpweb/.github/workflows/release.yml@refs/tags/v9.9.9"
         )
-    elif case == "yanked":
-        payload["urls"][1]["yanked"] = True
-
-    with pytest.raises(AssertionError, match=expected_error):
-        _run_pypi_state_step(
-            tmp_path,
-            monkeypatch,
-            step_id="verify-pypi",
-            mode="verify",
-            responses=[payload],
-        )
-
-
-def test_resolve_source_accepts_remote_branch_release_target(tmp_path: Path) -> None:
-    """A detached release checkout resolves a branch target through origin."""
-    repo, _, commit = _release_repo(tmp_path)
-
-    result = _run_resolve_source(repo, commit=commit)
-
-    assert result.returncode == 0, result.stderr
-    assert (
         subprocess.run(
-            ["git", "show-ref", "--verify", "--quiet", "refs/heads/main"], cwd=repo
-        ).returncode
-        != 0
-    )
-    assert _git(repo, "rev-parse", "refs/remotes/origin/main") == commit
-
-
-def test_resolve_source_accepts_full_commit_release_target(tmp_path: Path) -> None:
-    """GitHub may supply the complete target commit instead of a branch name."""
-    repo, _, commit = _release_repo(tmp_path)
-
-    result = _run_resolve_source(repo, commit=commit, release_target=commit)
-
-    assert result.returncode == 0, result.stderr
-
-
-def test_resolve_source_accepts_dispatch_and_rejects_other_events(tmp_path: Path) -> None:
-    """Manual validation is supported, but no other event may enter the build path."""
-    repo, parent, commit = _release_repo(tmp_path)
-
-    dispatch = _run_resolve_source(
-        repo,
-        commit=commit,
-        event_name="workflow_dispatch",
-        event_sha=parent,
-        release_tag="",
-        release_target="--ignored",
-    )
-    unsupported = _run_resolve_source(repo, commit=commit, event_name="push")
-
-    assert dispatch.returncode == 0, dispatch.stderr
-    assert unsupported.returncode != 0
-    assert "unsupported release workflow event" in unsupported.stderr
-
-
-@pytest.mark.parametrize("target", ["main~1", "--help", "deadbeef", "missing"])
-def test_resolve_source_rejects_ambiguous_or_malformed_target(tmp_path: Path, target: str) -> None:
-    """Only a full commit or an exact remote branch name is a valid target."""
-    repo, _, commit = _release_repo(tmp_path)
-
-    result = _run_resolve_source(repo, commit=commit, release_target=target)
-
+            ["git", "tag", "-a", "v9.9.9", case["merge"], "-m", "wrong version"],
+            cwd=case["repo"],
+            check=True,
+        )
+    result = _run_binding(case, tmp_path, **override)
     assert result.returncode != 0
-    assert "invalid or unresolved release target" in result.stderr
+    assert message.lower() in result.stderr.lower()
 
 
-@pytest.mark.parametrize("target_kind", ["branch", "commit"])
-def test_resolve_source_rejects_target_before_release(tmp_path: Path, target_kind: str) -> None:
-    """The release tag must be contained by either supported target form."""
-    repo, parent, commit = _release_repo(tmp_path)
-    target = parent
-    if target_kind == "branch":
+def test_binding_rejects_old_ancestor_or_main_movement(tmp_path: Path) -> None:
+    """Replacing equality with ancestry permits publication after main advances."""
+    case = _release_repo(tmp_path)
+    repo: Path = case["repo"]
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    _commit(repo, "later main", "later")
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "-q", "--detach", "v1.2.3"], cwd=repo, check=True)
+    result = _run_binding(case, tmp_path)
+    assert result.returncode != 0
+    assert "current main" in result.stderr.lower()
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "not-merge",
+        "octopus",
+        "no-pr",
+        "wrong-pr",
+        "wrong-merge-sha",
+        "wrong-base",
+        "wrong-base-sha",
+        "wrong-head",
+    ],
+)
+def test_binding_rejects_invalid_merge_and_associated_pr(tmp_path: Path, mutation: str) -> None:
+    """Relaxing merge geometry or PR identity admits a non-reviewed candidate."""
+    case = _release_repo(tmp_path)
+    repo: Path = case["repo"]
+    pull_key = f"repos/joyfulhouse/pylxpweb/commits/{case['merge']}/pulls"
+    pull = case["fixtures"][pull_key][0]
+    if mutation == "not-merge":
         subprocess.run(
-            ["git", "update-ref", "refs/remotes/origin/stable", parent],
+            ["git", "tag", "-f", "-a", "v1.2.3", case["head"], "-m", "non-merge"],
             cwd=repo,
             check=True,
         )
-        target = "stable"
-
-    result = _run_resolve_source(repo, commit=commit, release_target=target)
-
+        subprocess.run(["git", "branch", "-f", "main", case["head"]], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "push", "-q", "--force", "origin", "main", "v1.2.3"],
+            cwd=repo,
+            check=True,
+        )
+        case["merge"] = case["head"]
+    elif mutation == "octopus":
+        subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+        subprocess.run(["git", "checkout", "-qb", "side-a", case["merge"]], cwd=repo, check=True)
+        repo.joinpath("side-a.txt").write_text("a")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "side a"], cwd=repo, check=True)
+        subprocess.run(["git", "checkout", "-qb", "side-b", case["merge"]], cwd=repo, check=True)
+        repo.joinpath("side-b.txt").write_text("b")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "side b"], cwd=repo, check=True)
+        subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "merge", "-q", "--no-ff", "side-a", "side-b", "-m", "octopus"],
+            cwd=repo,
+            check=True,
+        )
+        octopus = _git(repo, "rev-parse", "HEAD")
+        subprocess.run(
+            ["git", "tag", "-f", "-a", "v1.2.3", octopus, "-m", "octopus"],
+            cwd=repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "push", "-q", "--force", "origin", "main", "v1.2.3"], cwd=repo, check=True
+        )
+        case["merge"] = octopus
+    elif mutation == "no-pr":
+        case["fixtures"][pull_key] = []
+    elif mutation == "wrong-pr":
+        case["fixtures"][pull_key].append(dict(pull, number=18))
+    elif mutation == "wrong-merge-sha":
+        pull["merge_commit_sha"] = case["head"]
+    elif mutation == "wrong-base":
+        pull["base"]["ref"] = "release"
+    elif mutation == "wrong-base-sha":
+        pull["base"]["sha"] = case["head"]
+    elif mutation == "wrong-head":
+        pull["head"]["sha"] = case["parent"]
+    result = _run_binding(case, tmp_path)
     assert result.returncode != 0
-    assert "release tag is not an ancestor of release target" in result.stderr
 
 
 @pytest.mark.parametrize(
-    ("mutation", "expected_error"),
+    "mutation",
     [
-        ("event", "release event commit does not match tag commit"),
-        ("tag-version", "release tag does not match project version"),
-        ("main-ancestry", "release tag is not an ancestor of origin/main"),
+        "dismissed",
+        "old-head",
+        "self",
+        "outsider",
+        "eligible-change-request",
+        "failed-ci",
+        "wrong-ci-head",
     ],
 )
-def test_resolve_source_rejects_identity_mismatch(
-    tmp_path: Path, mutation: str, expected_error: str
-) -> None:
-    """Event, tag, version, checkout tree, and main ancestry remain bound."""
-    repo, parent, commit = _release_repo(tmp_path)
-    kwargs: dict[str, str] = {}
-    if mutation == "event":
-        kwargs["event_sha"] = parent
-    elif mutation == "tag-version":
-        subprocess.run(["git", "tag", "-a", "v1.2.4", "-m", "wrong"], cwd=repo, check=True)
-        kwargs["release_tag"] = "v1.2.4"
-    elif mutation == "main-ancestry":
-        subprocess.run(
-            ["git", "update-ref", "refs/remotes/origin/main", parent], cwd=repo, check=True
+def test_binding_rejects_ineffective_review_or_required_ci(tmp_path: Path, mutation: str) -> None:
+    """Dropping exact-head approval or CI checks permits stale review state."""
+    case = _release_repo(tmp_path)
+    review_key = "repos/joyfulhouse/pylxpweb/pulls/17/reviews"
+    check_key = f"repos/joyfulhouse/pylxpweb/commits/{case['head']}/check-runs"
+    if mutation == "dismissed":
+        case["fixtures"][review_key][0]["state"] = "DISMISSED"
+    elif mutation == "old-head":
+        case["fixtures"][review_key][0]["commit_id"] = case["parent"]
+    elif mutation == "self":
+        case["fixtures"][review_key][0]["user"]["login"] = "author"
+    elif mutation == "outsider":
+        case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators/reviewer/permission"][
+            "permission"
+        ] = "read"
+    elif mutation == "eligible-change-request":
+        case["fixtures"][review_key].append(
+            {
+                "id": 2,
+                "state": "CHANGES_REQUESTED",
+                "commit_id": case["head"],
+                "submitted_at": "2026-08-16T11:30:00Z",
+                "user": {"login": "blocker"},
+            }
         )
-
-    result = _run_resolve_source(repo, commit=commit, **kwargs)
-
+        case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators/blocker/permission"] = {
+            "permission": "maintain"
+        }
+    elif mutation == "failed-ci":
+        case["fixtures"][check_key]["check_runs"][0]["conclusion"] = "failure"
+    elif mutation == "wrong-ci-head":
+        case["fixtures"][check_key]["check_runs"][0]["head_sha"] = case["parent"]
+    result = _run_binding(case, tmp_path)
     assert result.returncode != 0
-    assert expected_error in result.stderr
 
 
-def test_release_bundle_validator_rejects_tree_mismatch(tmp_path: Path) -> None:
-    """Artifact promotion rebinds the machine-readable source tree."""
-    bundle = tmp_path / "release-bundle"
-    dist = bundle / "dist"
-    dist.mkdir(parents=True)
-    wheel = dist / "pylxpweb-1.2.3-py3-none-any.whl"
-    sdist = dist / "pylxpweb-1.2.3.tar.gz"
-    wheel.write_bytes(b"wheel")
-    sdist.write_bytes(b"sdist")
-    source = {
-        "artifact_name": "pylxpweb-release-1.2.3-0123456789ab",
-        "commit": "0123456789abcdef0123456789abcdef01234567",
-        "project_name": "pylxpweb",
-        "tag": "v1.2.3",
-        "tree": "1111111111111111111111111111111111111111",
-        "version": "1.2.3",
-    }
-    bundle.joinpath("release-source.json").write_text(json.dumps(source))
-    hashed = [bundle / "release-source.json", wheel, sdist]
-    bundle.joinpath("SHA256SUMS").write_text(
-        "".join(
-            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
-            f"{path.relative_to(bundle).as_posix()}\n"
-            for path in hashed
-        )
+def test_binding_reads_all_review_pages_before_deciding(tmp_path: Path) -> None:
+    """Dropping pagination can miss a later blocking review after page one."""
+    case = _release_repo(tmp_path)
+    review_key = "repos/joyfulhouse/pylxpweb/pulls/17/reviews"
+    reviews = case["fixtures"][review_key]
+    reviews.extend(
+        {
+            "id": index,
+            "state": "COMMENTED",
+            "commit_id": case["head"],
+            "submitted_at": f"2026-08-16T11:{index:02d}:00Z",
+            "user": {"login": f"commenter-{index}"},
+        }
+        for index in range(1, 31)
     )
-    env = os.environ | {
-        "EXPECTED_ARTIFACT_NAME": source["artifact_name"],
-        "EXPECTED_COMMIT": source["commit"],
-        "EXPECTED_PROJECT_NAME": source["project_name"],
-        "EXPECTED_TAG": source["tag"],
-        "EXPECTED_TREE": "2222222222222222222222222222222222222222",
-        "EXPECTED_VERSION": source["version"],
+    reviews.append(
+        {
+            "id": 31,
+            "state": "CHANGES_REQUESTED",
+            "commit_id": case["head"],
+            "submitted_at": "2026-08-16T12:00:00Z",
+            "user": {"login": "late-blocker"},
+        }
+    )
+    case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators/late-blocker/permission"] = {
+        "permission": "write"
     }
+    result = _run_binding(case, tmp_path)
+    assert result.returncode != 0
 
+
+def test_sealing_rechecks_fresh_main_immediately_before_attestation(tmp_path: Path) -> None:
+    """Removing the second force-fetch permits main movement before sealing."""
+    case = _release_repo(tmp_path)
+    assert _run_binding(case, tmp_path).returncode == 0
+    repo: Path = case["repo"]
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    _commit(repo, "late movement", "late")
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "-q", "--detach", "v1.2.3"], cwd=repo, check=True)
+    env = os.environ | {"EXPECTED_COMMIT": case["merge"]}
     result = subprocess.run(
-        ["bash", "-c", _step(_workflow(), "build", "validate-release-bundle")["run"]],
-        cwd=tmp_path,
+        ["bash", "-c", _step("bind-build-attest", "seal-source")["run"]],
+        cwd=repo,
         env=env,
         text=True,
         capture_output=True,
         check=False,
     )
-
     assert result.returncode != 0
-    assert "release source identity does not match" in result.stderr
+    assert "current main" in result.stderr.lower()
 
 
-def test_release_triggers_are_published_release_or_main_only_manual_build() -> None:
-    """A tag push or manual publisher path must not bypass a published release."""
+def test_release_job_graph_and_permissions_are_fail_closed() -> None:
+    """Changing a dependency or granting publisher shell/OIDC broadens promotion authority."""
     workflow = _workflow()
-    triggers = workflow["on"]
-
-    assert set(triggers) == {"release", "workflow_dispatch"}
-    assert triggers["release"] == {"types": ["published"]}
-    assert triggers["workflow_dispatch"]["inputs"] == {
-        "tag": {
-            "description": "Existing v* tag to validate",
-            "required": True,
-            "type": "string",
-        }
-    }
-    assert _job(workflow, "build")["if"] == (
-        "github.event_name == 'release' || github.ref == 'refs/heads/main'"
-    )
-    for job_id in ("publish-testpypi", "verify-testpypi", "publish-pypi"):
-        assert _job(workflow, job_id)["if"] == "github.event_name == 'release'"
-
-
-def test_oidc_is_confined_to_publisher_jobs() -> None:
-    """Compromising build or verification must not yield an OIDC token."""
-    workflow = _workflow()
-
-    assert workflow["permissions"] == {"contents": "read"}
-    for job_id, job in workflow["jobs"].items():
-        permissions = job.get("permissions", {})
-        if job_id in {"publish-testpypi", "publish-pypi"}:
-            assert permissions == {"contents": "read", "id-token": "write"}
-        else:
-            assert "id-token" not in permissions
-
-
-def test_release_jobs_form_a_verified_promotion_chain() -> None:
-    """Production publication must depend on independent TestPyPI verification."""
-    workflow = _workflow()
-
-    assert set(workflow["jobs"]) == {
-        "build",
+    expected = [
+        "bind-build-attest",
+        "prepare-testpypi",
         "publish-testpypi",
         "verify-testpypi",
-        "publish-pypi",
-    }
-    assert _job(workflow, "publish-testpypi")["needs"] == "build"
-    assert _job(workflow, "verify-testpypi")["needs"] == ["build", "publish-testpypi"]
-    assert _job(workflow, "publish-pypi")["needs"] == ["build", "verify-testpypi"]
-    assert _job(workflow, "publish-testpypi")["environment"] == "testpypi"
-    assert "environment" not in _job(workflow, "verify-testpypi")
-    assert _job(workflow, "publish-pypi")["environment"] == "pypi"
-
-
-def test_build_exports_bound_source_and_artifact_identity() -> None:
-    """Every downstream check must consume identity resolved once by build."""
-    workflow = _workflow()
-    build = _job(workflow, "build")
-    source = _steps_by_id(build)["resolve-source"]
-
-    assert build["outputs"] == {
-        key: f"${{{{ steps.resolve-source.outputs.{key} }}}}"
-        for key in ("artifact-name", "commit", "project-name", "tag", "tree", "version")
-    }
-    assert source["env"] == {
-        "DISPATCH_TAG": "${{ inputs.tag }}",
-        "EVENT_NAME": "${{ github.event_name }}",
-        "EVENT_SHA": "${{ github.sha }}",
-        "RELEASE_DRAFT": "${{ github.event.release.draft }}",
-        "RELEASE_ID": "${{ github.event.release.id }}",
-        "RELEASE_TAG": "${{ github.event.release.tag_name }}",
-        "RELEASE_TARGET": "${{ github.event.release.target_commitish }}",
-        "RELEASE_URL": "${{ github.event.release.html_url }}",
-    }
-
-
-def test_build_uploads_one_complete_retained_release_artifact() -> None:
-    """Promotion must use one named bundle containing both distributions and manifests."""
-    workflow = _workflow()
-    build = _job(workflow, "build")
-    steps = _steps_by_id(build)
-    expected_order = [
-        "resolve-source",
-        "build-distributions",
-        "check-distributions",
-        "validate-distributions",
-        "write-source-manifest",
-        "write-sha256-manifest",
-        "validate-release-bundle",
-        "upload-release-artifact",
-    ]
-
-    positions = {step_id: index for index, step_id in enumerate(steps)}
-    assert positions.keys() >= set(expected_order)
-    assert [positions[step_id] for step_id in expected_order] == sorted(
-        positions[step_id] for step_id in expected_order
-    )
-    uploads = [
-        step
-        for step in _action_steps(workflow)
-        if step["uses"].startswith("actions/upload-artifact@")
-    ]
-    assert uploads == [steps["upload-release-artifact"]]
-    assert uploads[0]["with"] == {
-        "name": "${{ steps.resolve-source.outputs.artifact-name }}",
-        "path": "release-bundle/",
-        "if-no-files-found": "error",
-        "retention-days": 30,
-    }
-
-
-def test_build_uses_locked_tools_without_mutating_bound_source() -> None:
-    """Dependency setup must not change source after its commit and tree are bound."""
-    build = _job(_workflow(), "build")
-    steps = _steps_by_id(build)
-
-    assert build["env"] == {"UV_PYTHON": "3.13"}
-    assert steps["sync-build-tools"]["env"] == {"UV_LOCKED": "1"}
-    step_ids = list(steps)
-    assert step_ids.index("sync-build-tools") < step_ids.index("verify-clean-source")
-    assert step_ids.index("verify-clean-source") < step_ids.index("build-distributions")
-
-
-def test_every_promotion_downloads_and_revalidates_the_original_artifact() -> None:
-    """Publisher and verifier jobs must never rebuild or select a different bundle."""
-    workflow = _workflow()
-
-    for job_id in ("publish-testpypi", "verify-testpypi", "publish-pypi"):
-        job = _job(workflow, job_id)
-        steps = _steps_by_id(job)
-        assert steps["download-release-artifact"]["with"] == {
-            "name": "${{ needs.build.outputs.artifact-name }}",
-            "path": "release-bundle/",
-        }
-        assert steps["revalidate-release-bundle"]["env"] == {
-            "EXPECTED_ARTIFACT_NAME": "${{ needs.build.outputs.artifact-name }}",
-            "EXPECTED_COMMIT": "${{ needs.build.outputs.commit }}",
-            "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
-            "EXPECTED_TAG": "${{ needs.build.outputs.tag }}",
-            "EXPECTED_TREE": "${{ needs.build.outputs.tree }}",
-            "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
-        }
-        step_ids = list(steps)
-        assert step_ids.index("download-release-artifact") < step_ids.index(
-            "revalidate-release-bundle"
-        )
-        assert "build-distributions" not in steps
-
-
-def test_testpypi_verification_is_unprivileged_bounded_and_ordered() -> None:
-    """Verification must prove remote bytes and an isolated production-index install."""
-    workflow = _workflow()
-    verify = _job(workflow, "verify-testpypi")
-    steps = _steps_by_id(verify)
-    order = [
-        "download-release-artifact",
-        "revalidate-release-bundle",
-        "query-testpypi",
-        "create-verification-environment",
-        "install-testpypi-wheel",
-        "verify-installed-package",
-    ]
-
-    assert verify["permissions"] == {"contents": "read"}
-    assert [list(steps).index(step_id) for step_id in order] == sorted(
-        list(steps).index(step_id) for step_id in order
-    )
-    assert steps["query-testpypi"]["env"] == {
-        "ALLOWED_DISTRIBUTION_HOST": "test-files.pythonhosted.org",
-        "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
-        "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
-        "MAX_ATTEMPTS": "12",
-        "TESTPYPI_JSON_BASE_URL": "https://test.pypi.org/pypi",
-    }
-    assert steps["create-verification-environment"]["run"] == ("uv venv --python 3.13 .verify-venv")
-    assert steps["install-testpypi-wheel"]["env"] == {
-        "PYPI_INDEX_URL": "https://pypi.org/simple",
-        "WHEEL_PATH": "${{ steps.query-testpypi.outputs.wheel-path }}",
-    }
-    assert steps["verify-installed-package"]["env"] == {
-        "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
-        "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
-    }
-
-
-def test_publishers_use_trusted_publishing_with_skip_only_on_testpypi() -> None:
-    """Production stages absent files and verifies the final exact remote set."""
-    workflow = _workflow()
-    test_publish = _steps_by_id(_job(workflow, "publish-testpypi"))["publish-testpypi"]
-    production_steps = _steps_by_id(_job(workflow, "publish-pypi"))
-    production_publish = production_steps["publish-pypi"]
-
-    assert test_publish["with"] == {
-        "packages-dir": "release-bundle/dist/",
-        "repository-url": "https://test.pypi.org/legacy/",
-        "skip-existing": True,
-    }
-    assert production_steps["prepare-pypi"]["env"] == {
-        "BACKOFF_SECONDS": "2",
-        "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
-        "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
-        "MAX_ATTEMPTS": "3",
-        "MAX_BACKOFF_SECONDS": "5",
-        "MODE": "prepare",
-        "PYPI_JSON_BASE_URL": "https://pypi.org/pypi",
-        "REQUEST_TIMEOUT_SECONDS": "10",
-        "UPLOAD_DIR": "pypi-upload",
-    }
-    assert production_publish["if"] == (
-        "success() && steps.prepare-pypi.outputs.upload-needed == 'true'"
-    )
-    assert production_publish["with"] == {"packages-dir": "pypi-upload/"}
-    assert "skip-existing" not in production_publish["with"]
-    assert production_steps["verify-pypi"]["env"] == {
-        "BACKOFF_SECONDS": "5",
-        "EXPECTED_PROJECT_NAME": "${{ needs.build.outputs.project-name }}",
-        "EXPECTED_VERSION": "${{ needs.build.outputs.version }}",
-        "MAX_ATTEMPTS": "8",
-        "MAX_BACKOFF_SECONDS": "20",
-        "MODE": "verify",
-        "PYPI_JSON_BASE_URL": "https://pypi.org/pypi",
-        "REQUEST_TIMEOUT_SECONDS": "15",
-        "UPLOAD_DIR": "pypi-upload",
-    }
-    order = [
-        "download-release-artifact",
-        "revalidate-release-bundle",
         "prepare-pypi",
         "publish-pypi",
         "verify-pypi",
     ]
-    assert [list(production_steps).index(step_id) for step_id in order] == sorted(
-        list(production_steps).index(step_id) for step_id in order
+    assert list(workflow["jobs"]) == expected
+    previous: str | None = None
+    for job_id in expected:
+        job = workflow["jobs"][job_id]
+        if previous is not None:
+            needs = job["needs"] if isinstance(job["needs"], list) else [job["needs"]]
+            assert previous in needs
+        previous = job_id
+    for job_id in ("publish-testpypi", "publish-pypi"):
+        job = workflow["jobs"][job_id]
+        assert job["permissions"] == {"contents": "read", "id-token": "write"}
+        assert len(job["steps"]) == 2
+        assert all("uses" in step and "run" not in step for step in job["steps"])
+        assert "actions/download-artifact@" in job["steps"][0]["uses"]
+        assert "pypa/gh-action-pypi-publish@" in job["steps"][1]["uses"]
+    for job_id in set(expected) - {"bind-build-attest", "publish-testpypi", "publish-pypi"}:
+        assert _job(job_id).get("permissions", {}).get("id-token") != "write"
+
+
+def test_release_trigger_and_workflow_identity_are_tag_only() -> None:
+    """Adding branch dispatch permits branch-resident release workflow execution."""
+    trigger = _workflow()["on"]
+    assert trigger == {"release": {"types": ["published"]}}
+    checkout = _step("bind-build-attest", "checkout-source")
+    assert checkout["with"]["ref"] == "${{ github.event.release.tag_name }}"
+    assert checkout["with"]["fetch-tags"] is False
+
+
+def test_build_uses_verified_digest_pinned_offline_read_only_container() -> None:
+    """Floating image/tool/backend versions or writable/networked mounts break hermeticity."""
+    workflow = _workflow()
+    image = workflow["env"]["BUILD_IMAGE"]
+    assert image == (
+        "ghcr.io/astral-sh/uv:0.9.30-python3.13-bookworm-slim@"
+        "sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca"
     )
+    run = _step("bind-build-attest", "build-distributions")["run"]
+    for token in (
+        "--network none",
+        "--read-only",
+        '--user "$(id -u):$(id -g)"',
+        ":/src:ro",
+        ":/out:rw",
+        "--tmpfs /cache",
+        "uv build --offline --no-python-downloads --no-sources",
+        "uv 0.9.30",
+        "Python 3.13",
+        "uv_build==0.9.30",
+    ):
+        assert token in run
+    assert run.count("uv build --offline --no-python-downloads --no-sources") == 1
 
 
-def test_pypi_final_retry_budget_leaves_five_minutes_for_setup_and_upload() -> None:
-    """Worst-case request and backoff time must fit with meaningful job headroom."""
-    job = _job(_workflow(), "publish-pypi")
-    env = _step(_workflow(), "publish-pypi", "verify-pypi")["env"]
-    attempts = int(env["MAX_ATTEMPTS"])
-    request_timeout = int(env["REQUEST_TIMEOUT_SECONDS"])
-    backoff = int(env["BACKOFF_SECONDS"])
-    backoff_cap = int(env["MAX_BACKOFF_SECONDS"])
-    request_budget = attempts * request_timeout
-    backoff_budget = sum(min(backoff * attempt, backoff_cap) for attempt in range(1, attempts))
+def test_build_backend_is_exactly_the_bundled_uv_version() -> None:
+    """Widening the backend range permits an offline cache miss or different builder."""
+    pyproject = (_ROOT / "pyproject.toml").read_text()
+    assert 'requires = ["uv_build==0.9.30"]' in pyproject
 
-    assert attempts >= 2
-    assert request_budget + backoff_budget <= job["timeout-minutes"] * 60 - 5 * 60
+
+def test_build_attests_source_and_distributions_separately_with_full_sha_actions() -> None:
+    """Combining or omitting provenance prevents independent source/build verification."""
+    source = _step("bind-build-attest", "attest-source")
+    build = _step("bind-build-attest", "attest-build")
+    assert source["uses"].startswith("actions/attest@")
+    assert build["uses"].startswith("actions/attest@")
+    assert _FULL_SHA_ACTION.fullmatch(source["uses"])
+    assert _FULL_SHA_ACTION.fullmatch(build["uses"])
+    assert source["with"]["subject-path"].endswith("release-source.json")
+    assert build["with"]["subject-checksums"].endswith("DIST_SHA256SUMS")
+    assert source["with"] != build["with"]
+
+
+def test_preparation_verifies_attestation_identity_before_staging() -> None:
+    """Dropping signer/source constraints permits a valid attestation from the wrong run."""
+    for job_id in ("prepare-testpypi", "prepare-pypi"):
+        run = _step(job_id, "verify-release-bundle")["run"]
+        for option in (
+            "--signer-workflow",
+            "--signer-digest",
+            "--source-ref",
+            "--source-digest",
+            "--bundle",
+        ):
+            assert option in run
+        assert run.count("gh attestation verify") == 2  # source command + distribution loop
+
+
+def test_bundle_validation_rejects_artifact_and_attestation_tampering(tmp_path: Path) -> None:
+    """Removing hash or gh verification permits modified bytes into staging."""
+    bundle = tmp_path / "release-bundle"
+    dist = bundle / "dist"
+    attestations = bundle / "attestations"
+    dist.mkdir(parents=True)
+    attestations.mkdir()
+    wheel = dist / "pylxpweb-1.2.3-py3-none-any.whl"
+    sdist = dist / "pylxpweb-1.2.3.tar.gz"
+    source = bundle / "release-source.json"
+    dist_manifest = bundle / "DIST_SHA256SUMS"
+    wheel.write_bytes(b"wheel")
+    sdist.write_bytes(b"sdist")
+    source.write_text(
+        json.dumps(
+            {
+                "artifact_name": "release",
+                "commit": "a" * 40,
+                "container_image": _workflow()["env"]["BUILD_IMAGE"],
+                "head": "b" * 40,
+                "project_name": "pylxpweb",
+                "pr": 17,
+                "schema_version": 2,
+                "tag": "v1.2.3",
+                "tree": "c" * 40,
+                "version": "1.2.3",
+                "workflow_ref": _TEST_WORKFLOW_REF,
+                "workflow_sha": "a" * 40,
+            }
+        )
+    )
+    dist_manifest.write_text(
+        f"{hashlib.sha256(wheel.read_bytes()).hexdigest()}  dist/{wheel.name}\n"
+        f"{hashlib.sha256(sdist.read_bytes()).hexdigest()}  dist/{sdist.name}\n"
+    )
+    (attestations / "source.jsonl").write_text("source-bundle")
+    (attestations / "build.jsonl").write_text("build-bundle")
+    manifest_files = [source, dist_manifest, wheel, sdist]
+    (bundle / "SHA256SUMS").write_text(
+        "".join(
+            f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.relative_to(bundle)}\n"
+            for path in manifest_files
+        )
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_gh(bin_dir)
+    env = os.environ | {
+        "ARTIFACT_NAME": "release",
+        "EXPECTED_COMMIT": "a" * 40,
+        "EXPECTED_CONTAINER_IMAGE": _workflow()["env"]["BUILD_IMAGE"],
+        "EXPECTED_HEAD": "b" * 40,
+        "EXPECTED_PROJECT_NAME": "pylxpweb",
+        "EXPECTED_PR": "17",
+        "EXPECTED_TAG": "v1.2.3",
+        "EXPECTED_TREE": "c" * 40,
+        "EXPECTED_VERSION": "1.2.3",
+        "EXPECTED_WORKFLOW_REF": _TEST_WORKFLOW_REF,
+        "EXPECTED_WORKFLOW_SHA": "a" * 40,
+        "GH_CALLS": str(tmp_path / "gh-calls"),
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "github-summary"),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "REPOSITORY": "joyfulhouse/pylxpweb",
+    }
+    run = _step("prepare-testpypi", "verify-release-bundle")["run"]
+    good = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
+    assert good.returncode == 0
+    wheel.write_bytes(b"tampered")
+    tampered_artifact = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
+    assert tampered_artifact.returncode != 0
+    wheel.write_bytes(b"wheel")
+    env["EXPECTED_ATTESTATION_CONTENT"] = "not-the-bundle"
+    tampered_attestation = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
+    assert tampered_attestation.returncode != 0
+
+
+def test_all_release_actions_are_immutable_full_sha_pins() -> None:
+    """Replacing any action SHA with a tag restores mutable third-party code."""
+    actions = [
+        step["uses"]
+        for job in _workflow()["jobs"].values()
+        for step in job["steps"]
+        if "uses" in step
+    ]
+    assert actions
+    assert all(_FULL_SHA_ACTION.fullmatch(action) for action in actions)
 
 
 def test_release_is_the_only_package_index_publisher_workflow() -> None:
@@ -937,53 +709,99 @@ def test_package_index_workflow_audit_detects_known_publish_commands(
     assert _package_index_publisher_workflows(tmp_path) == {"competing.yml"}
 
 
-def test_workflow_docs_define_compromise_response_and_keep_settings_gate() -> None:
-    """Recovery guidance must stop publishing and preserve the post-merge gate."""
-    docs = _WORKFLOW_DOCS_PATH.read_text()
-    normalized_docs = " ".join(docs.split())
+def test_build_produces_exactly_two_bit_reproducible_distributions(tmp_path: Path) -> None:
+    """A second build or nondeterministic input changes the clean-build digest set."""
+    if shutil.which("docker") is None:
+        pytest.skip("Docker CLI is unavailable")
+    subprocess.run(["docker", "info"], capture_output=True, check=True)
+    script = _step("bind-build-attest", "build-distributions")["run"]
+    image = _workflow()["env"]["BUILD_IMAGE"]
+    subprocess.run(["docker", "pull", image], check=True)
+    source = tmp_path / "source"
+    shutil.copytree(
+        _ROOT,
+        source,
+        ignore=shutil.ignore_patterns(".git", ".venv", ".release-test-output-*"),
+    )
+    outputs: list[dict[str, str]] = []
+    for index in (1, 2):
+        output = tmp_path / f"output-{index}"
+        output.mkdir()
+        env = os.environ | {
+            "BUILD_IMAGE": image,
+            "EXPECTED_COMMIT": _git(_ROOT, "rev-parse", "HEAD"),
+            "GITHUB_WORKSPACE": str(source),
+            "OUTPUT_DIR": str(output),
+            "SOURCE_DATE_EPOCH": "1755302400",
+        }
+        result = subprocess.run(["bash", "-c", script], env=env, text=True, capture_output=True)
+        assert result.returncode == 0, result.stderr
+        files = sorted(path for path in output.iterdir() if path.is_file())
+        assert sum(path.suffix == ".whl" for path in files) == 1
+        assert sum(path.name.endswith(".tar.gz") for path in files) == 1
+        assert len(files) == 2
+        outputs.append({path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in files})
+    assert outputs[0] == outputs[1]
 
-    for phrase in (
-        "Cancel active release workflow runs and pending environment approvals",
-        "Disable the `pypi` and `testpypi` environments",
-        "remove the corresponding trusted-publisher bindings",
-        "Audit the compromised GitHub identity",
-        "revoke its sessions, tokens, and keys",
-        "Restore environments and trusted-publisher bindings only after recovery",
-        "These are post-merge settings gates",
-        "do not apply or mutate repository, environment, or package-index settings",
-        "No long-lived package-index credential is introduced",
-    ):
-        assert phrase in normalized_docs
 
-
-def test_all_actions_are_immutable_full_sha_pins() -> None:
-    """A mutable action tag must not change executable release code after review."""
-    workflow = _workflow()
-    pins: dict[str, set[str]] = {}
-
-    for step in _action_steps(workflow):
-        assert _FULL_SHA_ACTION.fullmatch(step["uses"]), step["uses"]
-        action, pin = step["uses"].split("@", 1)
-        pins.setdefault(action, set()).add(pin)
-    assert pins == {
-        "actions/checkout": {"3d3c42e5aac5ba805825da76410c181273ba90b1"},
-        "actions/download-artifact": {"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"},
-        "actions/upload-artifact": {"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"},
-        "astral-sh/setup-uv": {"37802adc94f370d6bfd71619e3f0bf239e1f3b78"},
-        "pypa/gh-action-pypi-publish": {"dc37677b2e1c63e2034f94d8a5b11f265b73ba33"},
+@pytest.mark.parametrize("mutation", ["backend", "uv", "python"])
+def test_build_container_rejects_wrong_backend_or_tool_version(
+    tmp_path: Path, mutation: str
+) -> None:
+    """Removing a version assertion lets a different builder produce release bytes."""
+    if shutil.which("docker") is None:
+        pytest.skip("Docker CLI is unavailable")
+    subprocess.run(["docker", "info"], capture_output=True, check=True)
+    image = _workflow()["env"]["BUILD_IMAGE"]
+    source = tmp_path / "source"
+    shutil.copytree(_ROOT, source, ignore=shutil.ignore_patterns(".git", ".venv"))
+    script = _step("bind-build-attest", "build-distributions")["run"]
+    if mutation == "backend":
+        pyproject = source / "pyproject.toml"
+        pyproject.write_text(pyproject.read_text().replace("uv_build==0.9.30", "uv_build==0.9.29"))
+    elif mutation == "uv":
+        script = script.replace('"uv 0.9.30"', '"uv 9.9.9"')
+    elif mutation == "python":
+        script = script.replace('"Python 3.13"', '"Python 9.9"')
+    output = tmp_path / "output"
+    output.mkdir()
+    env = os.environ | {
+        "BUILD_IMAGE": image,
+        "EXPECTED_COMMIT": _git(_ROOT, "rev-parse", "HEAD"),
+        "GITHUB_WORKSPACE": str(source),
+        "OUTPUT_DIR": str(output),
+        "SOURCE_DATE_EPOCH": "1755302400",
     }
+    result = subprocess.run(["bash", "-c", script], env=env, capture_output=True, check=False)
+    assert result.returncode != 0
 
 
-def test_release_job_conditions_fail_closed_without_always() -> None:
-    """Failed identity, publication, or verification checks must stop promotion."""
-    workflow = _workflow()
-
-    assert {job_id: job.get("if") for job_id, job in workflow["jobs"].items()} == {
-        "build": "github.event_name == 'release' || github.ref == 'refs/heads/main'",
-        "publish-testpypi": "github.event_name == 'release'",
-        "verify-testpypi": "github.event_name == 'release'",
-        "publish-pypi": "github.event_name == 'release'",
+def test_build_container_denies_network_when_workflow_network_flag_is_mutated(
+    tmp_path: Path,
+) -> None:
+    """Removing --network none is detected by the build's live network probe."""
+    if shutil.which("docker") is None:
+        pytest.skip("Docker CLI is unavailable")
+    subprocess.run(["docker", "info"], capture_output=True, check=True)
+    image = _workflow()["env"]["BUILD_IMAGE"]
+    source = tmp_path / "source"
+    shutil.copytree(_ROOT, source, ignore=shutil.ignore_patterns(".git", ".venv"))
+    output = tmp_path / "output"
+    output.mkdir()
+    script = _step("bind-build-attest", "build-distributions")["run"].replace(
+        "--network none", "--network bridge"
+    )
+    env = os.environ | {
+        "BUILD_IMAGE": image,
+        "EXPECTED_COMMIT": _git(_ROOT, "rev-parse", "HEAD"),
+        "GITHUB_WORKSPACE": str(source),
+        "OUTPUT_DIR": str(output),
+        "SOURCE_DATE_EPOCH": "1755302400",
     }
-    assert "always()" not in _WORKFLOW_PATH.read_text()
-    for job in workflow["jobs"].values():
-        assert job.get("if") != "always()"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1300,7 +1300,6 @@ def test_build_produces_exactly_two_bit_reproducible_distributions(tmp_path: Pat
         f'  test "$SOURCE_DATE_EPOCH" = "{commit_epoch}"\n{build_command}',
     )
     image = _workflow()["env"]["BUILD_IMAGE"]
-    subprocess.run(["docker", "pull", image], check=True)
     source = tmp_path / "source"
     shutil.copytree(
         _ROOT,


### PR DESCRIPTION
Closes #296

## Summary

- bind release publication to the tag-resident workflow, exact event/tag/current-main identity, and the reviewed two-parent GitHub merge commit
- build exactly once in a digest-pinned official uv/Python container with an offline, read-only, network-denied source environment
- seal and verify distinct GitHub source/build attestations before constrained TestPyPI and PyPI promotion
- add production-shaped release tests, reproducibility checks, and operational recovery documentation

## Verification

- `uv run pytest tests/unit/ --cov=pylxpweb --cov-report=term-missing --cov-report=xml --cov-report=html -q` (3337 passed, 89.63%)
- `uv run pytest tests/unit/test_release_workflow.py -q` (45 passed)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy --strict src/pylxpweb/`
- actionlint v1.7.12
- `uv build && uv run twine check dist/*`

This PR does not publish, create or alter tags/releases, modify publisher/environment settings, or modify #294.