### PR TITLE
ci: add provenance-bound PyPI recovery

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -103,13 +103,23 @@ distribution download at 60 seconds.
    the sealed artifact and attestations, reruns the same classifier against fresh
    PyPI bytes, and succeeds only for `EXACT_COMPLETE`. Unlike `prepare-pypi`, its
    evidence steps fail hard: any evidence failure fails the terminal verifier
-   itself.
+   itself. Because it runs immediately after `publish-pypi`, routine PyPI index
+   propagation can briefly report absence: the terminal reclassification wraps a
+   stable `ABSENT` snapshot pair in a bounded recheck loop (12 attempts, 5-second
+   backoff base capped at 30 seconds — the TestPyPI verifier's envelope). Each
+   attempt keeps the full two-snapshot stability rule, only `ABSENT` retries, and
+   `prepare-pypi` keeps its single-pass classification semantics: absence is a
+   publishable state there and must never be retried away.
 
-The production classifier's mechanical worst case is 3 minutes 5 seconds: two
+The prepare-time classifier's mechanical worst case is 3 minutes 5 seconds: two
 30-second index snapshots, two 60-second downloads, and a five-second stability
-interval. Its 15-minute verifier timeout leaves 11 minutes 55 seconds for Actions
+interval. Its 15-minute prepare timeout leaves 11 minutes 55 seconds for Actions
 API discovery, artifact download, checksum and attestation verification, and
-runner overhead.
+runner overhead. The terminal reclassification's mechanical worst case is 19
+minutes 15 seconds: twelve 65-second snapshot pairs, 255 seconds of capped
+backoff, and two 60-second downloads on the final attempt. The 25-minute
+`verify-pypi` timeout leaves 5 minutes 45 seconds for the same non-classifier
+work.
 
 | State | Meaning | Workflow consequence |
 |---|---|---|
@@ -117,7 +127,7 @@ runner overhead.
 | `EXACT_COMPLETE` | Stable exact filenames, index hashes, allowlisted final hosts, downloaded bytes, non-yanked status, sealed bundle, and GitHub attestations | Publisher skips; terminal verifier succeeds |
 | `PARTIAL` | A stable non-empty strict subset whose present files fully validate (metadata, hosts, and downloaded bytes) | Terminal failure; burn the version and never top up |
 | `MISMATCH` | Stable identity, hash, host, or downloaded-byte conflict — including one inside an otherwise partial or extra file set | Terminal failure; preserve evidence and use compromise/new-version procedure |
-| `YANKED` | Any expected remote file is yanked | Terminal failure; preserve evidence and use compromise/new-version procedure |
+| `YANKED` | Any advertised remote file for the version is yanked, expected or not | Terminal failure; preserve evidence and use compromise/new-version procedure |
 | `EXTRA` | The full expected set, fully validated, plus stable additional files | Terminal failure; preserve evidence and use compromise/new-version procedure |
 | `COMPETING` | A duplicate filename or another stable occupied file set | Terminal failure; preserve evidence and use compromise/new-version procedure |
 | `UNCERTAIN` | Timeout, TLS/JSON/API/429/5xx error, off-origin index redirect, inconsistent snapshots, or unavailable artifact/attestation evidence | Never publish; retry only the classifier/verifier recovery chain |
@@ -128,6 +138,39 @@ in their names so a recovery attempt cannot collide with immutable staging from 
 earlier attempt. Job summaries expose the tag, commit, tree, final PR/head,
 workflow ref/SHA, container digest, distribution names/digests, attestation
 verification, classifier state, evidence, and required action.
+
+### Pinned artifact-action contract evidence
+
+Three digest-binding assumptions in `release.yml` are properties of the pinned
+action code, not of the workflow YAML — GitHub Actions silently ignores unknown
+action inputs, so these facts must be re-verified whenever either pin moves
+(`tests/unit/test_release_workflow.py::test_artifact_action_pins_match_recorded_contract_verification`
+fails until this note and the test's recorded map match the new pin):
+
+- `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.0),
+  `action.yml` SHA-256
+  `e98559b7a31ba31be4709f20d22102dc2737fa630f69a339eb89981151e505fe`:
+  - Declares the `digest-mismatch` input (options `ignore`/`info`/`warn`/`error`,
+    default `error`), so `digest-mismatch: error` is enforced rather than
+    silently dropped.
+  - `src/download-artifact.ts` (SHA-256
+    `665dccdfa36cc93c7d75515fd93a9f97b8dee937b9b5517a15ba77d2a48f6934`) selects
+    the resolved `path:` directly whenever exactly one artifact is downloaded
+    (`isSingleArtifactDownload || inputs.mergeMultiple || artifacts.length === 1`),
+    so a single-`artifact-ids` download extracts flat into `path:`, not into a
+    per-artifact subdirectory.
+- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.0),
+  `action.yml` SHA-256
+  `c5979822866a72362e609844b6ebe77d4b7e759af68cc1c2c425dcf51481fab4`:
+  - Declares the `artifact-digest` output, and `src/shared/upload-artifact.ts`
+    (SHA-256 `bfab1f3c0e5ada3dd46e64addb583730dd84e17a47f06e24f9bda3cd50b9153b`)
+    sets it to the artifact toolkit's bare-hex SHA-256 digest — no `sha256:`
+    prefix — matching the workflow's `[0-9a-f]{64}` fullmatch. Independently
+    verified against the action source during review (2026-08) and re-verified
+    2026-08-18.
+
+Verified 2026-08-18 by fetching `action.yml` and the named source files at the
+exact pinned commits from `github.com` and hashing them with `sha256sum`.
 
 GitHub build/source attestations establish the GitHub workflow and source identity
 for the local subjects. They are distinct from the PEP 740 attestations that the

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -64,30 +64,66 @@ Publishing is a linear seven-job promotion chain:
    polls the exact TestPyPI version, requires exactly the two non-yanked filenames
    and SHA-256 digests, and downloads and rehashes their allowlisted HTTPS bytes.
    It then takes a second exact index snapshot so a competing publication during
-   download fails closed. Production verification uses the same rule.
+   download fails closed.
 
 The TestPyPI verifier's mechanical worst case is 12 minutes 45 seconds: twelve
 30-second index attempts, 255 seconds of capped backoff, two 60-second downloads,
 and a final 30-second snapshot. Its 20-minute job timeout leaves 7 minutes 15
 seconds for artifact download, checksums, attestation verification, and runner
-overhead. The PyPI verifier's corresponding worst case is 8 minutes 45 seconds
-inside a 15-minute job, leaving 6 minutes 15 seconds. A 10-second socket timeout
-only detects inactivity; a process-level total-transfer deadline separately caps
-each index request at 30 seconds and each distribution download at 60 seconds.
-7. `prepare-pypi`, `publish-pypi`, and `verify-pypi` repeat the separation for
-   production: the no-OIDC prepare job revalidates and stages only when the
-   version is absent; the OIDC publisher again contains only the two pinned
-   actions; and the no-OIDC verifier polls and downloads the exact final bytes.
+overhead. A 10-second socket timeout only detects inactivity; a process-level
+total-transfer deadline separately caps each index request at 30 seconds and each
+distribution download at 60 seconds.
+7. `prepare-pypi` has no OIDC and is itself protected by the `pypi` environment.
+   It does not trust only prior job outputs: it queries the Actions run and artifact
+   APIs for `github.run_id`, requires exactly one non-expired sealed artifact with
+   the expected repository, release run, head, deterministic name, and upload
+   digest, then downloads it by artifact ID with digest mismatch set to an error.
+   It rechecks the bundle hashes, source identity, and separate source/build
+   attestations before taking two PyPI snapshots around any distribution downloads.
+   It emits one state from the closed state machine below and stages the **full**
+   wheel-plus-sdist set only for `ABSENT`.
+8. `publish-pypi` runs only when the fresh prepare output is exactly `ABSENT`. It
+   retains exactly two full-SHA-pinned action steps: download the run-attempt-scoped
+   staging artifact and invoke the official PyPA publisher. This is the only
+   production OIDC job. It has no shell, `skip-existing`, partial-file path, or
+   continue-on-error behavior.
+9. `verify-pypi` is the sole terminal definition of production completion. Its
+   `always()`/non-cancelled condition runs it after a successful prepare whether
+   the publisher succeeded, failed, or was skipped. It rediscovers and revalidates
+   the sealed artifact and attestations, reruns the same classifier against fresh
+   PyPI bytes, and succeeds only for `EXACT_COMPLETE`.
+
+The production classifier's mechanical worst case is 3 minutes 5 seconds: two
+30-second index snapshots, two 60-second downloads, and a five-second stability
+interval. Its 15-minute verifier timeout leaves 11 minutes 55 seconds for Actions
+API discovery, artifact download, checksum and attestation verification, and
+runner overhead.
+
+| State | Meaning | Workflow consequence |
+|---|---|---|
+| `ABSENT` | Two clean 404 snapshots with no conflicting or uncertain evidence | The only state that stages and permits the publisher |
+| `EXACT_COMPLETE` | Stable exact filenames, index hashes, allowlisted final hosts, downloaded bytes, non-yanked status, sealed bundle, and GitHub attestations | Publisher skips; terminal verifier succeeds |
+| `PARTIAL` | A stable non-empty strict subset, even when every present byte matches | Terminal failure; burn the version and never top up |
+| `MISMATCH` | Stable identity, hash, host, or downloaded-byte conflict | Terminal failure; preserve evidence and use compromise/new-version procedure |
+| `YANKED` | Any expected remote file is yanked | Terminal failure; preserve evidence and use compromise/new-version procedure |
+| `EXTRA` | The full expected set plus stable additional files | Terminal failure; preserve evidence and use compromise/new-version procedure |
+| `COMPETING` | A duplicate filename or another stable occupied file set | Terminal failure; preserve evidence and use compromise/new-version procedure |
+| `UNCERTAIN` | Timeout, TLS/JSON/API/429/5xx error, inconsistent snapshots, or unavailable artifact/attestation evidence | Never publish; retry only the classifier/verifier recovery chain |
 
 The sealed artifact is named from the version and merge commit and is retained for
-30 days. The two staged upload artifacts use the same 30-day retention so a delayed
-protected-environment approval does not require rebuilding or restaging. Job
-summaries expose the tag, commit, tree, final PR/head, workflow
-ref/SHA, container digest, distribution names/digests, and attestation verification.
+30 days. Staging artifacts also retain for 30 days and include `github.run_attempt`
+in their names so a recovery attempt cannot collide with immutable staging from an
+earlier attempt. Job summaries expose the tag, commit, tree, final PR/head,
+workflow ref/SHA, container digest, distribution names/digests, attestation
+verification, classifier state, evidence, and required action.
 
 GitHub build/source attestations establish the GitHub workflow and source identity
 for the local subjects. They are distinct from the PEP 740 attestations that the
 PyPA publishing action generates and sends to PyPI during trusted publication.
+PyPI Integrity API inspection of the publish attestation is optional
+defense-in-depth when that API is available and reliable. It is not a substitute
+for any MUST check above, and this workflow does not claim or require the PyPI
+attestation to expose the same GitHub run or attempt as a PyPI-enforced property.
 
 ### Required repository settings
 
@@ -121,7 +157,12 @@ or mutate repository, environment, or package-index settings.
 4. Confirm no later commit has reached `main`, then create the protected `v*` tag
    on that GitHub merge commit and publish the GitHub Release for the same tag.
 5. Review the identity and attestation summaries after TestPyPI verification, then
-   approve the protected `pypi` environment if every value matches the candidate.
+   approve the protected `pypi` environment for `prepare-pypi` if every value
+   matches the candidate. Each job that references an environment is separately
+   protected. An `EXACT_COMPLETE` recovery needs only the prepare approval because
+   the publisher skips. An `ABSENT` path normally asks for a second `pypi` approval
+   when `publish-pypi` becomes pending; approve it only after reviewing the fresh
+   `ABSENT` summary. Never approve a publisher job directly as a recovery shortcut.
 
 ### Recovery at the sealing boundary
 
@@ -138,6 +179,54 @@ or mutate repository, environment, or package-index settings.
 - If TestPyPI or PyPI contains unexpected or mismatched files, stop. Package-index
   files are immutable; do not use `skip-existing` in production and do not rebuild
   under the same version. Investigate before preparing a new version.
+
+### PyPI recovery runbook
+
+The following decisions are **MUST** requirements. A normal PyPI recovery never
+rebuilds, never runs **Re-run all jobs**, never directly reruns `publish-pypi`, and
+never recreates, moves, or deletes the tag or GitHub Release. GitHub's job-rerun API
+reruns the selected job and its dependent jobs while retaining the original event
+SHA/ref. Select `prepare-pypi` so classification is fresh and its dependent
+publisher/verifier jobs follow the state machine:
+
+```bash
+run_id=<original-release-workflow-run-id>
+prepare_job_id=$(gh run view "$run_id" --repo joyfulhouse/pylxpweb \
+  --json jobs --jq '.jobs[] | select(.name == "Classify, verify, and conditionally stage for PyPI") | .databaseId')
+test -n "$prepare_job_id"
+gh run rerun --repo joyfulhouse/pylxpweb --job "$prepare_job_id"
+```
+
+- **Failure before upload / clean absence:** MUST rerun `prepare-pypi` and its
+  dependents as above. After protected-environment approval, two clean absence
+  snapshots permit one full-set publisher attempt. A verifier result of `ABSENT`
+  means the attempt did not complete; use the same recovery invocation, not the
+  publisher job.
+- **Lost publisher response / exact complete:** MUST use the same recovery
+  invocation. Fresh `EXACT_COMPLETE` classification skips the publisher and the
+  terminal verifier completes from the sealed artifact and exact remote bytes.
+- **Partial publication:** MUST preserve the run summaries and package-index
+  evidence, treat the version as burned, and prepare a new version through the
+  normal reviewed release process. Never upload the missing file as a top-up.
+- **Mismatch, yanked, extra, or competing publication:** MUST stop publication,
+  preserve all evidence, and begin the compromise assessment below before creating
+  a new reviewed version. Do not normalize, delete, or overwrite remote evidence.
+- **Uncertain evidence:** MUST NOT approve or publish. Retry only `prepare-pypi`
+  and its dependent verifier/classifier path after the transient condition is
+  understood. Repeated uncertainty is not evidence of absence.
+- **Missing, expired, duplicated, or unverifiable sealed artifact/attestation:**
+  MUST treat the run as `UNCERTAIN`; never rebuild under the same version. If the
+  original 30-day artifact cannot be recovered, prepare a new version through the
+  normal release process.
+- **Compromise or revocation:** MUST follow the response steps below, including
+  canceling pending approvals and disabling trusted-publisher authority before any
+  new release. Normal recovery does not authorize tag/Release cleanup.
+
+An operator **MAY** additionally inspect PyPI's Integrity API publish attestation
+for the expected repository, `release.yml`, tag, and `pypi` environment identity
+when the API is available and its fixture contract has been revalidated. This is a
+SHOULD defense-in-depth check, not a completion condition. Do not infer a mandatory
+same-run or same-attempt binding that PyPI does not enforce and expose reliably.
 
 ## Package publishing compromise response
 

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -80,8 +80,18 @@ distribution download at 60 seconds.
    digest, then downloads it by artifact ID with digest mismatch set to an error.
    It rechecks the bundle hashes, source identity, and separate source/build
    attestations before taking two PyPI snapshots around any distribution downloads.
-   It emits one state from the closed state machine below and stages the **full**
-   wheel-plus-sdist set only for `ABSENT`.
+   Each index snapshot requires the final response URL to be HTTPS on the pinned
+   `pypi.org` index host, so an off-origin redirect — including one that ends in a
+   404 — classifies as `UNCERTAIN`, never as `ABSENT`. Every expected file the
+   index advertises is validated (metadata digest, advertised and final HTTPS
+   `files.pythonhosted.org` URL, and downloaded bytes) before subset/superset
+   classification, so a partial or extra file set with any conflicting evidence
+   classifies as `MISMATCH` rather than `PARTIAL`/`EXTRA`. Its evidence steps
+   tolerate failure: a missing, expired, duplicated, or unverifiable sealed
+   artifact or attestation funnels into a **successful** prepare result with
+   state `UNCERTAIN` instead of terminating the job, so the terminal verifier
+   below still runs and fails closed. It emits one state from the closed state
+   machine below and stages the **full** wheel-plus-sdist set only for `ABSENT`.
 8. `publish-pypi` runs only when the fresh prepare output is exactly `ABSENT`. It
    retains exactly two full-SHA-pinned action steps: download the run-attempt-scoped
    staging artifact and invoke the official PyPA publisher. This is the only
@@ -91,7 +101,9 @@ distribution download at 60 seconds.
    `always()`/non-cancelled condition runs it after a successful prepare whether
    the publisher succeeded, failed, or was skipped. It rediscovers and revalidates
    the sealed artifact and attestations, reruns the same classifier against fresh
-   PyPI bytes, and succeeds only for `EXACT_COMPLETE`.
+   PyPI bytes, and succeeds only for `EXACT_COMPLETE`. Unlike `prepare-pypi`, its
+   evidence steps fail hard: any evidence failure fails the terminal verifier
+   itself.
 
 The production classifier's mechanical worst case is 3 minutes 5 seconds: two
 30-second index snapshots, two 60-second downloads, and a five-second stability
@@ -103,12 +115,12 @@ runner overhead.
 |---|---|---|
 | `ABSENT` | Two clean 404 snapshots with no conflicting or uncertain evidence | The only state that stages and permits the publisher |
 | `EXACT_COMPLETE` | Stable exact filenames, index hashes, allowlisted final hosts, downloaded bytes, non-yanked status, sealed bundle, and GitHub attestations | Publisher skips; terminal verifier succeeds |
-| `PARTIAL` | A stable non-empty strict subset, even when every present byte matches | Terminal failure; burn the version and never top up |
-| `MISMATCH` | Stable identity, hash, host, or downloaded-byte conflict | Terminal failure; preserve evidence and use compromise/new-version procedure |
+| `PARTIAL` | A stable non-empty strict subset whose present files fully validate (metadata, hosts, and downloaded bytes) | Terminal failure; burn the version and never top up |
+| `MISMATCH` | Stable identity, hash, host, or downloaded-byte conflict — including one inside an otherwise partial or extra file set | Terminal failure; preserve evidence and use compromise/new-version procedure |
 | `YANKED` | Any expected remote file is yanked | Terminal failure; preserve evidence and use compromise/new-version procedure |
-| `EXTRA` | The full expected set plus stable additional files | Terminal failure; preserve evidence and use compromise/new-version procedure |
+| `EXTRA` | The full expected set, fully validated, plus stable additional files | Terminal failure; preserve evidence and use compromise/new-version procedure |
 | `COMPETING` | A duplicate filename or another stable occupied file set | Terminal failure; preserve evidence and use compromise/new-version procedure |
-| `UNCERTAIN` | Timeout, TLS/JSON/API/429/5xx error, inconsistent snapshots, or unavailable artifact/attestation evidence | Never publish; retry only the classifier/verifier recovery chain |
+| `UNCERTAIN` | Timeout, TLS/JSON/API/429/5xx error, off-origin index redirect, inconsistent snapshots, or unavailable artifact/attestation evidence | Never publish; retry only the classifier/verifier recovery chain |
 
 The sealed artifact is named from the version and merge commit and is retained for
 30 days. Staging artifacts also retain for 30 days and include `github.run_attempt`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       attestations: write
       artifact-metadata: write
     outputs:
+      artifact-digest: ${{ steps.upload-release-artifact.outputs.artifact-digest }}
       artifact-name: ${{ steps.bind-source.outputs.artifact-name }}
       commit: ${{ steps.bind-source.outputs.commit }}
       head: ${{ steps.bind-source.outputs.head }}
@@ -651,7 +652,7 @@ jobs:
           REQUIRED_FILE_SCHEME: https
           RETRY_BASE_SECONDS: '5'
           SOCKET_TIMEOUT_SECONDS: '10'
-        run: &verify-index |
+        run: |
           python3 - <<'PY'
           import hashlib
           import json
@@ -725,52 +726,324 @@ jobs:
           PY
 
   prepare-pypi:
-    name: Verify and stage for PyPI
+    name: Classify, verify, and conditionally stage for PyPI
     needs: [bind-build-attest, verify-testpypi]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    environment: pypi
     permissions:
+      actions: read
       contents: read
     outputs:
       staging-artifact: ${{ steps.stage.outputs.artifact-name }}
+      state: ${{ steps.classify-pypi-state.outputs.state }}
     steps:
+      - id: resolve-release-artifact
+        name: Rediscover the immutable sealed artifact from this run
+        env: &artifact-identity
+          EXPECTED_ARTIFACT_DIGEST: ${{ needs.bind-build-attest.outputs.artifact-digest }}
+          EXPECTED_ARTIFACT_NAME: ${{ needs.bind-build-attest.outputs.artifact-name }}
+          EXPECTED_COMMIT: ${{ needs.bind-build-attest.outputs.commit }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: &resolve-release-artifact |
+          set -euo pipefail
+          evidence=$(mktemp -d)
+          trap 'rm -rf "$evidence"' EXIT
+          gh api -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/actions/runs/$RUN_ID" > "$evidence/run.json"
+          gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/actions/runs/$RUN_ID/artifacts" > "$evidence/artifacts.json"
+          python3 - "$evidence/run.json" "$evidence/artifacts.json" <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import sys
+
+          run = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          pages = json.loads(pathlib.Path(sys.argv[2]).read_text())
+          assert isinstance(pages, list) and pages, "artifact response pages are missing"
+          assert all(
+              isinstance(page, dict)
+              and isinstance(page.get("total_count"), int)
+              and isinstance(page.get("artifacts"), list)
+              for page in pages
+          ), "artifact response has the wrong shape"
+          artifacts = [artifact for page in pages for artifact in page["artifacts"]]
+          assert pages[0]["total_count"] == len(artifacts), "artifact pagination mismatch"
+          repository = os.environ["REPOSITORY"]
+          run_id = int(os.environ["RUN_ID"])
+          commit = os.environ["EXPECTED_COMMIT"]
+          expected_digest = os.environ["EXPECTED_ARTIFACT_DIGEST"]
+          assert re.fullmatch(r"[0-9a-f]{64}", expected_digest), (
+              "upload artifact digest has the wrong format"
+          )
+          assert run["id"] == run_id, "workflow run id mismatch"
+          assert run["repository"]["full_name"] == repository, "workflow repository mismatch"
+          assert run["head_repository"]["full_name"] == repository, "head repository mismatch"
+          assert run["event"] == "release", "workflow event mismatch"
+          assert run["path"] == ".github/workflows/release.yml", "workflow path mismatch"
+          assert run["head_sha"] == commit, "workflow head mismatch"
+          matches = [
+              artifact
+              for artifact in artifacts
+              if artifact["name"] == os.environ["EXPECTED_ARTIFACT_NAME"]
+          ]
+          assert len(matches) == 1, "sealed artifact is missing or duplicated"
+          artifact = matches[0]
+          assert not artifact["expired"], "sealed artifact is expired"
+          assert artifact["digest"] == f"sha256:{expected_digest}", (
+              "sealed artifact digest mismatch"
+          )
+          owner = artifact["workflow_run"]
+          assert owner["id"] == run_id, "artifact workflow run mismatch"
+          assert owner["head_sha"] == commit, "artifact head mismatch"
+          assert owner["repository_id"] == run["repository"]["id"], (
+              "artifact repository mismatch"
+          )
+          assert owner["head_repository_id"] == run["head_repository"]["id"], (
+              "artifact head repository mismatch"
+          )
+          with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              print(f'artifact-id={artifact["id"]}', file=output)
+              print(f'artifact-name={artifact["name"]}', file=output)
+              print(f'artifact-digest={artifact["digest"]}', file=output)
+          with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+              print("## Rediscovered sealed artifact", file=summary)
+              print(f'- Run/head: `{run_id}` / `{commit}`', file=summary)
+              print(f'- Artifact ID/name: `{artifact["id"]}` / `{artifact["name"]}`', file=summary)
+              print(f'- Artifact digest: `{artifact["digest"]}`', file=summary)
+          PY
       - id: download-release-artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
-          name: ${{ needs.bind-build-attest.outputs.artifact-name }}
+          artifact-ids: ${{ steps.resolve-release-artifact.outputs.artifact-id }}
+          digest-mismatch: error
+          github-token: ${{ github.token }}
           path: release-bundle/
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
       - id: verify-release-bundle
         env: *bundle-identity
         run: *verify-release-bundle
-      - id: verify-pypi-absence
-        name: Fail closed if the production version already exists
+      - id: classify-pypi-state
+        name: Classify stable PyPI state against the sealed bytes
         env:
+          ALLOWED_FILE_HOST: files.pythonhosted.org
+          DOWNLOAD_TOTAL_SECONDS: '60'
           EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
           EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
-          PYPI_JSON_BASE: https://pypi.org/pypi
-        run: |
+          INDEX_JSON_BASE: https://pypi.org/pypi
+          INDEX_TOTAL_SECONDS: '30'
+          REQUIRED_FILE_SCHEME: https
+          SNAPSHOT_DELAY_SECONDS: '5'
+          SOCKET_TIMEOUT_SECONDS: '10'
+        run: &classify-pypi-state |
           python3 - <<'PY'
+          import hashlib
+          import json
           import os
+          import pathlib
+          import signal
+          import time
           import urllib.error
+          import urllib.parse
           import urllib.request
-          url = f'{os.environ["PYPI_JSON_BASE"]}/{os.environ["EXPECTED_PROJECT_NAME"]}/{os.environ["EXPECTED_VERSION"]}/json'
+
+          bundle = pathlib.Path("release-bundle")
+          expected = {}
+          for line in bundle.joinpath("DIST_SHA256SUMS").read_text().splitlines():
+              digest, path = line.split("  ", 1)
+              expected[pathlib.PurePosixPath(path).name] = digest
+          assert len(expected) == 2
+          project = os.environ["EXPECTED_PROJECT_NAME"]
+          version = os.environ["EXPECTED_VERSION"]
+          request = urllib.request.Request(
+              f'{os.environ["INDEX_JSON_BASE"]}/{project}/{version}/json',
+              headers={"User-Agent": "pylxpweb-release-classifier"},
+          )
+          socket_timeout = float(os.environ["SOCKET_TIMEOUT_SECONDS"])
+
+          def timeout_handler(_signum, _frame):
+              raise TimeoutError("total HTTP transfer deadline exceeded")
+
+          signal.signal(signal.SIGALRM, timeout_handler)
+
+          def fetch(url, total_seconds):
+              signal.setitimer(signal.ITIMER_REAL, total_seconds)
+              try:
+                  with urllib.request.urlopen(url, timeout=socket_timeout) as response:
+                      return response.geturl(), response.read()
+              finally:
+                  signal.setitimer(signal.ITIMER_REAL, 0)
+
+          def snapshot():
+              try:
+                  _, content = fetch(request, float(os.environ["INDEX_TOTAL_SECONDS"]))
+              except urllib.error.HTTPError as error:
+                  if error.code == 404:
+                      return "absent", None, None
+                  raise
+              payload = json.loads(content)
+              if not isinstance(payload, dict):
+                  raise TypeError("index response is not an object")
+              info = payload["info"]
+              urls = payload["urls"]
+              if not isinstance(info, dict) or not isinstance(urls, list):
+                  raise TypeError("index response has the wrong shape")
+              canonical = json.dumps(
+                  {
+                      "name": info.get("name"),
+                      "version": info.get("version"),
+                      "urls": sorted(
+                          (
+                              item.get("filename"),
+                              item.get("digests", {}).get("sha256"),
+                              item.get("url"),
+                              item.get("yanked"),
+                          )
+                          for item in urls
+                          if isinstance(item, dict)
+                      ),
+                  },
+                  separators=(",", ":"),
+              )
+              return "present", payload, canonical
+
+          def shape_state(payload):
+              if payload["info"].get("name") != project or payload["info"].get(
+                  "version"
+              ) != version:
+                  return "MISMATCH"
+              releases = payload["urls"]
+              if not all(isinstance(item, dict) for item in releases):
+                  return "MISMATCH"
+              filenames = [item.get("filename") for item in releases]
+              if len(filenames) != len(set(filenames)):
+                  return "COMPETING"
+              if any(item.get("yanked") is not False for item in releases):
+                  return "YANKED"
+              remote = set(filenames)
+              wanted = set(expected)
+              if remote and remote < wanted:
+                  return "PARTIAL"
+              if wanted < remote:
+                  return "EXTRA"
+              if remote != wanted:
+                  return "COMPETING"
+              for item in releases:
+                  filename = item["filename"]
+                  if item.get("digests", {}).get("sha256") != expected[filename]:
+                      return "MISMATCH"
+                  advertised = urllib.parse.urlparse(item.get("url", ""))
+                  if (
+                      advertised.scheme != os.environ["REQUIRED_FILE_SCHEME"]
+                      or advertised.hostname != os.environ["ALLOWED_FILE_HOST"]
+                  ):
+                      return "MISMATCH"
+              return "candidate-exact"
+
+          state = "UNCERTAIN"
+          reason = "remote evidence could not be classified"
+          first_kind = "unavailable"
+          first_canonical = None
+          second_kind = "unavailable"
+          second_canonical = None
           try:
-              urllib.request.urlopen(url, timeout=30)
-          except urllib.error.HTTPError as error:
-              assert error.code == 404, error
-          else:
-              raise AssertionError("production version already exists")
+              first_kind, first_payload, first_canonical = snapshot()
+              first_state = None
+              downloaded_state = None
+              if first_kind == "present":
+                  first_state = shape_state(first_payload)
+                  if first_state == "candidate-exact":
+                      downloaded_state = "EXACT_COMPLETE"
+                      for item in first_payload["urls"]:
+                          final_url, content = fetch(
+                              item["url"], float(os.environ["DOWNLOAD_TOTAL_SECONDS"])
+                          )
+                          final = urllib.parse.urlparse(final_url)
+                          if (
+                              final.scheme != os.environ["REQUIRED_FILE_SCHEME"]
+                              or final.hostname != os.environ["ALLOWED_FILE_HOST"]
+                              or hashlib.sha256(content).hexdigest()
+                              != expected[item["filename"]]
+                          ):
+                              downloaded_state = "MISMATCH"
+                              break
+              time.sleep(float(os.environ["SNAPSHOT_DELAY_SECONDS"]))
+              second_kind, second_payload, second_canonical = snapshot()
+              if first_kind != second_kind or first_canonical != second_canonical:
+                  state = "UNCERTAIN"
+                  reason = "PyPI snapshots were inconsistent"
+              elif first_kind == "absent":
+                  state = "ABSENT"
+                  reason = "two clean PyPI snapshots report version absence"
+              else:
+                  second_state = shape_state(second_payload)
+                  if first_state != second_state:
+                      state = "UNCERTAIN"
+                      reason = "PyPI classifications changed between snapshots"
+                  elif first_state != "candidate-exact":
+                      state = first_state
+                      reason = "stable PyPI metadata conflicts with the sealed set"
+                  elif downloaded_state == "MISMATCH":
+                      state = "MISMATCH"
+                      reason = "downloaded PyPI bytes do not match the sealed set"
+                  else:
+                      state = "EXACT_COMPLETE"
+                      reason = "stable PyPI metadata and downloaded bytes exactly match"
+          except (
+              json.JSONDecodeError,
+              KeyError,
+              OSError,
+              TimeoutError,
+              TypeError,
+              ValueError,
+          ) as error:
+              state = "UNCERTAIN"
+              reason = f"remote evidence error: {type(error).__name__}"
+
+          guidance = {
+              "ABSENT": "Publisher may upload the full sealed wheel and sdist once.",
+              "EXACT_COMPLETE": "Do not republish; verifier-only completion is required.",
+              "PARTIAL": "Burn this immutable version and prepare a new version; never top up.",
+              "MISMATCH": "Stop, preserve evidence, investigate compromise, and use a new version.",
+              "YANKED": "Stop, preserve evidence, and use the compromise/new-version runbook.",
+              "EXTRA": "Stop, preserve evidence, and use the compromise/new-version runbook.",
+              "COMPETING": "Stop, preserve evidence, and use the compromise/new-version runbook.",
+              "UNCERTAIN": "Do not publish; retry only prepare-pypi and its dependent jobs.",
+          }
+          assert state in guidance
+          with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              print(f"state={state}", file=output)
+              print(f"reason={reason}", file=output)
+          with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+              print("## PyPI publication state", file=summary)
+              print(f"- State: `{state}`", file=summary)
+              print(f"- Evidence: {reason}", file=summary)
+              print(
+                  f"- Expected sealed files: `{json.dumps(expected, sort_keys=True)}`",
+                  file=summary,
+              )
+              print(f"- First snapshot: `{first_canonical or first_kind}`", file=summary)
+              print(f"- Second snapshot: `{second_canonical or second_kind}`", file=summary)
+              print(f"- Required action: {guidance[state]}", file=summary)
           PY
       - id: stage
         name: Stage the verified distributions
+        if: steps.classify-pypi-state.outputs.state == 'ABSENT'
         env:
           COMMIT: ${{ needs.bind-build-attest.outputs.commit }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
           mkdir pypi-upload
           cp release-bundle/dist/* pypi-upload/
-          echo "artifact-name=pylxpweb-pypi-${COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "artifact-name=pylxpweb-pypi-${COMMIT}-attempt-${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
       - id: upload-staging-artifact
+        if: steps.classify-pypi-state.outputs.state == 'ABSENT'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: ${{ steps.stage.outputs.artifact-name }}
@@ -781,6 +1054,7 @@ jobs:
   publish-pypi:
     name: Publish staged artifact to PyPI
     needs: prepare-pypi
+    if: needs.prepare-pypi.outputs.state == 'ABSENT'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi
@@ -797,32 +1071,72 @@ jobs:
           packages-dir: upload/
 
   verify-pypi:
-    name: Verify PyPI publication
-    needs: [bind-build-attest, publish-pypi]
+    name: Define terminal PyPI completion
+    needs: [bind-build-attest, prepare-pypi, publish-pypi]
+    if: ${{ always() && !cancelled() && needs.prepare-pypi.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      actions: read
       contents: read
     steps:
+      - id: resolve-release-artifact
+        name: Rediscover the immutable sealed artifact from this run
+        env: *artifact-identity
+        run: *resolve-release-artifact
       - id: download-release-artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
-          name: ${{ needs.bind-build-attest.outputs.artifact-name }}
+          artifact-ids: ${{ steps.resolve-release-artifact.outputs.artifact-id }}
+          digest-mismatch: error
+          github-token: ${{ github.token }}
           path: release-bundle/
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
       - id: verify-release-bundle
         env: *bundle-identity
         run: *verify-release-bundle
-      - id: verify-pypi-files
-        name: Poll PyPI and verify the exact remote bytes
+      - id: classify-pypi-state
+        name: Reclassify PyPI from stable remote bytes
         env:
+          ALLOWED_FILE_HOST: files.pythonhosted.org
+          DOWNLOAD_TOTAL_SECONDS: '60'
           EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
           EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
           INDEX_JSON_BASE: https://pypi.org/pypi
-          ALLOWED_FILE_HOST: files.pythonhosted.org
-          DOWNLOAD_TOTAL_SECONDS: '60'
           INDEX_TOTAL_SECONDS: '30'
-          MAX_ATTEMPTS: '8'
           REQUIRED_FILE_SCHEME: https
-          RETRY_BASE_SECONDS: '5'
+          SNAPSHOT_DELAY_SECONDS: '5'
           SOCKET_TIMEOUT_SECONDS: '10'
-        run: *verify-index
+        run: *classify-pypi-state
+      - id: require-exact-complete
+        name: Require exact-complete terminal state
+        env:
+          STATE: ${{ steps.classify-pypi-state.outputs.state }}
+        run: |
+          set -euo pipefail
+          case "$STATE" in
+            EXACT_COMPLETE)
+              echo "PyPI exactly contains the sealed wheel and sdist."
+              ;;
+            ABSENT)
+              echo "PyPI is still absent; retry prepare-pypi and its dependent jobs only." >&2
+              exit 1
+              ;;
+            PARTIAL)
+              echo "PyPI is partial; burn this version and prepare a new version. Never top up." >&2
+              exit 1
+              ;;
+            UNCERTAIN)
+              echo "PyPI evidence is uncertain; do not publish. Retry prepare-pypi and its dependent jobs only." >&2
+              exit 1
+              ;;
+            MISMATCH|YANKED|EXTRA|COMPETING)
+              echo "PyPI state is $STATE; preserve evidence and follow the compromise/new-version runbook." >&2
+              exit 1
+              ;;
+            *)
+              echo "Unknown PyPI state: $STATE" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -830,7 +830,7 @@ jobs:
         run: *verify-release-bundle
       - id: classify-pypi-state
         name: Classify stable PyPI state against the sealed bytes
-        env:
+        env: &pypi-classifier-env
           ALLOWED_FILE_HOST: files.pythonhosted.org
           DOWNLOAD_TOTAL_SECONDS: '60'
           EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
@@ -1098,16 +1098,7 @@ jobs:
         run: *verify-release-bundle
       - id: classify-pypi-state
         name: Reclassify PyPI from stable remote bytes
-        env:
-          ALLOWED_FILE_HOST: files.pythonhosted.org
-          DOWNLOAD_TOTAL_SECONDS: '60'
-          EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
-          EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
-          INDEX_JSON_BASE: https://pypi.org/pypi
-          INDEX_TOTAL_SECONDS: '30'
-          REQUIRED_FILE_SCHEME: https
-          SNAPSHOT_DELAY_SECONDS: '5'
-          SOCKET_TIMEOUT_SECONDS: '10'
+        env: *pypi-classifier-env
         run: *classify-pypi-state
       - id: require-exact-complete
         name: Require exact-complete terminal state

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -736,10 +736,11 @@ jobs:
       contents: read
     outputs:
       staging-artifact: ${{ steps.stage.outputs.artifact-name }}
-      state: ${{ steps.classify-pypi-state.outputs.state }}
+      state: ${{ steps.resolve-prepare-state.outputs.state }}
     steps:
       - id: resolve-release-artifact
         name: Rediscover the immutable sealed artifact from this run
+        continue-on-error: true
         env: &artifact-identity
           EXPECTED_ARTIFACT_DIGEST: ${{ needs.bind-build-attest.outputs.artifact-digest }}
           EXPECTED_ARTIFACT_NAME: ${{ needs.bind-build-attest.outputs.artifact-name }}
@@ -817,6 +818,8 @@ jobs:
               print(f'- Artifact digest: `{artifact["digest"]}`', file=summary)
           PY
       - id: download-release-artifact
+        if: steps.resolve-release-artifact.outcome == 'success'
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
           artifact-ids: ${{ steps.resolve-release-artifact.outputs.artifact-id }}
@@ -826,18 +829,24 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ github.run_id }}
       - id: verify-release-bundle
+        if: steps.download-release-artifact.outcome == 'success'
+        continue-on-error: true
         env: *bundle-identity
         run: *verify-release-bundle
       - id: classify-pypi-state
         name: Classify stable PyPI state against the sealed bytes
+        if: steps.verify-release-bundle.outcome == 'success'
+        continue-on-error: true
         env: &pypi-classifier-env
           ALLOWED_FILE_HOST: files.pythonhosted.org
+          ALLOWED_INDEX_HOST: pypi.org
           DOWNLOAD_TOTAL_SECONDS: '60'
           EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
           EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
           INDEX_JSON_BASE: https://pypi.org/pypi
           INDEX_TOTAL_SECONDS: '30'
           REQUIRED_FILE_SCHEME: https
+          REQUIRED_INDEX_SCHEME: https
           SNAPSHOT_DELAY_SECONDS: '5'
           SOCKET_TIMEOUT_SECONDS: '10'
         run: &classify-pypi-state |
@@ -879,13 +888,23 @@ jobs:
               finally:
                   signal.setitimer(signal.ITIMER_REAL, 0)
 
+          def require_index_origin(url):
+              parsed = urllib.parse.urlparse(url)
+              if (
+                  parsed.scheme != os.environ["REQUIRED_INDEX_SCHEME"]
+                  or parsed.hostname != os.environ["ALLOWED_INDEX_HOST"]
+              ):
+                  raise ValueError("index response final URL is not the pinned index origin")
+
           def snapshot():
               try:
-                  _, content = fetch(request, float(os.environ["INDEX_TOTAL_SECONDS"]))
+                  final_url, content = fetch(request, float(os.environ["INDEX_TOTAL_SECONDS"]))
               except urllib.error.HTTPError as error:
                   if error.code == 404:
+                      require_index_origin(error.url)
                       return "absent", None, None
                   raise
+              require_index_origin(final_url)
               payload = json.loads(content)
               if not isinstance(payload, dict):
                   raise TypeError("index response is not an object")
@@ -925,16 +944,10 @@ jobs:
                   return "COMPETING"
               if any(item.get("yanked") is not False for item in releases):
                   return "YANKED"
-              remote = set(filenames)
-              wanted = set(expected)
-              if remote and remote < wanted:
-                  return "PARTIAL"
-              if wanted < remote:
-                  return "EXTRA"
-              if remote != wanted:
-                  return "COMPETING"
               for item in releases:
-                  filename = item["filename"]
+                  filename = item.get("filename")
+                  if filename not in expected:
+                      continue
                   if item.get("digests", {}).get("sha256") != expected[filename]:
                       return "MISMATCH"
                   advertised = urllib.parse.urlparse(item.get("url", ""))
@@ -943,7 +956,15 @@ jobs:
                       or advertised.hostname != os.environ["ALLOWED_FILE_HOST"]
                   ):
                       return "MISMATCH"
-              return "candidate-exact"
+              remote = set(filenames)
+              wanted = set(expected)
+              if remote == wanted:
+                  return "candidate-exact"
+              if remote and remote < wanted:
+                  return "PARTIAL"
+              if wanted < remote:
+                  return "EXTRA"
+              return "COMPETING"
 
           state = "UNCERTAIN"
           reason = "remote evidence could not be classified"
@@ -957,9 +978,12 @@ jobs:
               downloaded_state = None
               if first_kind == "present":
                   first_state = shape_state(first_payload)
-                  if first_state == "candidate-exact":
-                      downloaded_state = "EXACT_COMPLETE"
+                  if first_state in {"candidate-exact", "PARTIAL", "EXTRA"}:
+                      downloaded_state = "downloads-exact"
                       for item in first_payload["urls"]:
+                          filename = item.get("filename")
+                          if filename not in expected:
+                              continue
                           final_url, content = fetch(
                               item["url"], float(os.environ["DOWNLOAD_TOTAL_SECONDS"])
                           )
@@ -968,7 +992,7 @@ jobs:
                               final.scheme != os.environ["REQUIRED_FILE_SCHEME"]
                               or final.hostname != os.environ["ALLOWED_FILE_HOST"]
                               or hashlib.sha256(content).hexdigest()
-                              != expected[item["filename"]]
+                              != expected[filename]
                           ):
                               downloaded_state = "MISMATCH"
                               break
@@ -985,12 +1009,12 @@ jobs:
                   if first_state != second_state:
                       state = "UNCERTAIN"
                       reason = "PyPI classifications changed between snapshots"
-                  elif first_state != "candidate-exact":
-                      state = first_state
-                      reason = "stable PyPI metadata conflicts with the sealed set"
                   elif downloaded_state == "MISMATCH":
                       state = "MISMATCH"
                       reason = "downloaded PyPI bytes do not match the sealed set"
+                  elif first_state != "candidate-exact":
+                      state = first_state
+                      reason = "stable PyPI metadata conflicts with the sealed set"
                   else:
                       state = "EXACT_COMPLETE"
                       reason = "stable PyPI metadata and downloaded bytes exactly match"
@@ -1031,9 +1055,37 @@ jobs:
               print(f"- Second snapshot: `{second_canonical or second_kind}`", file=summary)
               print(f"- Required action: {guidance[state]}", file=summary)
           PY
+      - id: resolve-prepare-state
+        name: Funnel missing prerequisite evidence into an UNCERTAIN result
+        env:
+          CLASSIFIED_REASON: ${{ steps.classify-pypi-state.outputs.reason }}
+          CLASSIFIED_STATE: ${{ steps.classify-pypi-state.outputs.state }}
+          CLASSIFY_OUTCOME: ${{ steps.classify-pypi-state.outcome }}
+          DOWNLOAD_OUTCOME: ${{ steps.download-release-artifact.outcome }}
+          RESOLVE_OUTCOME: ${{ steps.resolve-release-artifact.outcome }}
+          VERIFY_OUTCOME: ${{ steps.verify-release-bundle.outcome }}
+        run: |
+          set -euo pipefail
+          state="UNCERTAIN"
+          reason="artifact, bundle, or attestation evidence failed before classification"
+          if [[ "$RESOLVE_OUTCOME" == "success" && "$DOWNLOAD_OUTCOME" == "success" && \
+                "$VERIFY_OUTCOME" == "success" && "$CLASSIFY_OUTCOME" == "success" && \
+                -n "$CLASSIFIED_STATE" ]]; then
+            state="$CLASSIFIED_STATE"
+            reason="$CLASSIFIED_REASON"
+          fi
+          {
+            echo "state=$state"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Prepare result"
+            echo "- State: \`$state\`"
+            echo "- Evidence: $reason"
+          } >> "$GITHUB_STEP_SUMMARY"
       - id: stage
         name: Stage the verified distributions
-        if: steps.classify-pypi-state.outputs.state == 'ABSENT'
+        if: steps.resolve-prepare-state.outputs.state == 'ABSENT'
         env:
           COMMIT: ${{ needs.bind-build-attest.outputs.commit }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -1043,7 +1095,7 @@ jobs:
           cp release-bundle/dist/* pypi-upload/
           echo "artifact-name=pylxpweb-pypi-${COMMIT}-attempt-${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
       - id: upload-staging-artifact
-        if: steps.classify-pypi-state.outputs.state == 'ABSENT'
+        if: steps.resolve-prepare-state.outputs.state == 'ABSENT'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: ${{ steps.stage.outputs.artifact-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -838,6 +838,10 @@ jobs:
         if: steps.verify-release-bundle.outcome == 'success'
         continue-on-error: true
         env: &pypi-classifier-env
+          # Prepare-time classification is a single stability pair: absence is a
+          # publishable state here, so it must never be retried away.
+          ABSENT_RECHECK_BASE_SECONDS: '0'
+          ABSENT_RECHECK_MAX_ATTEMPTS: '1'
           ALLOWED_FILE_HOST: files.pythonhosted.org
           ALLOWED_INDEX_HOST: pypi.org
           DOWNLOAD_TOTAL_SECONDS: '60'
@@ -966,68 +970,80 @@ jobs:
                   return "EXTRA"
               return "COMPETING"
 
-          state = "UNCERTAIN"
-          reason = "remote evidence could not be classified"
-          first_kind = "unavailable"
-          first_canonical = None
-          second_kind = "unavailable"
-          second_canonical = None
-          try:
-              first_kind, first_payload, first_canonical = snapshot()
-              first_state = None
-              downloaded_state = None
-              if first_kind == "present":
-                  first_state = shape_state(first_payload)
-                  if first_state in {"candidate-exact", "PARTIAL", "EXTRA"}:
-                      downloaded_state = "downloads-exact"
-                      for item in first_payload["urls"]:
-                          filename = item.get("filename")
-                          if filename not in expected:
-                              continue
-                          final_url, content = fetch(
-                              item["url"], float(os.environ["DOWNLOAD_TOTAL_SECONDS"])
-                          )
-                          final = urllib.parse.urlparse(final_url)
-                          if (
-                              final.scheme != os.environ["REQUIRED_FILE_SCHEME"]
-                              or final.hostname != os.environ["ALLOWED_FILE_HOST"]
-                              or hashlib.sha256(content).hexdigest()
-                              != expected[filename]
-                          ):
-                              downloaded_state = "MISMATCH"
-                              break
-              time.sleep(float(os.environ["SNAPSHOT_DELAY_SECONDS"]))
-              second_kind, second_payload, second_canonical = snapshot()
-              if first_kind != second_kind or first_canonical != second_canonical:
-                  state = "UNCERTAIN"
-                  reason = "PyPI snapshots were inconsistent"
-              elif first_kind == "absent":
-                  state = "ABSENT"
-                  reason = "two clean PyPI snapshots report version absence"
-              else:
-                  second_state = shape_state(second_payload)
-                  if first_state != second_state:
-                      state = "UNCERTAIN"
-                      reason = "PyPI classifications changed between snapshots"
-                  elif downloaded_state == "MISMATCH":
-                      state = "MISMATCH"
-                      reason = "downloaded PyPI bytes do not match the sealed set"
-                  elif first_state != "candidate-exact":
-                      state = first_state
-                      reason = "stable PyPI metadata conflicts with the sealed set"
-                  else:
-                      state = "EXACT_COMPLETE"
-                      reason = "stable PyPI metadata and downloaded bytes exactly match"
-          except (
-              json.JSONDecodeError,
-              KeyError,
-              OSError,
-              TimeoutError,
-              TypeError,
-              ValueError,
-          ) as error:
+          # An ABSENT pair of snapshots is re-taken up to ABSENT_RECHECK_MAX_ATTEMPTS
+          # times with capped backoff so routine index-propagation lag right after a
+          # publish cannot fail terminal verification. Only ABSENT retries: every
+          # other state (including UNCERTAIN) returns after one stability pair, and
+          # prepare-time classification pins the attempt budget to a single pass.
+          recheck_attempts = int(os.environ.get("ABSENT_RECHECK_MAX_ATTEMPTS", "1"))
+          recheck_base = int(os.environ.get("ABSENT_RECHECK_BASE_SECONDS", "0"))
+          assert recheck_attempts >= 1
+          for recheck in range(1, recheck_attempts + 1):
               state = "UNCERTAIN"
-              reason = f"remote evidence error: {type(error).__name__}"
+              reason = "remote evidence could not be classified"
+              first_kind = "unavailable"
+              first_canonical = None
+              second_kind = "unavailable"
+              second_canonical = None
+              try:
+                  first_kind, first_payload, first_canonical = snapshot()
+                  first_state = None
+                  downloaded_state = None
+                  if first_kind == "present":
+                      first_state = shape_state(first_payload)
+                      if first_state in {"candidate-exact", "PARTIAL", "EXTRA"}:
+                          downloaded_state = "downloads-exact"
+                          for item in first_payload["urls"]:
+                              filename = item.get("filename")
+                              if filename not in expected:
+                                  continue
+                              final_url, content = fetch(
+                                  item["url"], float(os.environ["DOWNLOAD_TOTAL_SECONDS"])
+                              )
+                              final = urllib.parse.urlparse(final_url)
+                              if (
+                                  final.scheme != os.environ["REQUIRED_FILE_SCHEME"]
+                                  or final.hostname != os.environ["ALLOWED_FILE_HOST"]
+                                  or hashlib.sha256(content).hexdigest()
+                                  != expected[filename]
+                              ):
+                                  downloaded_state = "MISMATCH"
+                                  break
+                  time.sleep(float(os.environ["SNAPSHOT_DELAY_SECONDS"]))
+                  second_kind, second_payload, second_canonical = snapshot()
+                  if first_kind != second_kind or first_canonical != second_canonical:
+                      state = "UNCERTAIN"
+                      reason = "PyPI snapshots were inconsistent"
+                  elif first_kind == "absent":
+                      state = "ABSENT"
+                      reason = "two clean PyPI snapshots report version absence"
+                  else:
+                      second_state = shape_state(second_payload)
+                      if first_state != second_state:
+                          state = "UNCERTAIN"
+                          reason = "PyPI classifications changed between snapshots"
+                      elif downloaded_state == "MISMATCH":
+                          state = "MISMATCH"
+                          reason = "downloaded PyPI bytes do not match the sealed set"
+                      elif first_state != "candidate-exact":
+                          state = first_state
+                          reason = "stable PyPI metadata conflicts with the sealed set"
+                      else:
+                          state = "EXACT_COMPLETE"
+                          reason = "stable PyPI metadata and downloaded bytes exactly match"
+              except (
+                  json.JSONDecodeError,
+                  KeyError,
+                  OSError,
+                  TimeoutError,
+                  TypeError,
+                  ValueError,
+              ) as error:
+                  state = "UNCERTAIN"
+                  reason = f"remote evidence error: {type(error).__name__}"
+              if state != "ABSENT" or recheck == recheck_attempts:
+                  break
+              time.sleep(min(recheck * recheck_base, 30))
 
           guidance = {
               "ABSENT": "Publisher may upload the full sealed wheel and sdist once.",
@@ -1127,7 +1143,7 @@ jobs:
     needs: [bind-build-attest, prepare-pypi, publish-pypi]
     if: ${{ always() && !cancelled() && needs.prepare-pypi.result == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       actions: read
       contents: read
@@ -1150,7 +1166,24 @@ jobs:
         run: *verify-release-bundle
       - id: classify-pypi-state
         name: Reclassify PyPI from stable remote bytes
-        env: *pypi-classifier-env
+        # Same script and identity/host/deadline values as prepare-pypi, but the
+        # terminal reclassification may re-take an ABSENT snapshot pair with the
+        # TestPyPI-verifier retry envelope (12 attempts, 5s base, 30s backoff cap)
+        # so index-propagation lag after publish-pypi cannot fail the happy path.
+        env:
+          ABSENT_RECHECK_BASE_SECONDS: '5'
+          ABSENT_RECHECK_MAX_ATTEMPTS: '12'
+          ALLOWED_FILE_HOST: files.pythonhosted.org
+          ALLOWED_INDEX_HOST: pypi.org
+          DOWNLOAD_TOTAL_SECONDS: '60'
+          EXPECTED_PROJECT_NAME: ${{ needs.bind-build-attest.outputs.project-name }}
+          EXPECTED_VERSION: ${{ needs.bind-build-attest.outputs.version }}
+          INDEX_JSON_BASE: https://pypi.org/pypi
+          INDEX_TOTAL_SECONDS: '30'
+          REQUIRED_FILE_SCHEME: https
+          REQUIRED_INDEX_SCHEME: https
+          SNAPSHOT_DELAY_SECONDS: '5'
+          SOCKET_TIMEOUT_SECONDS: '10'
         run: *classify-pypi-state
       - id: require-exact-complete
         name: Require exact-complete terminal state

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -17,7 +17,7 @@ import time
 from collections.abc import Iterator
 from contextlib import suppress
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 import pytest
 import yaml
@@ -437,6 +437,9 @@ def _run_bounded_subprocess(
     env: dict[str, str],
     timeout_seconds: float,
 ) -> subprocess.CompletedProcess[str]:
+    # The deadline bounds *silence*, not total runtime: a child that keeps
+    # writing to either captured pipe stays alive, while one that produces no
+    # output for timeout_seconds is killed with its whole process group.
     process = subprocess.Popen(
         args,
         cwd=cwd,
@@ -444,18 +447,53 @@ def _run_bounded_subprocess(
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
         close_fds=True,
         start_new_session=True,
     )
+    stdout_pipe = process.stdout
+    stderr_pipe = process.stderr
+    assert stdout_pipe is not None and stderr_pipe is not None
+    captured: dict[str, list[bytes]] = {"stdout": [], "stderr": []}
+    last_progress = [time.monotonic()]
+
+    def drain(stream: IO[bytes], key: str) -> None:
+        while chunk := os.read(stream.fileno(), 65536):
+            captured[key].append(chunk)
+            last_progress[0] = time.monotonic()
+
+    readers = [
+        threading.Thread(target=drain, args=(stdout_pipe, "stdout")),
+        threading.Thread(target=drain, args=(stderr_pipe, "stderr")),
+    ]
+    for reader in readers:
+        reader.start()
+
+    def decoded(key: str) -> str:
+        return b"".join(captured[key]).decode(errors="replace")
+
     try:
-        stdout, stderr = process.communicate(timeout=timeout_seconds)
+        while process.poll() is None or any(reader.is_alive() for reader in readers):
+            if time.monotonic() - last_progress[0] >= timeout_seconds:
+                raise subprocess.TimeoutExpired(
+                    args,
+                    timeout_seconds,
+                    output=decoded("stdout"),
+                    stderr=decoded("stderr"),
+                )
+            time.sleep(0.01)
     except BaseException:
         with suppress(ProcessLookupError):
             os.killpg(process.pid, signal.SIGKILL)
-        process.communicate()
+        for reader in readers:
+            reader.join()
+        process.wait()
         raise
-    return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+    finally:
+        for reader in readers:
+            reader.join()
+        stdout_pipe.close()
+        stderr_pipe.close()
+    return subprocess.CompletedProcess(args, process.wait(), decoded("stdout"), decoded("stderr"))
 
 
 def _materialize_python_heredocs(script: str, tmp_path: Path) -> str:
@@ -540,6 +578,41 @@ def test_bounded_subprocess_terminates_entire_child_group(tmp_path: Path) -> Non
             timeout_seconds=0.2,
         )
     assert time.monotonic() - started < 2
+
+
+def test_bounded_subprocess_tolerates_slow_but_progressing_child(tmp_path: Path) -> None:
+    """The deadline bounds silence, not total runtime.
+
+    A child whose output gaps stay under the deadline must run to completion
+    even when its total runtime exceeds the deadline several times over, and
+    the harness must not leave reader threads behind afterwards.
+    """
+    threads_before = threading.active_count()
+    result = _run_bounded_subprocess(
+        ["bash", "-c", 'for i in $(seq 20); do echo "tick $i"; sleep 0.05; done'],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        timeout_seconds=0.3,
+    )
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == [f"tick {i}" for i in range(1, 21)]
+    assert threading.active_count() == threads_before
+
+
+def test_bounded_subprocess_kills_child_that_stops_progressing(tmp_path: Path) -> None:
+    """Progress followed by silence is still killed, with the whole group."""
+    threads_before = threading.active_count()
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+        _run_bounded_subprocess(
+            ["bash", "-c", 'echo "made progress"; sleep 60 & wait'],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=0.3,
+        )
+    assert time.monotonic() - started < 2
+    assert "made progress" in (excinfo.value.output or "")
+    assert threading.active_count() == threads_before
 
 
 def test_harness_never_hands_bash_a_python_heredoc(

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -542,17 +542,52 @@ def test_bounded_subprocess_terminates_entire_child_group(tmp_path: Path) -> Non
     assert time.monotonic() - started < 2
 
 
-def test_binding_harness_terminates_under_bash_52_stress(
+def test_harness_never_hands_bash_a_python_heredoc(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Materialized heredocs avoid the macOS Bash pipe deadlock under stress."""
-    monkeypatch.setenv("BASH_COMPAT", "52")
-    for index in range(12):
-        run_path = tmp_path / str(index)
-        run_path.mkdir()
-        case = _release_repo(run_path)
-        result = _run_binding(case, run_path)
-        assert result.returncode == 0, result.stderr
+    """Every workflow heredoc must be a private file before bash parses the script.
+
+    Homebrew Bash 5.3 on macOS can deadlock in heredoc_write under load, so the
+    harness removes the heredoc construct entirely instead of racing the pipe.
+    This checks the command actually handed to bash for every heredoc-bearing
+    workflow script: no ``<<'PY'`` survives, each body is byte-identical on
+    disk, and the interpreter arguments are preserved.
+    """
+    scripts = [
+        text
+        for job in _workflow()["jobs"].values()
+        for step in job["steps"]
+        for text in [step.get("run")]
+        if isinstance(text, str) and "<<'PY'" in text
+    ]
+    assert scripts, "release.yml no longer contains python heredocs to materialize"
+    executed: list[list[str]] = []
+
+    def record(
+        args: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str],
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[str]:
+        executed.append(args)
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(sys.modules[__name__], "_run_bounded_subprocess", record)
+    for index, script in enumerate(scripts):
+        script_tmp = tmp_path / str(index)
+        script_tmp.mkdir()
+        _run_yaml_script(script, cwd=script_tmp, env={}, tmp_path=script_tmp, timeout_seconds=1.0)
+        executable, flag, command = executed[-1]
+        assert (executable, flag) == ("bash", "-c")
+        assert "<<'PY'" not in command
+        heredocs = list(_PYTHON_HEREDOC.finditer(script))
+        assert len(heredocs) == script.count("<<'PY'")
+        for heredoc_index, heredoc in enumerate(heredocs):
+            body_path = script_tmp / "yaml-script" / f"heredoc-{heredoc_index}.py"
+            invocation = f"python3 {shlex.quote(str(body_path))}{heredoc.group('args')}"
+            assert invocation in command
+            assert body_path.read_text() == heredoc.group("body") + "\n"
 
 
 @pytest.mark.parametrize("lightweight", [False, True], ids=["annotated", "lightweight"])

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -513,16 +513,13 @@ def _run_bounded_subprocess(
     except BaseException:
         with suppress(ProcessLookupError):
             os.killpg(process.pid, signal.SIGKILL)
-        for reader in readers:
-            reader.join()
-        process.wait()
         raise
     finally:
         for reader in readers:
             reader.join()
         stdout_pipe.close()
         stderr_pipe.close()
-    returncode = process.wait()
+        returncode = process.wait()
     if expired_deadline is not None:
         raise subprocess.TimeoutExpired(
             args,

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1071,22 +1071,19 @@ def test_bundle_validation_rejects_artifact_and_attestation_tampering(tmp_path: 
     assert tampered_attestation.returncode != 0
 
 
-@pytest.mark.parametrize("job_id", ["verify-testpypi"])
 def test_index_verifier_retries_then_accepts_exact_remote_bytes(
     tmp_path: Path,
     package_index_server: tuple[str, dict[str, Any]],
-    job_id: str,
 ) -> None:
     """The YAML-derived verifier handles transient index lag and exact bytes."""
     base_url, state = package_index_server
     _, payload = _prepare_index_case(tmp_path, base_url, state)
     state["index_responses"] = [503, payload]
-    result = _run_index_verifier(tmp_path, base_url, job_id=job_id)
+    result = _run_index_verifier(tmp_path, base_url, job_id="verify-testpypi")
     assert result.returncode == 0, result.stderr
     assert state["index_calls"] >= 2
 
 
-@pytest.mark.parametrize("job_id", ["verify-testpypi"])
 @pytest.mark.parametrize(
     "mutation",
     [
@@ -1105,7 +1102,6 @@ def test_index_verifier_retries_then_accepts_exact_remote_bytes(
 def test_index_verifier_rejects_remote_identity_and_byte_mutations(
     tmp_path: Path,
     package_index_server: tuple[str, dict[str, Any]],
-    job_id: str,
     mutation: str,
 ) -> None:
     """Weakening any remote-index check admits a different published artifact set."""
@@ -1144,15 +1140,13 @@ def test_index_verifier_rejects_remote_identity_and_byte_mutations(
         state["index_responses"] = [503, 503, 503]
     if not state["index_responses"]:
         state["index_responses"] = [payload]
-    result = _run_index_verifier(tmp_path, base_url, job_id=job_id)
+    result = _run_index_verifier(tmp_path, base_url, job_id="verify-testpypi")
     assert result.returncode != 0
 
 
-@pytest.mark.parametrize("job_id", ["verify-testpypi"])
 def test_index_verifier_rejects_competing_publication_race(
     tmp_path: Path,
     package_index_server: tuple[str, dict[str, Any]],
-    job_id: str,
 ) -> None:
     """A second index snapshot catches a file added while exact bytes are downloaded."""
     base_url, state = package_index_server
@@ -1167,18 +1161,15 @@ def test_index_verifier_rejects_competing_publication_race(
         }
     )
     state["index_responses"] = [exact, raced]
-    result = _run_index_verifier(tmp_path, base_url, job_id=job_id)
+    result = _run_index_verifier(tmp_path, base_url, job_id="verify-testpypi")
     assert result.returncode != 0
     assert state["index_calls"] == 2
 
 
-@pytest.mark.parametrize("job_id", ["verify-testpypi"])
-def test_index_verifier_worst_case_fits_job_timeout_with_five_minute_headroom(
-    job_id: str,
-) -> None:
+def test_index_verifier_worst_case_fits_job_timeout_with_five_minute_headroom() -> None:
     """Polling, transfers, final snapshot, and non-index verification fit mechanically."""
-    job = _job(job_id)
-    step = _step(job_id, f"verify-{job_id.removeprefix('verify-')}-files")
+    job = _job("verify-testpypi")
+    step = _step("verify-testpypi", "verify-testpypi-files")
     env = step["env"]
     attempts = int(env["MAX_ATTEMPTS"])
     retry_base = int(env["RETRY_BASE_SECONDS"])
@@ -1230,11 +1221,10 @@ def _run_pypi_classifier(
     tmp_path: Path,
     base_url: str,
     *,
-    job_id: str = "prepare-pypi",
     env_overrides: dict[str, str] | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str]:
-    output = tmp_path / f"{job_id}-output"
-    summary = tmp_path / f"{job_id}-summary"
+    output = tmp_path / "prepare-pypi-output"
+    summary = tmp_path / "prepare-pypi-summary"
     env = os.environ | {
         "ALLOWED_FILE_HOST": "127.0.0.1",
         "DOWNLOAD_TOTAL_SECONDS": "2",
@@ -1249,7 +1239,7 @@ def _run_pypi_classifier(
         "SOCKET_TIMEOUT_SECONDS": "1",
     }
     env.update(env_overrides or {})
-    step = _step(job_id, "classify-pypi-state")
+    step = _step("prepare-pypi", "classify-pypi-state")
     marker = "python3 - <<'PY'\n"
     assert step["run"].startswith(marker)
     python = step["run"].removeprefix(marker).removesuffix("\nPY\n")

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -48,6 +48,7 @@ def package_index_server() -> Iterator[tuple[str, dict[str, Any]]]:
         "index_calls": 0,
         "index_responses": [],
         "redirected_files": {},
+        "redirected_index": None,
         "request_events": [],
     }
 
@@ -61,6 +62,11 @@ def package_index_server() -> Iterator[tuple[str, dict[str, Any]]]:
                 response = responses[index]
                 if isinstance(response, int):
                     self.send_error(response)
+                    return
+                if isinstance(response, dict) and "redirect" in response:
+                    self.send_response(302)
+                    self.send_header("Location", response["redirect"])
+                    self.end_headers()
                     return
                 body = json.dumps(response).encode()
                 self.send_response(200)
@@ -103,6 +109,18 @@ def package_index_server() -> Iterator[tuple[str, dict[str, Any]]]:
                 self.send_header("Content-Length", str(len(response)))
                 self.end_headers()
                 self.wfile.write(response)
+                return
+            if self.path.startswith("/redirected-index"):
+                response = state["redirected_index"]
+                if response is None:
+                    self.send_error(404)
+                    return
+                body = json.dumps(response).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
                 return
             self.send_error(404)
 
@@ -1331,6 +1349,7 @@ def _run_pypi_classifier(
     summary = tmp_path / "prepare-pypi-summary"
     env = os.environ | {
         "ALLOWED_FILE_HOST": "127.0.0.1",
+        "ALLOWED_INDEX_HOST": "127.0.0.1",
         "DOWNLOAD_TOTAL_SECONDS": "2",
         "EXPECTED_PROJECT_NAME": "pylxpweb",
         "EXPECTED_VERSION": "1.2.3",
@@ -1339,6 +1358,7 @@ def _run_pypi_classifier(
         "INDEX_JSON_BASE": f"{base_url}/pypi",
         "INDEX_TOTAL_SECONDS": "2",
         "REQUIRED_FILE_SCHEME": "http",
+        "REQUIRED_INDEX_SCHEME": "http",
         "SNAPSHOT_DELAY_SECONDS": "0",
         "SOCKET_TIMEOUT_SECONDS": "1",
     }
@@ -1427,6 +1447,14 @@ def test_pypi_classifier_emits_closed_state_machine_from_remote_bytes(
         "downloaded-bytes",
         "inconsistent-snapshots",
         "malformed-json",
+        "partial-metadata-hash",
+        "partial-advertised-host",
+        "partial-downloaded-bytes",
+        "partial-redirect-host",
+        "extra-metadata-hash",
+        "extra-downloaded-bytes",
+        "index-redirect-host",
+        "index-redirect-absent",
     ],
 )
 def test_pypi_classifier_never_publishes_untrusted_or_unstable_evidence(
@@ -1437,19 +1465,31 @@ def test_pypi_classifier_never_publishes_untrusted_or_unstable_evidence(
     """Weakening host/hash/byte/snapshot checks can misclassify occupied PyPI as absent."""
     base_url, server = package_index_server
     files, payload = _prepare_index_case(tmp_path, base_url, server)
+    localhost_base = base_url.replace("127.0.0.1", "localhost")
     expected = "MISMATCH"
+    if mutation.startswith("partial-"):
+        payload["urls"] = payload["urls"][:1]
+    elif mutation.startswith("extra-"):
+        payload["urls"].append(
+            {
+                "digests": {"sha256": hashlib.sha256(b"extra").hexdigest()},
+                "filename": "pylxpweb-1.2.3.zip",
+                "url": f"{base_url}/files/pylxpweb-1.2.3.zip",
+                "yanked": False,
+            }
+        )
     if mutation == "advertised-host":
         payload["urls"][0]["url"] = payload["urls"][0]["url"].replace("127.0.0.1", "localhost")
-    elif mutation == "redirect-host":
+    elif mutation in {"redirect-host", "partial-redirect-host"}:
         name = payload["urls"][0]["filename"]
         server["redirected_files"][name] = files[name]
-        server["files"][name] = {
-            "redirect": f"{base_url.replace('127.0.0.1', 'localhost')}/redirected/{name}"
-        }
-    elif mutation == "metadata-hash":
+        server["files"][name] = {"redirect": f"{localhost_base}/redirected/{name}"}
+    elif mutation in {"metadata-hash", "partial-metadata-hash", "extra-metadata-hash"}:
         payload["urls"][0]["digests"]["sha256"] = "0" * 64
-    elif mutation == "downloaded-bytes":
+    elif mutation in {"downloaded-bytes", "partial-downloaded-bytes", "extra-downloaded-bytes"}:
         server["files"][payload["urls"][0]["filename"]] = b"tampered"
+    elif mutation == "partial-advertised-host":
+        payload["urls"][0]["url"] = payload["urls"][0]["url"].replace("127.0.0.1", "localhost")
     elif mutation == "inconsistent-snapshots":
         changed = json.loads(json.dumps(payload))
         changed["urls"][0]["yanked"] = True
@@ -1457,6 +1497,15 @@ def test_pypi_classifier_never_publishes_untrusted_or_unstable_evidence(
         expected = "UNCERTAIN"
     elif mutation == "malformed-json":
         server["index_responses"] = ["not-an-object", "not-an-object"]
+        expected = "UNCERTAIN"
+    elif mutation == "index-redirect-host":
+        server["redirected_index"] = payload
+        redirect = {"redirect": f"{localhost_base}/redirected-index"}
+        server["index_responses"] = [redirect, redirect]
+        expected = "UNCERTAIN"
+    elif mutation == "index-redirect-absent":
+        redirect = {"redirect": f"{localhost_base}/missing-index"}
+        server["index_responses"] = [redirect, redirect]
         expected = "UNCERTAIN"
     if not server["index_responses"]:
         server["index_responses"] = [payload, payload]
@@ -1628,12 +1677,12 @@ def test_production_recovery_topology_has_one_terminal_verifier() -> None:
     publish = _job("publish-pypi")
     verify = _job("verify-pypi")
     assert prepare["environment"] == "pypi"
-    assert prepare["outputs"]["state"] == "${{ steps.classify-pypi-state.outputs.state }}"
+    assert prepare["outputs"]["state"] == "${{ steps.resolve-prepare-state.outputs.state }}"
     assert _step("prepare-pypi", "stage")["if"] == (
-        "steps.classify-pypi-state.outputs.state == 'ABSENT'"
+        "steps.resolve-prepare-state.outputs.state == 'ABSENT'"
     )
     assert _step("prepare-pypi", "upload-staging-artifact")["if"] == (
-        "steps.classify-pypi-state.outputs.state == 'ABSENT'"
+        "steps.resolve-prepare-state.outputs.state == 'ABSENT'"
     )
     assert publish["if"] == "needs.prepare-pypi.outputs.state == 'ABSENT'"
     assert publish["needs"] == "prepare-pypi"
@@ -1650,6 +1699,107 @@ def test_production_recovery_topology_has_one_terminal_verifier() -> None:
     assert terminal["env"]["STATE"] == "${{ steps.classify-pypi-state.outputs.state }}"
     assert "EXACT_COMPLETE" in terminal["run"]
     assert not any("continue-on-error" in step for step in publish["steps"])
+
+
+_PREPARE_EVIDENCE_STEPS = (
+    "resolve-release-artifact",
+    "download-release-artifact",
+    "verify-release-bundle",
+    "classify-pypi-state",
+)
+
+
+def test_prepare_evidence_failures_funnel_into_uncertain_not_job_failure() -> None:
+    """A hard prepare failure skips the terminal verifier and hides a lost upload."""
+    for step_id in _PREPARE_EVIDENCE_STEPS:
+        assert _step("prepare-pypi", step_id).get("continue-on-error") is True
+    assert _step("prepare-pypi", "download-release-artifact")["if"] == (
+        "steps.resolve-release-artifact.outcome == 'success'"
+    )
+    assert _step("prepare-pypi", "verify-release-bundle")["if"] == (
+        "steps.download-release-artifact.outcome == 'success'"
+    )
+    assert _step("prepare-pypi", "classify-pypi-state")["if"] == (
+        "steps.verify-release-bundle.outcome == 'success'"
+    )
+    resolver = _step("prepare-pypi", "resolve-prepare-state")
+    assert "if" not in resolver
+    assert "continue-on-error" not in resolver
+    assert resolver["env"]["CLASSIFY_OUTCOME"] == "${{ steps.classify-pypi-state.outcome }}"
+    # The terminal verifier must keep failing hard on the same evidence.
+    for step_id in _PREPARE_EVIDENCE_STEPS:
+        verify_step = _step("verify-pypi", step_id)
+        assert "continue-on-error" not in verify_step
+        assert "if" not in verify_step
+    verify_step_ids = [step.get("id") for step in _job("verify-pypi")["steps"]]
+    assert "resolve-prepare-state" not in verify_step_ids
+
+
+def _run_prepare_state_resolver(
+    tmp_path: Path, outcomes: dict[str, str]
+) -> tuple[subprocess.CompletedProcess[str], str, str]:
+    output = tmp_path / "resolver-output"
+    summary = tmp_path / "resolver-summary"
+    env = os.environ | {
+        "CLASSIFIED_REASON": "",
+        "CLASSIFIED_STATE": "",
+        "CLASSIFY_OUTCOME": "skipped",
+        "DOWNLOAD_OUTCOME": "success",
+        "GITHUB_OUTPUT": str(output),
+        "GITHUB_STEP_SUMMARY": str(summary),
+        "RESOLVE_OUTCOME": "success",
+        "VERIFY_OUTCOME": "success",
+    }
+    env.update(outcomes)
+    result = _run_yaml_script(
+        _step("prepare-pypi", "resolve-prepare-state")["run"],
+        cwd=tmp_path,
+        env=env,
+        tmp_path=tmp_path,
+        timeout_seconds=15,
+    )
+    state = _read_output(output, "state") if output.exists() else ""
+    reason = _read_output(output, "reason") if output.exists() else ""
+    return result, state, reason
+
+
+@pytest.mark.parametrize(
+    "outcomes",
+    [
+        {"RESOLVE_OUTCOME": "failure"},
+        {"DOWNLOAD_OUTCOME": "failure"},
+        {"VERIFY_OUTCOME": "failure"},
+        {"CLASSIFY_OUTCOME": "failure"},
+        {"CLASSIFY_OUTCOME": "skipped"},
+        {"CLASSIFY_OUTCOME": "success"},  # succeeded but emitted no state
+    ],
+)
+def test_prepare_state_resolver_reports_uncertain_for_missing_evidence(
+    tmp_path: Path, outcomes: dict[str, str]
+) -> None:
+    """Terminating prepare on evidence failure would skip the sole terminal verifier."""
+    result, state, reason = _run_prepare_state_resolver(tmp_path, outcomes)
+    assert result.returncode == 0, result.stderr
+    assert state == "UNCERTAIN"
+    assert reason
+
+
+@pytest.mark.parametrize("classified_state", ["ABSENT", "EXACT_COMPLETE", "PARTIAL", "UNCERTAIN"])
+def test_prepare_state_resolver_passes_through_classified_states(
+    tmp_path: Path, classified_state: str
+) -> None:
+    """The resolver must not invent, drop, or rewrite a genuine classification."""
+    result, state, reason = _run_prepare_state_resolver(
+        tmp_path,
+        {
+            "CLASSIFY_OUTCOME": "success",
+            "CLASSIFIED_STATE": classified_state,
+            "CLASSIFIED_REASON": "classifier evidence reason",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert state == classified_state
+    assert reason == "classifier evidence reason"
 
 
 @pytest.mark.parametrize(
@@ -1692,6 +1842,17 @@ def test_production_classifier_worst_case_fits_verifier_timeout() -> None:
     assert "signal.setitimer" in _step("verify-pypi", "classify-pypi-state")["run"]
 
 
+def test_production_classifier_pins_https_pypi_index_origin() -> None:
+    """An off-origin index redirect could impersonate absence and trigger a republish."""
+    for job_id in ("prepare-pypi", "verify-pypi"):
+        env = _step(job_id, "classify-pypi-state")["env"]
+        assert env["INDEX_JSON_BASE"] == "https://pypi.org/pypi"
+        assert env["ALLOWED_INDEX_HOST"] == "pypi.org"
+        assert env["REQUIRED_INDEX_SCHEME"] == "https"
+        assert env["ALLOWED_FILE_HOST"] == "files.pythonhosted.org"
+        assert env["REQUIRED_FILE_SCHEME"] == "https"
+
+
 def test_prepare_and_verifier_share_artifact_and_remote_evidence_scripts() -> None:
     """Divergent recovery verification can bless evidence normal verification rejects."""
     assert (
@@ -1726,10 +1887,16 @@ def test_only_absent_state_can_reach_action_only_production_publisher() -> None:
         and job.get("environment") == "pypi"
     ]
     assert production_oidc == ["publish-pypi"]
-    assert not any(
-        "continue-on-error" in job or any("continue-on-error" in step for step in job["steps"])
-        for job in workflow["jobs"].values()
-    )
+    assert not any("continue-on-error" in job for job in workflow["jobs"].values())
+    tolerated = [
+        (job_id, step.get("id"))
+        for job_id, job in workflow["jobs"].items()
+        for step in job["steps"]
+        if "continue-on-error" in step
+    ]
+    # Only prepare-pypi evidence steps may tolerate failure: they funnel into an
+    # UNCERTAIN prepare result so the sole terminal verifier still runs and fails.
+    assert tolerated == [("prepare-pypi", step_id) for step_id in _PREPARE_EVIDENCE_STEPS]
 
 
 def test_all_release_actions_are_immutable_full_sha_pins() -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -37,8 +37,11 @@ _PACKAGE_INDEX_PUBLISHER = re.compile(
 _BINDING_TIMEOUT_SECONDS = 15.0
 _SUBPROCESS_WALL_MULTIPLIER = 20.0
 _SUBPROCESS_TAIL_BYTES = 1 << 20
+_SUBPROCESS_READER_JOIN_SECONDS = 2.0
+# The terminator must be a whole ``PY`` line: without the lookahead a body line
+# merely *starting* with ``PY`` would silently truncate the materialized script.
 _PYTHON_HEREDOC = re.compile(
-    r"python3 -(?P<args>[^\n]*(?:\\\n[^\n]*)*) <<'PY'\n(?P<body>.*?)\nPY",
+    r"python3 -(?P<args>[^\n]*(?:\\\n[^\n]*)*) <<'PY'\n(?P<body>.*?)\nPY(?=\n|$)",
     re.DOTALL,
 )
 
@@ -470,23 +473,28 @@ def _run_bounded_subprocess(
     last_progress = [started]
 
     def drain(stream: IO[bytes], key: str) -> None:
-        while chunk := os.read(stream.fileno(), 65536):
-            captured[key].append(chunk)
-            retained[key] += len(chunk)
-            while retained[key] > capture_tail_bytes and len(captured[key]) > 1:
-                oldest = captured[key].popleft()
-                retained[key] -= len(oldest)
-                dropped[key] += len(oldest)
-            if retained[key] > capture_tail_bytes:
-                excess = retained[key] - capture_tail_bytes
-                captured[key][0] = captured[key][0][excess:]
-                retained[key] -= excess
-                dropped[key] += excess
-            last_progress[0] = time.monotonic()
+        # OSError/ValueError terminate the drain when the parent closes the
+        # read end from under a reader blocked on a pipe an escaped descendant
+        # still holds open.
+        fd = stream.fileno()
+        with suppress(OSError, ValueError):
+            while chunk := os.read(fd, 65536):
+                captured[key].append(chunk)
+                retained[key] += len(chunk)
+                while retained[key] > capture_tail_bytes and len(captured[key]) > 1:
+                    oldest = captured[key].popleft()
+                    retained[key] -= len(oldest)
+                    dropped[key] += len(oldest)
+                if retained[key] > capture_tail_bytes:
+                    excess = retained[key] - capture_tail_bytes
+                    captured[key][0] = captured[key][0][excess:]
+                    retained[key] -= excess
+                    dropped[key] += excess
+                last_progress[0] = time.monotonic()
 
     readers = [
-        threading.Thread(target=drain, args=(stdout_pipe, "stdout")),
-        threading.Thread(target=drain, args=(stderr_pipe, "stderr")),
+        threading.Thread(target=drain, args=(stdout_pipe, "stdout"), daemon=True),
+        threading.Thread(target=drain, args=(stderr_pipe, "stderr"), daemon=True),
     ]
     for reader in readers:
         reader.start()
@@ -515,8 +523,22 @@ def _run_bounded_subprocess(
             os.killpg(process.pid, signal.SIGKILL)
         raise
     finally:
+        # A descendant that re-setsid'd or double-forked survives the group
+        # SIGKILL and keeps the captured pipes open, so joins must be bounded
+        # or pytest hangs despite both deadlines. On expiry, close the
+        # parent's read ends to force the drains to EOF/EBADF, then join once
+        # more; the readers are daemon threads so a reader stuck in a blocked
+        # read can never block interpreter exit.
+        deadline = time.monotonic() + _SUBPROCESS_READER_JOIN_SECONDS
         for reader in readers:
-            reader.join()
+            reader.join(timeout=max(0.0, deadline - time.monotonic()))
+        if any(reader.is_alive() for reader in readers):
+            for pipe in (stdout_pipe, stderr_pipe):
+                with suppress(OSError):
+                    pipe.close()
+            deadline = time.monotonic() + _SUBPROCESS_READER_JOIN_SECONDS
+            for reader in readers:
+                reader.join(timeout=max(0.0, deadline - time.monotonic()))
         stdout_pipe.close()
         stderr_pipe.close()
         returncode = process.wait()
@@ -601,6 +623,19 @@ def _run_binding(
     )
 
 
+def _assert_reader_threads_settled(threads_before: int) -> None:
+    """Reader threads must wind down after the harness returns.
+
+    Uses a bounded retry and a ``<=`` comparison instead of exact equality:
+    unrelated interpreter threads can start or stop under load, and exact
+    ``threading.active_count()`` equality is flaky on loaded CI runners.
+    """
+    deadline = time.monotonic() + 5.0
+    while threading.active_count() > threads_before and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert threading.active_count() <= threads_before
+
+
 def test_bounded_subprocess_terminates_entire_child_group(tmp_path: Path) -> None:
     """A timed-out shell must not leave descendants holding captured pipes open."""
     started = time.monotonic()
@@ -614,23 +649,64 @@ def test_bounded_subprocess_terminates_entire_child_group(tmp_path: Path) -> Non
     assert time.monotonic() - started < 2
 
 
+def test_bounded_subprocess_join_stays_bounded_when_descendant_escapes_group(
+    tmp_path: Path,
+) -> None:
+    """A re-setsid'd descendant surviving the group SIGKILL cannot hang pytest.
+
+    The escaped child inherits the captured pipes and keeps them open for 30
+    seconds after the group is killed, so an unbounded ``reader.join()`` would
+    block until the child exits. The harness must instead give up on the
+    readers within its bounded join budget and raise the timeout promptly.
+    """
+    escaped = (
+        f"{shlex.quote(sys.executable)} -c "
+        '"import os, time; os.setsid(); time.sleep(30)" & sleep 30'
+    )
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        _run_bounded_subprocess(
+            ["bash", "-c", escaped],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=0.3,
+        )
+    assert time.monotonic() - started < 15
+
+
+def test_heredoc_materialization_keeps_body_lines_starting_with_py(tmp_path: Path) -> None:
+    """A heredoc body line starting with ``PY`` is body, not the terminator.
+
+    Without a line-anchored terminator the materialized script is silently
+    truncated at the first ``PY``-prefixed body line and the sync assertions
+    in ``_materialize_python_heredocs`` cannot catch it.
+    """
+    script = "python3 - <<'PY'\nx = 1\nPY_MARKER = 2\nprint(x + PY_MARKER)\nPY\n"
+    materialized = _materialize_python_heredocs(script, tmp_path)
+    body_path = tmp_path / "yaml-script" / "heredoc-0.py"
+    assert body_path.read_text() == "x = 1\nPY_MARKER = 2\nprint(x + PY_MARKER)\n"
+    assert "PY_MARKER" not in materialized
+
+
 def test_bounded_subprocess_tolerates_slow_but_progressing_child(tmp_path: Path) -> None:
     """The deadline bounds silence, not total runtime.
 
     A child whose output gaps stay under the deadline must run to completion
     even when its total runtime exceeds the deadline several times over, and
-    the harness must not leave reader threads behind afterwards.
+    the harness must not leave reader threads behind afterwards. The 1-second
+    silence deadline leaves ~20x margin over the 0.05-second cadence so a
+    loaded CI runner cannot stretch one gap past the deadline.
     """
     threads_before = threading.active_count()
     result = _run_bounded_subprocess(
-        ["bash", "-c", 'for i in $(seq 20); do echo "tick $i"; sleep 0.05; done'],
+        ["bash", "-c", 'for i in $(seq 60); do echo "tick $i"; sleep 0.05; done'],
         cwd=tmp_path,
         env=os.environ.copy(),
-        timeout_seconds=0.3,
+        timeout_seconds=1.0,
     )
     assert result.returncode == 0
-    assert result.stdout.splitlines() == [f"tick {i}" for i in range(1, 21)]
-    assert threading.active_count() == threads_before
+    assert result.stdout.splitlines() == [f"tick {i}" for i in range(1, 61)]
+    _assert_reader_threads_settled(threads_before)
 
 
 def test_bounded_subprocess_kills_child_that_stops_progressing(tmp_path: Path) -> None:
@@ -646,7 +722,7 @@ def test_bounded_subprocess_kills_child_that_stops_progressing(tmp_path: Path) -
         )
     assert time.monotonic() - started < 2
     assert "made progress" in (excinfo.value.output or "")
-    assert threading.active_count() == threads_before
+    _assert_reader_threads_settled(threads_before)
 
 
 def test_bounded_subprocess_enforces_wall_deadline_despite_progress(tmp_path: Path) -> None:
@@ -664,7 +740,7 @@ def test_bounded_subprocess_enforces_wall_deadline_despite_progress(tmp_path: Pa
     assert time.monotonic() - started < 3
     assert excinfo.value.timeout == 0.4
     assert "still alive" in (excinfo.value.output or "")
-    assert threading.active_count() == threads_before
+    _assert_reader_threads_settled(threads_before)
 
 
 def test_bounded_subprocess_default_wall_deadline_is_finite() -> None:
@@ -2029,17 +2105,97 @@ def test_terminal_verifier_succeeds_only_for_exact_complete(state: str, tmp_path
 
 
 def test_production_classifier_worst_case_fits_verifier_timeout() -> None:
-    """Two snapshots and both byte downloads leave at least five minutes of headroom."""
+    """Bounded ABSENT rechecks and both byte downloads leave five minutes of headroom."""
     job = _job("verify-pypi")
     env = _step("verify-pypi", "classify-pypi-state")["env"]
+    attempts = int(env["ABSENT_RECHECK_MAX_ATTEMPTS"])
+    retry_base = int(env["ABSENT_RECHECK_BASE_SECONDS"])
+    snapshot_pair = 2 * int(env["INDEX_TOTAL_SECONDS"]) + int(env["SNAPSHOT_DELAY_SECONDS"])
+    backoff = sum(min(recheck * retry_base, 30) for recheck in range(1, attempts))
     classifier_worst_case = (
-        2 * int(env["INDEX_TOTAL_SECONDS"])
-        + 2 * int(env["DOWNLOAD_TOTAL_SECONDS"])
-        + int(env["SNAPSHOT_DELAY_SECONDS"])
+        attempts * snapshot_pair + backoff + 2 * int(env["DOWNLOAD_TOTAL_SECONDS"])
     )
     assert int(job["timeout-minutes"]) * 60 - classifier_worst_case >= 300
     assert int(env["SOCKET_TIMEOUT_SECONDS"]) < int(env["INDEX_TOTAL_SECONDS"])
     assert "signal.setitimer" in _step("verify-pypi", "classify-pypi-state")["run"]
+    prepare_env = _step("prepare-pypi", "classify-pypi-state")["env"]
+    prepare_worst_case = snapshot_pair + 2 * int(prepare_env["DOWNLOAD_TOTAL_SECONDS"])
+    assert int(_job("prepare-pypi")["timeout-minutes"]) * 60 - prepare_worst_case >= 300
+
+
+def test_verify_pypi_retries_absent_but_prepare_classifies_once() -> None:
+    """Prepare must keep single-pass semantics; only terminal verification retries.
+
+    A retrying prepare could wait out genuine absence differently than the
+    reviewed publish gate expects, while a non-retrying terminal verifier fails
+    the happy path on routine PyPI index-propagation lag after publish-pypi.
+    """
+    prepare_env = _step("prepare-pypi", "classify-pypi-state")["env"]
+    verify_env = _step("verify-pypi", "classify-pypi-state")["env"]
+    assert int(prepare_env["ABSENT_RECHECK_MAX_ATTEMPTS"]) == 1
+    assert int(verify_env["ABSENT_RECHECK_MAX_ATTEMPTS"]) > 1
+    assert int(verify_env["ABSENT_RECHECK_BASE_SECONDS"]) > 0
+    # The retry knob is the only permitted divergence between the two envs.
+    divergent = {
+        key
+        for key in prepare_env.keys() | verify_env.keys()
+        if prepare_env.get(key) != verify_env.get(key)
+    }
+    assert divergent == {"ABSENT_RECHECK_MAX_ATTEMPTS", "ABSENT_RECHECK_BASE_SECONDS"}
+
+
+def test_pypi_classifier_rechecks_absent_within_bounded_attempts(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+) -> None:
+    """An ABSENT snapshot pair is re-taken until stable evidence appears."""
+    base_url, server = package_index_server
+    _, payload = _prepare_index_case(tmp_path, base_url, server)
+    server["index_responses"] = [404, 404, 404, 404, payload, payload]
+    result, state = _run_pypi_classifier(
+        tmp_path,
+        base_url,
+        env_overrides={
+            "ABSENT_RECHECK_MAX_ATTEMPTS": "5",
+            "ABSENT_RECHECK_BASE_SECONDS": "0",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert state == "EXACT_COMPLETE"
+    assert server["index_calls"] == 6
+
+
+@pytest.mark.parametrize(
+    ("responses", "expected_state", "expected_calls"),
+    [
+        # Persistent absence exhausts the bounded budget and stays ABSENT.
+        ([404, 404, 404, 404, 404, 404], "ABSENT", 6),
+        # Snapshot instability is UNCERTAIN and must not consume retry budget.
+        ([404, "payload", 404, 404], "UNCERTAIN", 2),
+    ],
+)
+def test_pypi_classifier_absent_recheck_is_bounded_and_absent_only(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+    responses: list[Any],
+    expected_state: str,
+    expected_calls: int,
+) -> None:
+    """Only a stable ABSENT pair retries; the per-attempt stability rule survives."""
+    base_url, server = package_index_server
+    _, payload = _prepare_index_case(tmp_path, base_url, server)
+    server["index_responses"] = [payload if item == "payload" else item for item in responses]
+    result, state = _run_pypi_classifier(
+        tmp_path,
+        base_url,
+        env_overrides={
+            "ABSENT_RECHECK_MAX_ATTEMPTS": "3",
+            "ABSENT_RECHECK_BASE_SECONDS": "0",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert state == expected_state
+    assert server["index_calls"] == expected_calls
 
 
 def test_production_classifier_pins_https_pypi_index_origin() -> None:
@@ -2097,6 +2253,55 @@ def test_only_absent_state_can_reach_action_only_production_publisher() -> None:
     # Only prepare-pypi evidence steps may tolerate failure: they funnel into an
     # UNCERTAIN prepare result so the sole terminal verifier still runs and fails.
     assert tolerated == [("prepare-pypi", step_id) for step_id in _PREPARE_EVIDENCE_STEPS]
+
+
+# CI-only artifact-action contract facts, verified 2026-08-18 against the pinned
+# actions' committed sources (evidence, including the verified file hashes, lives
+# in .github/WORKFLOWS.md under "Pinned artifact-action contract evidence"):
+# - actions/download-artifact `action.yml` declares the `digest-mismatch` input
+#   (unknown action inputs are silently ignored, so existence at the exact pin is
+#   load-bearing) and `src/download-artifact.ts` selects `resolvedPath` whenever
+#   `artifacts.length === 1`, so a single-`artifact-ids` download extracts flat
+#   into `path:`, not into a per-artifact subdirectory.
+# - actions/upload-artifact `action.yml` declares the `artifact-digest` output and
+#   `src/shared/upload-artifact.ts` emits the toolkit's bare-hex SHA-256 (no
+#   `sha256:` prefix), matching the workflow's `[0-9a-f]{64}` fullmatch.
+_VERIFIED_ARTIFACT_ACTION_CONTRACTS = {
+    "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c": (
+        "e98559b7a31ba31be4709f20d22102dc2737fa630f69a339eb89981151e505fe"
+    ),
+    "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a": (
+        "c5979822866a72362e609844b6ebe77d4b7e759af68cc1c2c425dcf51481fab4"
+    ),
+}
+
+
+def test_artifact_action_pins_match_recorded_contract_verification() -> None:
+    """Every artifact-action pin must carry recorded contract evidence.
+
+    Bumping either pin invalidates the recorded verification of the CI-only
+    contract facts above, so the new SHA must be re-verified and both this map
+    and the WORKFLOWS.md evidence note updated before the pin can land.
+    """
+    used = {
+        step["uses"]
+        for job in _workflow()["jobs"].values()
+        for step in job["steps"]
+        if step.get("uses", "").split("@")[0]
+        in {"actions/download-artifact", "actions/upload-artifact"}
+    }
+    assert used == set(_VERIFIED_ARTIFACT_ACTION_CONTRACTS)
+    evidence = (_ROOT / ".github" / "WORKFLOWS.md").read_text()
+    for pin, action_yml_sha256 in _VERIFIED_ARTIFACT_ACTION_CONTRACTS.items():
+        assert pin.split("@")[1] in evidence
+        assert action_yml_sha256 in evidence
+    # The digest binding only holds if every by-id download opts into hard failure.
+    for job in _workflow()["jobs"].values():
+        for step in job["steps"]:
+            if "download-artifact@" in step.get("uses", ""):
+                with_options = step.get("with", {})
+                if "artifact-ids" in with_options:
+                    assert with_options["digest-mismatch"] == "error"
 
 
 def test_all_release_actions_are_immutable_full_sha_pins() -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -436,6 +436,47 @@ def _release_repo(
     }
 
 
+# Pipes whose reader threads were abandoned are parked here for the life of the
+# process instead of being closed: closing them would free the fd numbers for
+# reuse while a zombie reader could still loop, letting it read an unrelated
+# later file that happened to receive the recycled fd number.
+_ABANDONED_PIPES: list[IO[bytes]] = []
+
+
+def _drain_pipe(
+    fd: int,
+    key: str,
+    captured: dict[str, deque[bytes]],
+    retained: dict[str, int],
+    dropped: dict[str, int],
+    capture_tail_bytes: int,
+    last_progress: list[float],
+    abandoned: threading.Event,
+) -> None:
+    """Drain one captured pipe into a bounded tail until EOF or abandonment.
+
+    The abandon event is checked before every read: once the harness gives up
+    on this reader it must never issue another ``os.read``, because the fd
+    number could otherwise be recycled to an unrelated file whose bytes a
+    still-looping zombie reader would steal. OSError also ends the drain when
+    the abandoning thread switches the fd to non-blocking (EAGAIN).
+    """
+    with suppress(OSError, ValueError):
+        while not abandoned.is_set() and (chunk := os.read(fd, 65536)):
+            captured[key].append(chunk)
+            retained[key] += len(chunk)
+            while retained[key] > capture_tail_bytes and len(captured[key]) > 1:
+                oldest = captured[key].popleft()
+                retained[key] -= len(oldest)
+                dropped[key] += len(oldest)
+            if retained[key] > capture_tail_bytes:
+                excess = retained[key] - capture_tail_bytes
+                captured[key][0] = captured[key][0][excess:]
+                retained[key] -= excess
+                dropped[key] += excess
+            last_progress[0] = time.monotonic()
+
+
 def _run_bounded_subprocess(
     args: list[str],
     *,
@@ -471,30 +512,24 @@ def _run_bounded_subprocess(
     dropped = {"stdout": 0, "stderr": 0}
     started = time.monotonic()
     last_progress = [started]
-
-    def drain(stream: IO[bytes], key: str) -> None:
-        # OSError/ValueError terminate the drain when the parent closes the
-        # read end from under a reader blocked on a pipe an escaped descendant
-        # still holds open.
-        fd = stream.fileno()
-        with suppress(OSError, ValueError):
-            while chunk := os.read(fd, 65536):
-                captured[key].append(chunk)
-                retained[key] += len(chunk)
-                while retained[key] > capture_tail_bytes and len(captured[key]) > 1:
-                    oldest = captured[key].popleft()
-                    retained[key] -= len(oldest)
-                    dropped[key] += len(oldest)
-                if retained[key] > capture_tail_bytes:
-                    excess = retained[key] - capture_tail_bytes
-                    captured[key][0] = captured[key][0][excess:]
-                    retained[key] -= excess
-                    dropped[key] += excess
-                last_progress[0] = time.monotonic()
+    abandoned = threading.Event()
 
     readers = [
-        threading.Thread(target=drain, args=(stdout_pipe, "stdout"), daemon=True),
-        threading.Thread(target=drain, args=(stderr_pipe, "stderr"), daemon=True),
+        threading.Thread(
+            target=_drain_pipe,
+            args=(
+                pipe.fileno(),
+                key,
+                captured,
+                retained,
+                dropped,
+                capture_tail_bytes,
+                last_progress,
+                abandoned,
+            ),
+            daemon=True,
+        )
+        for pipe, key in ((stdout_pipe, "stdout"), (stderr_pipe, "stderr"))
     ]
     for reader in readers:
         reader.start()
@@ -525,22 +560,33 @@ def _run_bounded_subprocess(
     finally:
         # A descendant that re-setsid'd or double-forked survives the group
         # SIGKILL and keeps the captured pipes open, so joins must be bounded
-        # or pytest hangs despite both deadlines. On expiry, close the
-        # parent's read ends to force the drains to EOF/EBADF, then join once
-        # more; the readers are daemon threads so a reader stuck in a blocked
-        # read can never block interpreter exit.
+        # or pytest hangs despite both deadlines. On join expiry the readers
+        # are abandoned, never woken by force: close() from this thread would
+        # not interrupt a reader blocked in os.read (the syscall holds the old
+        # file description) and would free the fd numbers for reuse, letting a
+        # still-looping reader steal bytes from an unrelated later file. So
+        # instead the abandon event guarantees no reader issues a new os.read,
+        # the fds are switched to non-blocking so a not-yet-blocked read fails
+        # fast, and the pipe objects are parked module-globally, never closed,
+        # so their fd numbers cannot be recycled. A reader already blocked in
+        # os.read may stay blocked; the daemon flag plus the bounded joins are
+        # the backstop that keeps pytest exit and this harness prompt.
         deadline = time.monotonic() + _SUBPROCESS_READER_JOIN_SECONDS
         for reader in readers:
             reader.join(timeout=max(0.0, deadline - time.monotonic()))
         if any(reader.is_alive() for reader in readers):
+            abandoned.set()
             for pipe in (stdout_pipe, stderr_pipe):
-                with suppress(OSError):
-                    pipe.close()
+                with suppress(OSError, ValueError):
+                    os.set_blocking(pipe.fileno(), False)
             deadline = time.monotonic() + _SUBPROCESS_READER_JOIN_SECONDS
             for reader in readers:
                 reader.join(timeout=max(0.0, deadline - time.monotonic()))
-        stdout_pipe.close()
-        stderr_pipe.close()
+        if any(reader.is_alive() for reader in readers):
+            _ABANDONED_PIPES.extend((stdout_pipe, stderr_pipe))
+        else:
+            stdout_pipe.close()
+            stderr_pipe.close()
         returncode = process.wait()
     if expired_deadline is not None:
         raise subprocess.TimeoutExpired(
@@ -672,6 +718,41 @@ def test_bounded_subprocess_join_stays_bounded_when_descendant_escapes_group(
             timeout_seconds=0.3,
         )
     assert time.monotonic() - started < 15
+
+
+def test_drain_pipe_never_issues_a_read_once_abandoned() -> None:
+    """An abandoned drain must not touch its fd again, even with bytes pending.
+
+    After the harness abandons a reader, its fd number must be treated as
+    poisoned: one more ``os.read`` from a zombie reader could consume bytes
+    from an unrelated file if the number were ever recycled. The abandon event
+    is therefore checked before every read, so a drain entered (or resumed)
+    after abandonment returns without consuming the pending bytes.
+    """
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, b"pending bytes")
+        os.close(write_fd)
+        write_fd = -1
+        captured: dict[str, deque[bytes]] = {"stdout": deque()}
+        abandoned = threading.Event()
+        abandoned.set()
+        _drain_pipe(
+            read_fd,
+            "stdout",
+            captured,
+            {"stdout": 0},
+            {"stdout": 0},
+            _SUBPROCESS_TAIL_BYTES,
+            [time.monotonic()],
+            abandoned,
+        )
+        assert not captured["stdout"]
+        assert os.read(read_fd, 65536) == b"pending bytes"
+    finally:
+        os.close(read_fd)
+        if write_fd != -1:
+            os.close(write_fd)
 
 
 def test_heredoc_materialization_keeps_body_lines_starting_with_py(tmp_path: Path) -> None:

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -7,12 +7,15 @@ import http.server
 import json
 import os
 import re
+import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import threading
 import time
 from collections.abc import Iterator
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +32,11 @@ _PACKAGE_INDEX_PUBLISHER = re.compile(
     r"https://(?:(?:test|upload)\.)?pypi\.org/legacy/|"
     r"\b(?:twine\s+upload|(?:uv|poetry|hatch|flit|pdm)\s+publish)\b",
     re.IGNORECASE,
+)
+_BINDING_TIMEOUT_SECONDS = 15.0
+_PYTHON_HEREDOC = re.compile(
+    r"python3 -(?P<args>[^\n]*(?:\\\n[^\n]*)*) <<'PY'\n(?P<body>.*?)\nPY",
+    re.DOTALL,
 )
 
 
@@ -205,13 +213,12 @@ def _run_index_verifier(
         "SOCKET_TIMEOUT_SECONDS": "1",
     }
     env.update(env_overrides or {})
-    return subprocess.run(
-        ["bash", "-c", _step(job_id, f"verify-{job_id.removeprefix('verify-')}-files")["run"]],
+    return _run_yaml_script(
+        _step(job_id, f"verify-{job_id.removeprefix('verify-')}-files")["run"],
         cwd=tmp_path,
         env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=15,
     )
 
 
@@ -405,6 +412,68 @@ def _release_repo(
     }
 
 
+def _run_bounded_subprocess(
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout_seconds: float,
+) -> subprocess.CompletedProcess[str]:
+    process = subprocess.Popen(
+        args,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        close_fds=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except BaseException:
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.communicate()
+        raise
+    return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+
+
+def _materialize_python_heredocs(script: str, tmp_path: Path) -> str:
+    script_dir = tmp_path / "yaml-script"
+    script_dir.mkdir(exist_ok=True)
+    heredoc_count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal heredoc_count
+        body_path = script_dir / f"heredoc-{heredoc_count}.py"
+        heredoc_count += 1
+        body_path.write_text(match.group("body") + "\n")
+        return f"python3 {shlex.quote(str(body_path))}{match.group('args')}"
+
+    materialized = _PYTHON_HEREDOC.sub(replace, script)
+    assert heredoc_count == script.count("<<'PY'")
+    assert "<<'PY'" not in materialized
+    return materialized
+
+
+def _run_yaml_script(
+    script: str,
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    tmp_path: Path,
+    timeout_seconds: float,
+) -> subprocess.CompletedProcess[str]:
+    return _run_bounded_subprocess(
+        ["bash", "-c", _materialize_python_heredocs(script, tmp_path)],
+        cwd=cwd,
+        env=env,
+        timeout_seconds=timeout_seconds,
+    )
+
+
 def _run_binding(
     case: dict[str, Any], tmp_path: Path, **env_overrides: str
 ) -> subprocess.CompletedProcess[str]:
@@ -422,6 +491,9 @@ def _run_binding(
         "GITHUB_OUTPUT": str(output),
         "GITHUB_STEP_SUMMARY": str(summary),
         "GH_FIXTURES": str(fixtures_path),
+        "GH_PROMPT_DISABLED": "1",
+        "GCM_INTERACTIVE": "Never",
+        "GIT_TERMINAL_PROMPT": "0",
         "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
         "RELEASE_DRAFT": "false",
         "RELEASE_TAG": "v1.2.3",
@@ -430,14 +502,39 @@ def _run_binding(
         "WORKFLOW_SHA": case["merge"],
     }
     env.update(env_overrides)
-    return subprocess.run(
-        ["bash", "-c", _step("bind-build-attest", "bind-source")["run"]],
+    return _run_yaml_script(
+        _step("bind-build-attest", "bind-source")["run"],
         cwd=repo,
         env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=_BINDING_TIMEOUT_SECONDS,
     )
+
+
+def test_bounded_subprocess_terminates_entire_child_group(tmp_path: Path) -> None:
+    """A timed-out shell must not leave descendants holding captured pipes open."""
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        _run_bounded_subprocess(
+            ["bash", "-c", "sleep 60 & wait"],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=0.2,
+        )
+    assert time.monotonic() - started < 2
+
+
+def test_binding_harness_terminates_under_bash_52_stress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Materialized heredocs avoid the macOS Bash pipe deadlock under stress."""
+    monkeypatch.setenv("BASH_COMPAT", "52")
+    for index in range(12):
+        run_path = tmp_path / str(index)
+        run_path.mkdir()
+        case = _release_repo(run_path)
+        result = _run_binding(case, run_path)
+        assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize("lightweight", [False, True], ids=["annotated", "lightweight"])
@@ -797,13 +894,12 @@ def test_source_tree_checks_reject_mutable_build_inputs(
     else:
         repo.joinpath("build-input.py").write_text("MUTATED = True\n")
     env = os.environ | {"EXPECTED_COMMIT": case["merge"]}
-    result = subprocess.run(
-        ["bash", "-c", _step("bind-build-attest", step_id)["run"]],
+    result = _run_yaml_script(
+        _step("bind-build-attest", step_id)["run"],
         cwd=repo,
         env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=15,
     )
     assert result.returncode != 0
     assert "source tree" in result.stderr.lower()
@@ -818,13 +914,12 @@ def test_sealing_allows_only_the_expected_release_bundle(tmp_path: Path) -> None
     output.mkdir(parents=True)
     output.joinpath("expected.whl").write_bytes(b"expected output")
     env = os.environ | {"EXPECTED_COMMIT": case["merge"]}
-    result = subprocess.run(
-        ["bash", "-c", _step("bind-build-attest", "seal-source")["run"]],
+    result = _run_yaml_script(
+        _step("bind-build-attest", "seal-source")["run"],
         cwd=repo,
         env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=15,
     )
     assert result.returncode == 0, result.stderr
 
@@ -839,13 +934,12 @@ def test_sealing_rechecks_fresh_main_immediately_before_attestation(tmp_path: Pa
     subprocess.run(["git", "push", "-q", "origin", "main"], cwd=repo, check=True)
     subprocess.run(["git", "checkout", "-q", "--detach", "v1.2.3"], cwd=repo, check=True)
     env = os.environ | {"EXPECTED_COMMIT": case["merge"]}
-    result = subprocess.run(
-        ["bash", "-c", _step("bind-build-attest", "seal-source")["run"]],
+    result = _run_yaml_script(
+        _step("bind-build-attest", "seal-source")["run"],
         cwd=repo,
         env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=15,
     )
     assert result.returncode != 0
     assert "current main" in result.stderr.lower()
@@ -1025,10 +1119,20 @@ def test_bundle_validation_rejects_artifact_and_attestation_tampering(tmp_path: 
     }
     env.pop("GH_TOKEN", None)
     run = _step("prepare-testpypi", "verify-release-bundle")["run"]
-    missing_auth = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
+
+    def run_verifier(script: str) -> subprocess.CompletedProcess[str]:
+        return _run_yaml_script(
+            script,
+            cwd=tmp_path,
+            env=env,
+            tmp_path=tmp_path,
+            timeout_seconds=15,
+        )
+
+    missing_auth = run_verifier(run)
     assert missing_auth.returncode != 0
     env["GH_TOKEN"] = "scoped-test-token"
-    good = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
+    good = run_verifier(run)
     assert good.returncode == 0
     calls = (tmp_path / "gh-calls").read_text().splitlines()
     assert len(calls) == 3
@@ -1060,14 +1164,14 @@ def test_bundle_validation_rejects_artifact_and_attestation_tampering(tmp_path: 
     for label, (expected, replacement) in identity_mutations.items():
         assert expected in run, label
         mutated = run.replace(expected, replacement, 1)
-        result = subprocess.run(["bash", "-c", mutated], cwd=tmp_path, env=env, check=False)
+        result = run_verifier(mutated)
         assert result.returncode != 0, label
     wheel.write_bytes(b"tampered")
-    tampered_artifact = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
+    tampered_artifact = run_verifier(run)
     assert tampered_artifact.returncode != 0
     wheel.write_bytes(b"wheel")
     env["EXPECTED_ATTESTATION_CONTENT"] = "not-the-bundle"
-    tampered_attestation = subprocess.run(["bash", "-c", run], cwd=tmp_path, env=env, check=False)
+    tampered_attestation = run_verifier(run)
     assert tampered_attestation.returncode != 0
 
 
@@ -1435,22 +1539,12 @@ def _run_artifact_resolution(
         "REPOSITORY": "joyfulhouse/pylxpweb",
         "RUN_ID": "12345",
     }
-    run = _step("prepare-pypi", "resolve-release-artifact")["run"]
-    marker = 'python3 - "$evidence/run.json" "$evidence/artifacts.json" <<\'PY\'\n'
-    shell, python = run.split(marker, 1)
-    resolver = tmp_path / "resolve-release-artifact.py"
-    resolver.write_text(python.removesuffix("\nPY\n"))
-    script = tmp_path / "resolve-release-artifact.sh"
-    script.write_text(
-        shell + f'python3 "{resolver}" "$evidence/run.json" "$evidence/artifacts.json"\n'
-    )
-    return subprocess.run(
-        ["bash", str(script)],
+    return _run_yaml_script(
+        _step("prepare-pypi", "resolve-release-artifact")["run"],
         cwd=tmp_path,
         env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=15,
     )
 
 
@@ -1571,15 +1665,15 @@ def test_production_recovery_topology_has_one_terminal_verifier() -> None:
         "UNCERTAIN",
     ],
 )
-def test_terminal_verifier_succeeds_only_for_exact_complete(state: str) -> None:
+def test_terminal_verifier_succeeds_only_for_exact_complete(state: str, tmp_path: Path) -> None:
     """Any other successful terminal state can hide a lost or immutable partial upload."""
     step = _step("verify-pypi", "require-exact-complete")
-    result = subprocess.run(
-        ["bash", "-c", step["run"]],
+    result = _run_yaml_script(
+        step["run"],
+        cwd=_ROOT,
         env=os.environ | {"STATE": state},
-        text=True,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=15,
     )
     assert (result.returncode == 0) is (state == "EXACT_COMPLETE")
 
@@ -1710,7 +1804,13 @@ def test_build_produces_exactly_two_bit_reproducible_distributions(tmp_path: Pat
             "OUTPUT_DIR": str(output),
             "SOURCE_DATE_EPOCH": ambient_epoch,
         }
-        result = subprocess.run(["bash", "-c", script], env=env, text=True, capture_output=True)
+        result = _run_yaml_script(
+            script,
+            cwd=_ROOT,
+            env=env,
+            tmp_path=tmp_path,
+            timeout_seconds=180,
+        )
         assert result.returncode == 0, result.stderr
         files = sorted(path for path in output.iterdir() if path.is_file())
         assert sum(path.suffix == ".whl" for path in files) == 1
@@ -1748,7 +1848,13 @@ def test_build_container_rejects_wrong_backend_or_tool_version(
         "OUTPUT_DIR": str(output),
         "SOURCE_DATE_EPOCH": "1755302400",
     }
-    result = subprocess.run(["bash", "-c", script], env=env, capture_output=True, check=False)
+    result = _run_yaml_script(
+        script,
+        cwd=_ROOT,
+        env=env,
+        tmp_path=tmp_path,
+        timeout_seconds=180,
+    )
     assert result.returncode != 0
 
 
@@ -1774,10 +1880,11 @@ def test_build_container_denies_network_when_workflow_network_flag_is_mutated(
         "OUTPUT_DIR": str(output),
         "SOURCE_DATE_EPOCH": "1755302400",
     }
-    result = subprocess.run(
-        ["bash", "-c", script],
+    result = _run_yaml_script(
+        script,
+        cwd=_ROOT,
         env=env,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=180,
     )
     assert result.returncode != 0

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections import deque
 from collections.abc import Iterator
 from contextlib import suppress
 from pathlib import Path
@@ -34,6 +35,8 @@ _PACKAGE_INDEX_PUBLISHER = re.compile(
     re.IGNORECASE,
 )
 _BINDING_TIMEOUT_SECONDS = 15.0
+_SUBPROCESS_WALL_MULTIPLIER = 20.0
+_SUBPROCESS_TAIL_BYTES = 1 << 20
 _PYTHON_HEREDOC = re.compile(
     r"python3 -(?P<args>[^\n]*(?:\\\n[^\n]*)*) <<'PY'\n(?P<body>.*?)\nPY",
     re.DOTALL,
@@ -436,10 +439,17 @@ def _run_bounded_subprocess(
     cwd: Path,
     env: dict[str, str],
     timeout_seconds: float,
+    wall_timeout_seconds: float | None = None,
+    capture_tail_bytes: int = _SUBPROCESS_TAIL_BYTES,
 ) -> subprocess.CompletedProcess[str]:
-    # The deadline bounds *silence*, not total runtime: a child that keeps
-    # writing to either captured pipe stays alive, while one that produces no
-    # output for timeout_seconds is killed with its whole process group.
+    # Two independent deadlines: timeout_seconds bounds *silence* (a child that
+    # keeps writing to either captured pipe stays alive), wall_timeout_seconds
+    # bounds *total runtime* even while output keeps arriving. Either firing
+    # kills the whole process group. Captured output is a bounded tail: only
+    # the most recent capture_tail_bytes per stream are retained, with a
+    # truncation notice when earlier bytes were dropped.
+    if wall_timeout_seconds is None:
+        wall_timeout_seconds = timeout_seconds * _SUBPROCESS_WALL_MULTIPLIER
     process = subprocess.Popen(
         args,
         cwd=cwd,
@@ -453,12 +463,25 @@ def _run_bounded_subprocess(
     stdout_pipe = process.stdout
     stderr_pipe = process.stderr
     assert stdout_pipe is not None and stderr_pipe is not None
-    captured: dict[str, list[bytes]] = {"stdout": [], "stderr": []}
-    last_progress = [time.monotonic()]
+    captured: dict[str, deque[bytes]] = {"stdout": deque(), "stderr": deque()}
+    retained = {"stdout": 0, "stderr": 0}
+    dropped = {"stdout": 0, "stderr": 0}
+    started = time.monotonic()
+    last_progress = [started]
 
     def drain(stream: IO[bytes], key: str) -> None:
         while chunk := os.read(stream.fileno(), 65536):
             captured[key].append(chunk)
+            retained[key] += len(chunk)
+            while retained[key] > capture_tail_bytes and len(captured[key]) > 1:
+                oldest = captured[key].popleft()
+                retained[key] -= len(oldest)
+                dropped[key] += len(oldest)
+            if retained[key] > capture_tail_bytes:
+                excess = retained[key] - capture_tail_bytes
+                captured[key][0] = captured[key][0][excess:]
+                retained[key] -= excess
+                dropped[key] += excess
             last_progress[0] = time.monotonic()
 
     readers = [
@@ -469,17 +492,23 @@ def _run_bounded_subprocess(
         reader.start()
 
     def decoded(key: str) -> str:
-        return b"".join(captured[key]).decode(errors="replace")
+        text = b"".join(captured[key]).decode(errors="replace")
+        if dropped[key]:
+            return f"[... {dropped[key]} bytes dropped ...]\n{text}"
+        return text
 
+    expired_deadline: float | None = None
     try:
         while process.poll() is None or any(reader.is_alive() for reader in readers):
-            if time.monotonic() - last_progress[0] >= timeout_seconds:
-                raise subprocess.TimeoutExpired(
-                    args,
-                    timeout_seconds,
-                    output=decoded("stdout"),
-                    stderr=decoded("stderr"),
-                )
+            now = time.monotonic()
+            if now - started >= wall_timeout_seconds:
+                expired_deadline = wall_timeout_seconds
+            elif now - last_progress[0] >= timeout_seconds:
+                expired_deadline = timeout_seconds
+            if expired_deadline is not None:
+                with suppress(ProcessLookupError):
+                    os.killpg(process.pid, signal.SIGKILL)
+                break
             time.sleep(0.01)
     except BaseException:
         with suppress(ProcessLookupError):
@@ -493,7 +522,15 @@ def _run_bounded_subprocess(
             reader.join()
         stdout_pipe.close()
         stderr_pipe.close()
-    return subprocess.CompletedProcess(args, process.wait(), decoded("stdout"), decoded("stderr"))
+    returncode = process.wait()
+    if expired_deadline is not None:
+        raise subprocess.TimeoutExpired(
+            args,
+            expired_deadline,
+            output=decoded("stdout"),
+            stderr=decoded("stderr"),
+        )
+    return subprocess.CompletedProcess(args, returncode, decoded("stdout"), decoded("stderr"))
 
 
 def _materialize_python_heredocs(script: str, tmp_path: Path) -> str:
@@ -613,6 +650,71 @@ def test_bounded_subprocess_kills_child_that_stops_progressing(tmp_path: Path) -
     assert time.monotonic() - started < 2
     assert "made progress" in (excinfo.value.output or "")
     assert threading.active_count() == threads_before
+
+
+def test_bounded_subprocess_enforces_wall_deadline_despite_progress(tmp_path: Path) -> None:
+    """A child that keeps emitting output must still die at the wall deadline."""
+    threads_before = threading.active_count()
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+        _run_bounded_subprocess(
+            ["bash", "-c", 'while true; do echo "still alive"; sleep 0.02; done'],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=5.0,
+            wall_timeout_seconds=0.4,
+        )
+    assert time.monotonic() - started < 3
+    assert excinfo.value.timeout == 0.4
+    assert "still alive" in (excinfo.value.output or "")
+    assert threading.active_count() == threads_before
+
+
+def test_bounded_subprocess_default_wall_deadline_is_finite() -> None:
+    """Omitting the wall deadline must still yield a hard total-runtime bound."""
+    assert _SUBPROCESS_WALL_MULTIPLIER > 1
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+        _run_bounded_subprocess(
+            ["bash", "-c", 'while true; do echo "still alive"; done'],
+            cwd=Path.cwd(),
+            env=os.environ.copy(),
+            timeout_seconds=0.1,
+        )
+    assert time.monotonic() - started < 5
+    assert excinfo.value.timeout == pytest.approx(0.1 * _SUBPROCESS_WALL_MULTIPLIER)
+
+
+def test_bounded_subprocess_retains_bounded_tail_of_output(tmp_path: Path) -> None:
+    """Retained output stays bounded while the diagnostic tail survives."""
+    result = _run_bounded_subprocess(
+        ["bash", "-c", 'for i in $(seq 2000); do echo "line $i"; done'],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        timeout_seconds=5.0,
+        capture_tail_bytes=1024,
+    )
+    assert result.returncode == 0
+    assert len(result.stdout.encode()) < 1024 + 200
+    assert result.stdout.startswith("[... ")
+    assert "bytes dropped ...]" in result.stdout
+    assert result.stdout.rstrip().endswith("line 2000")
+
+
+def test_bounded_subprocess_bounds_memory_of_endlessly_emitting_child(tmp_path: Path) -> None:
+    """A killed chatty child leaves a bounded diagnostic, not unbounded capture."""
+    with pytest.raises(subprocess.TimeoutExpired) as excinfo:
+        _run_bounded_subprocess(
+            ["bash", "-c", 'while true; do echo "flood flood flood flood"; done'],
+            cwd=tmp_path,
+            env=os.environ.copy(),
+            timeout_seconds=5.0,
+            wall_timeout_seconds=0.4,
+            capture_tail_bytes=2048,
+        )
+    output = excinfo.value.output or ""
+    assert len(output.encode()) < 2048 + 200
+    assert "flood" in output
 
 
 def test_harness_never_hands_bash_a_python_heredoc(

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1398,17 +1398,12 @@ def _run_pypi_classifier(
         "SOCKET_TIMEOUT_SECONDS": "1",
     }
     env.update(env_overrides or {})
-    step = _step("prepare-pypi", "classify-pypi-state")
-    marker = "python3 - <<'PY'\n"
-    assert step["run"].startswith(marker)
-    python = step["run"].removeprefix(marker).removesuffix("\nPY\n")
-    result = subprocess.run(
-        [sys.executable, "-c", python],
+    result = _run_yaml_script(
+        _step("prepare-pypi", "classify-pypi-state")["run"],
         cwd=tmp_path,
         env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        tmp_path=tmp_path,
+        timeout_seconds=15,
     )
     state = _read_output(output, "state") if output.exists() else ""
     return result, state
@@ -1513,7 +1508,7 @@ def test_pypi_classifier_never_publishes_untrusted_or_unstable_evidence(
                 "yanked": False,
             }
         )
-    if mutation == "advertised-host":
+    if mutation in {"advertised-host", "partial-advertised-host"}:
         payload["urls"][0]["url"] = payload["urls"][0]["url"].replace("127.0.0.1", "localhost")
     elif mutation in {"redirect-host", "partial-redirect-host"}:
         name = payload["urls"][0]["filename"]
@@ -1523,8 +1518,6 @@ def test_pypi_classifier_never_publishes_untrusted_or_unstable_evidence(
         payload["urls"][0]["digests"]["sha256"] = "0" * 64
     elif mutation in {"downloaded-bytes", "partial-downloaded-bytes", "extra-downloaded-bytes"}:
         server["files"][payload["urls"][0]["filename"]] = b"tampered"
-    elif mutation == "partial-advertised-host":
-        payload["urls"][0]["url"] = payload["urls"][0]["url"].replace("127.0.0.1", "localhost")
     elif mutation == "inconsistent-snapshots":
         changed = json.loads(json.dumps(payload))
         changed["urls"][0]["yanked"] = True

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -9,6 +9,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from collections.abc import Iterator
@@ -39,11 +40,13 @@ def package_index_server() -> Iterator[tuple[str, dict[str, Any]]]:
         "index_calls": 0,
         "index_responses": [],
         "redirected_files": {},
+        "request_events": [],
     }
 
     class Handler(http.server.BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
             if self.path.startswith("/pypi/"):
+                state["request_events"].append("index")
                 responses = state["index_responses"]
                 index = min(state["index_calls"], len(responses) - 1)
                 state["index_calls"] += 1
@@ -59,6 +62,7 @@ def package_index_server() -> Iterator[tuple[str, dict[str, Any]]]:
                 self.wfile.write(body)
                 return
             if self.path.startswith("/files/"):
+                state["request_events"].append("file")
                 name = self.path.removeprefix("/files/")
                 response = state["files"][name]
                 if isinstance(response, dict) and "redirect" in response:
@@ -1067,7 +1071,7 @@ def test_bundle_validation_rejects_artifact_and_attestation_tampering(tmp_path: 
     assert tampered_attestation.returncode != 0
 
 
-@pytest.mark.parametrize("job_id", ["verify-testpypi", "verify-pypi"])
+@pytest.mark.parametrize("job_id", ["verify-testpypi"])
 def test_index_verifier_retries_then_accepts_exact_remote_bytes(
     tmp_path: Path,
     package_index_server: tuple[str, dict[str, Any]],
@@ -1082,7 +1086,7 @@ def test_index_verifier_retries_then_accepts_exact_remote_bytes(
     assert state["index_calls"] >= 2
 
 
-@pytest.mark.parametrize("job_id", ["verify-testpypi", "verify-pypi"])
+@pytest.mark.parametrize("job_id", ["verify-testpypi"])
 @pytest.mark.parametrize(
     "mutation",
     [
@@ -1144,7 +1148,7 @@ def test_index_verifier_rejects_remote_identity_and_byte_mutations(
     assert result.returncode != 0
 
 
-@pytest.mark.parametrize("job_id", ["verify-testpypi", "verify-pypi"])
+@pytest.mark.parametrize("job_id", ["verify-testpypi"])
 def test_index_verifier_rejects_competing_publication_race(
     tmp_path: Path,
     package_index_server: tuple[str, dict[str, Any]],
@@ -1168,7 +1172,7 @@ def test_index_verifier_rejects_competing_publication_race(
     assert state["index_calls"] == 2
 
 
-@pytest.mark.parametrize("job_id", ["verify-testpypi", "verify-pypi"])
+@pytest.mark.parametrize("job_id", ["verify-testpypi"])
 def test_index_verifier_worst_case_fits_job_timeout_with_five_minute_headroom(
     job_id: str,
 ) -> None:
@@ -1212,37 +1216,436 @@ def test_index_verifier_enforces_total_deadline_despite_socket_activity(
     assert result.returncode != 0
 
 
-@pytest.mark.parametrize(
-    ("response", "expected_success"),
-    [(404, True), ("existing", False), (503, False)],
-    ids=["absent", "pre-existing", "unexpected-error"],
-)
-def test_pypi_absence_check_uses_controlled_index_and_fails_closed(
+def _read_output(path: Path, key: str) -> str:
+    """Read the last scalar written for a GitHub Actions output."""
+    prefix = f"{key}="
+    return next(
+        line.removeprefix(prefix)
+        for line in reversed(path.read_text().splitlines())
+        if line.startswith(prefix)
+    )
+
+
+def _run_pypi_classifier(
     tmp_path: Path,
-    package_index_server: tuple[str, dict[str, Any]],
-    response: int | str,
-    expected_success: bool,
-) -> None:
-    """The exact prepare path accepts only a 404 and rejects an occupied version."""
-    base_url, state = package_index_server
-    state["index_responses"] = [
-        _index_payload(base_url, {}) if response == "existing" else response
-    ]
+    base_url: str,
+    *,
+    job_id: str = "prepare-pypi",
+    env_overrides: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    output = tmp_path / f"{job_id}-output"
+    summary = tmp_path / f"{job_id}-summary"
     env = os.environ | {
+        "ALLOWED_FILE_HOST": "127.0.0.1",
+        "DOWNLOAD_TOTAL_SECONDS": "2",
         "EXPECTED_PROJECT_NAME": "pylxpweb",
         "EXPECTED_VERSION": "1.2.3",
-        "PYPI_JSON_BASE": f"{base_url}/pypi",
+        "GITHUB_OUTPUT": str(output),
+        "GITHUB_STEP_SUMMARY": str(summary),
+        "INDEX_JSON_BASE": f"{base_url}/pypi",
+        "INDEX_TOTAL_SECONDS": "2",
+        "REQUIRED_FILE_SCHEME": "http",
+        "SNAPSHOT_DELAY_SECONDS": "0",
+        "SOCKET_TIMEOUT_SECONDS": "1",
     }
+    env.update(env_overrides or {})
+    step = _step(job_id, "classify-pypi-state")
+    marker = "python3 - <<'PY'\n"
+    assert step["run"].startswith(marker)
+    python = step["run"].removeprefix(marker).removesuffix("\nPY\n")
     result = subprocess.run(
-        ["bash", "-c", _step("prepare-pypi", "verify-pypi-absence")["run"]],
+        [sys.executable, "-c", python],
         cwd=tmp_path,
         env=env,
         text=True,
         capture_output=True,
         check=False,
     )
-    assert state["index_calls"] == 1
-    assert (result.returncode == 0) is expected_success
+    state = _read_output(output, "state") if output.exists() else ""
+    return result, state
+
+
+@pytest.mark.parametrize(
+    ("remote_case", "expected_state"),
+    [
+        ("absent", "ABSENT"),
+        ("exact", "EXACT_COMPLETE"),
+        ("partial", "PARTIAL"),
+        ("mismatch", "MISMATCH"),
+        ("yanked", "YANKED"),
+        ("extra", "EXTRA"),
+        ("competing", "COMPETING"),
+        ("uncertain", "UNCERTAIN"),
+    ],
+)
+def test_pypi_classifier_emits_closed_state_machine_from_remote_bytes(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+    remote_case: str,
+    expected_state: str,
+) -> None:
+    """Deleting any state branch makes an immutable remote state publishable or ambiguous."""
+    base_url, server = package_index_server
+    files, payload = _prepare_index_case(tmp_path, base_url, server)
+    if remote_case == "absent":
+        server["index_responses"] = [404, 404]
+    elif remote_case == "partial":
+        payload["urls"] = payload["urls"][:1]
+    elif remote_case == "mismatch":
+        payload["urls"][0]["digests"]["sha256"] = "0" * 64
+    elif remote_case == "yanked":
+        payload["urls"][0]["yanked"] = True
+    elif remote_case == "extra":
+        payload["urls"].append(
+            {
+                "digests": {"sha256": hashlib.sha256(b"extra").hexdigest()},
+                "filename": "pylxpweb-1.2.3.zip",
+                "url": f"{base_url}/files/pylxpweb-1.2.3.zip",
+                "yanked": False,
+            }
+        )
+    elif remote_case == "competing":
+        payload["urls"].append(dict(payload["urls"][0]))
+    elif remote_case == "uncertain":
+        server["index_responses"] = [503, 503]
+    if not server["index_responses"]:
+        server["index_responses"] = [payload, payload]
+    result, state = _run_pypi_classifier(tmp_path, base_url)
+    assert result.returncode == 0, result.stderr
+    assert state == expected_state
+    summary = (tmp_path / "prepare-pypi-summary").read_text()
+    assert "Expected sealed files" in summary
+    assert "First snapshot" in summary
+    assert "Second snapshot" in summary
+    if expected_state == "EXACT_COMPLETE":
+        assert server["files"] == files
+        assert server["request_events"][0] == "index"
+        assert server["request_events"][-1] == "index"
+        assert "file" in server["request_events"][1:-1]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "advertised-host",
+        "redirect-host",
+        "metadata-hash",
+        "downloaded-bytes",
+        "inconsistent-snapshots",
+        "malformed-json",
+    ],
+)
+def test_pypi_classifier_never_publishes_untrusted_or_unstable_evidence(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+    mutation: str,
+) -> None:
+    """Weakening host/hash/byte/snapshot checks can misclassify occupied PyPI as absent."""
+    base_url, server = package_index_server
+    files, payload = _prepare_index_case(tmp_path, base_url, server)
+    expected = "MISMATCH"
+    if mutation == "advertised-host":
+        payload["urls"][0]["url"] = payload["urls"][0]["url"].replace("127.0.0.1", "localhost")
+    elif mutation == "redirect-host":
+        name = payload["urls"][0]["filename"]
+        server["redirected_files"][name] = files[name]
+        server["files"][name] = {
+            "redirect": f"{base_url.replace('127.0.0.1', 'localhost')}/redirected/{name}"
+        }
+    elif mutation == "metadata-hash":
+        payload["urls"][0]["digests"]["sha256"] = "0" * 64
+    elif mutation == "downloaded-bytes":
+        server["files"][payload["urls"][0]["filename"]] = b"tampered"
+    elif mutation == "inconsistent-snapshots":
+        changed = json.loads(json.dumps(payload))
+        changed["urls"][0]["yanked"] = True
+        server["index_responses"] = [payload, changed]
+        expected = "UNCERTAIN"
+    elif mutation == "malformed-json":
+        server["index_responses"] = ["not-an-object", "not-an-object"]
+        expected = "UNCERTAIN"
+    if not server["index_responses"]:
+        server["index_responses"] = [payload, payload]
+    result, state = _run_pypi_classifier(tmp_path, base_url)
+    assert result.returncode == 0, result.stderr
+    assert state == expected
+    assert state != "ABSENT"
+
+
+def test_recovery_recomputes_state_from_mutable_remote_without_rebuilding(
+    tmp_path: Path,
+    package_index_server: tuple[str, dict[str, Any]],
+) -> None:
+    """Caching prepare output would miss an upload accepted after a lost publisher response."""
+    base_url, server = package_index_server
+    _, payload = _prepare_index_case(tmp_path, base_url, server)
+    server["index_responses"] = [404, 404]
+    first, first_state = _run_pypi_classifier(tmp_path, base_url)
+    server["index_calls"] = 0
+    server["index_responses"] = [payload, payload]
+    second, second_state = _run_pypi_classifier(tmp_path, base_url)
+    assert first.returncode == second.returncode == 0
+    assert (first_state, second_state) == ("ABSENT", "EXACT_COMPLETE")
+    assert _job("prepare-pypi")["needs"] == ["bind-build-attest", "verify-testpypi"]
+    assert "bind-build-attest" not in _job("prepare-pypi").get("if", "")
+
+
+def _artifact_fixture(expected_name: str, expected_digest: str) -> dict[str, Any]:
+    run_id = 12345
+    commit = "a" * 40
+    repository = "joyfulhouse/pylxpweb"
+    artifact = {
+        "id": 987,
+        "name": expected_name,
+        "expired": False,
+        "digest": expected_digest,
+        "workflow_run": {
+            "id": run_id,
+            "head_sha": commit,
+            "repository_id": 42,
+            "head_repository_id": 42,
+        },
+    }
+    return {
+        f"repos/{repository}/actions/runs/{run_id}": {
+            "id": run_id,
+            "event": "release",
+            "head_sha": commit,
+            "path": ".github/workflows/release.yml",
+            "repository": {"id": 42, "full_name": repository},
+            "head_repository": {"id": 42, "full_name": repository},
+        },
+        f"repos/{repository}/actions/runs/{run_id}/artifacts": {
+            "total_count": 1,
+            "artifacts": [artifact],
+        },
+    }
+
+
+def _run_artifact_resolution(
+    tmp_path: Path,
+    fixtures: dict[str, Any],
+    *,
+    expected_digest: str = "d" * 64,
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    _write_fake_gh(bin_dir)
+    fixtures_path = tmp_path / "artifact-fixtures.json"
+    fixtures_path.write_text(json.dumps(fixtures))
+    env = os.environ | {
+        "EXPECTED_ARTIFACT_DIGEST": expected_digest,
+        "EXPECTED_ARTIFACT_NAME": "pylxpweb-release-1.2.3-aaaaaaaaaaaa",
+        "EXPECTED_COMMIT": "a" * 40,
+        "GH_FIXTURES": str(fixtures_path),
+        "GITHUB_OUTPUT": str(tmp_path / "artifact-output"),
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "artifact-summary"),
+        "GH_TOKEN": "scoped-test-token",
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "REPOSITORY": "joyfulhouse/pylxpweb",
+        "RUN_ID": "12345",
+    }
+    run = _step("prepare-pypi", "resolve-release-artifact")["run"]
+    marker = 'python3 - "$evidence/run.json" "$evidence/artifacts.json" <<\'PY\'\n'
+    shell, python = run.split(marker, 1)
+    resolver = tmp_path / "resolve-release-artifact.py"
+    resolver.write_text(python.removesuffix("\nPY\n"))
+    script = tmp_path / "resolve-release-artifact.sh"
+    script.write_text(
+        shell + f'python3 "{resolver}" "$evidence/run.json" "$evidence/artifacts.json"\n'
+    )
+    return subprocess.run(
+        ["bash", str(script)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing",
+        "expired",
+        "duplicate",
+        "count-mismatch",
+        "wrong-envelope",
+        "wrong-name",
+        "wrong-digest",
+        "wrong-action-digest-format",
+        "wrong-run",
+        "wrong-head",
+        "wrong-repository",
+    ],
+)
+def test_prepare_rediscovers_one_exact_nonexpired_run_artifact(
+    tmp_path: Path, mutation: str
+) -> None:
+    """Trusting only stale job outputs can select missing, replaced, or cross-run bytes."""
+    name = "pylxpweb-release-1.2.3-aaaaaaaaaaaa"
+    digest = "sha256:" + "d" * 64
+    fixtures = _artifact_fixture(name, digest)
+    page = fixtures["repos/joyfulhouse/pylxpweb/actions/runs/12345/artifacts"]
+    artifacts = page["artifacts"]
+    artifact = artifacts[0]
+    run = fixtures["repos/joyfulhouse/pylxpweb/actions/runs/12345"]
+    if mutation == "missing":
+        artifacts.clear()
+        page["total_count"] = 0
+    elif mutation == "expired":
+        artifact["expired"] = True
+    elif mutation == "duplicate":
+        artifacts.append(dict(artifact, id=988))
+        page["total_count"] = 2
+    elif mutation == "count-mismatch":
+        page["total_count"] = 2
+    elif mutation == "wrong-envelope":
+        fixtures["repos/joyfulhouse/pylxpweb/actions/runs/12345/artifacts"] = artifacts
+    elif mutation == "wrong-name":
+        artifact["name"] = "attacker-artifact"
+    elif mutation == "wrong-digest":
+        artifact["digest"] = "sha256:" + "0" * 64
+    elif mutation == "wrong-run":
+        artifact["workflow_run"]["id"] = 54321
+    elif mutation == "wrong-head":
+        artifact["workflow_run"]["head_sha"] = "b" * 40
+    elif mutation == "wrong-repository":
+        run["repository"]["full_name"] = "attacker/pylxpweb"
+    expected_digest = "sha256:" + "d" * 64 if mutation == "wrong-action-digest-format" else "d" * 64
+    result = _run_artifact_resolution(tmp_path, fixtures, expected_digest=expected_digest)
+    assert result.returncode != 0
+
+
+def test_prepare_accepts_exact_run_artifact_and_binds_download_by_id(tmp_path: Path) -> None:
+    """The accepted API identity must drive the immutable artifact download selector."""
+    name = "pylxpweb-release-1.2.3-aaaaaaaaaaaa"
+    digest = "sha256:" + "d" * 64
+    result = _run_artifact_resolution(tmp_path, _artifact_fixture(name, digest))
+    assert result.returncode == 0, result.stderr
+    output = tmp_path / "artifact-output"
+    assert _read_output(output, "artifact-id") == "987"
+    summary = (tmp_path / "artifact-summary").read_text()
+    assert "987" in summary
+    assert name in summary
+    assert digest in summary
+    download = _step("prepare-pypi", "download-release-artifact")
+    assert download["with"]["artifact-ids"] == (
+        "${{ steps.resolve-release-artifact.outputs.artifact-id }}"
+    )
+    assert download["with"]["run-id"] == "${{ github.run_id }}"
+    assert download["with"]["digest-mismatch"] == "error"
+
+
+def test_production_recovery_topology_has_one_terminal_verifier() -> None:
+    """Changing conditions can republish exact state, top up partial state, or hide failure."""
+    prepare = _job("prepare-pypi")
+    publish = _job("publish-pypi")
+    verify = _job("verify-pypi")
+    assert prepare["environment"] == "pypi"
+    assert prepare["outputs"]["state"] == "${{ steps.classify-pypi-state.outputs.state }}"
+    assert _step("prepare-pypi", "stage")["if"] == (
+        "steps.classify-pypi-state.outputs.state == 'ABSENT'"
+    )
+    assert _step("prepare-pypi", "upload-staging-artifact")["if"] == (
+        "steps.classify-pypi-state.outputs.state == 'ABSENT'"
+    )
+    assert publish["if"] == "needs.prepare-pypi.outputs.state == 'ABSENT'"
+    assert publish["needs"] == "prepare-pypi"
+    assert verify["needs"] == ["bind-build-attest", "prepare-pypi", "publish-pypi"]
+    assert verify["if"] == (
+        "${{ always() && !cancelled() && needs.prepare-pypi.result == 'success' }}"
+    )
+    assert "needs.publish-pypi.result" not in verify["if"]
+    assert (
+        _step("verify-pypi", "classify-pypi-state")["run"]
+        == _step("prepare-pypi", "classify-pypi-state")["run"]
+    )
+    terminal = _step("verify-pypi", "require-exact-complete")
+    assert terminal["env"]["STATE"] == "${{ steps.classify-pypi-state.outputs.state }}"
+    assert "EXACT_COMPLETE" in terminal["run"]
+    assert not any("continue-on-error" in step for step in publish["steps"])
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        "ABSENT",
+        "EXACT_COMPLETE",
+        "PARTIAL",
+        "MISMATCH",
+        "YANKED",
+        "EXTRA",
+        "COMPETING",
+        "UNCERTAIN",
+    ],
+)
+def test_terminal_verifier_succeeds_only_for_exact_complete(state: str) -> None:
+    """Any other successful terminal state can hide a lost or immutable partial upload."""
+    step = _step("verify-pypi", "require-exact-complete")
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        env=os.environ | {"STATE": state},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert (result.returncode == 0) is (state == "EXACT_COMPLETE")
+
+
+def test_production_classifier_worst_case_fits_verifier_timeout() -> None:
+    """Two snapshots and both byte downloads leave at least five minutes of headroom."""
+    job = _job("verify-pypi")
+    env = _step("verify-pypi", "classify-pypi-state")["env"]
+    classifier_worst_case = (
+        2 * int(env["INDEX_TOTAL_SECONDS"])
+        + 2 * int(env["DOWNLOAD_TOTAL_SECONDS"])
+        + int(env["SNAPSHOT_DELAY_SECONDS"])
+    )
+    assert int(job["timeout-minutes"]) * 60 - classifier_worst_case >= 300
+    assert int(env["SOCKET_TIMEOUT_SECONDS"]) < int(env["INDEX_TOTAL_SECONDS"])
+    assert "signal.setitimer" in _step("verify-pypi", "classify-pypi-state")["run"]
+
+
+def test_prepare_and_verifier_share_artifact_and_remote_evidence_scripts() -> None:
+    """Divergent recovery verification can bless evidence normal verification rejects."""
+    assert (
+        _step("prepare-pypi", "resolve-release-artifact")["run"]
+        == _step("verify-pypi", "resolve-release-artifact")["run"]
+    )
+    assert (
+        _step("prepare-pypi", "verify-release-bundle")["run"]
+        == _step("verify-pypi", "verify-release-bundle")["run"]
+    )
+    assert (
+        _step("prepare-pypi", "classify-pypi-state")["run"]
+        == _step("verify-pypi", "classify-pypi-state")["run"]
+    )
+
+
+def test_only_absent_state_can_reach_action_only_production_publisher() -> None:
+    """Any broader publisher guard permits republish or immutable one-file top-up."""
+    publish = _job("publish-pypi")
+    assert publish["environment"] == "pypi"
+    assert publish["permissions"] == {"contents": "read", "id-token": "write"}
+    assert publish["if"] == "needs.prepare-pypi.outputs.state == 'ABSENT'"
+    assert len(publish["steps"]) == 2
+    assert all(set(step) <= {"uses", "with", "name"} for step in publish["steps"])
+    assert all("run" not in step for step in publish["steps"])
+    assert "skip-existing" not in publish["steps"][1].get("with", {})
+    workflow = _workflow()
+    production_oidc = [
+        job_id
+        for job_id, job in workflow["jobs"].items()
+        if job.get("permissions", {}).get("id-token") == "write"
+        and job.get("environment") == "pypi"
+    ]
+    assert production_oidc == ["publish-pypi"]
+    assert not any(
+        "continue-on-error" in job or any("continue-on-error" in step for step in job["steps"])
+        for job in workflow["jobs"].values()
+    )
 
 
 def test_all_release_actions_are_immutable_full_sha_pins() -> None:


### PR DESCRIPTION
## Summary

- classify production PyPI into the closed `ABSENT`, `EXACT_COMPLETE`, `PARTIAL`, `MISMATCH`, `YANKED`, `EXTRA`, `COMPETING`, and `UNCERTAIN` states
- rediscover and verify the original run-scoped sealed artifact through Actions API repository/run/head/name/digest evidence before bundle and GitHub source/build attestation verification
- stage and publish the full sealed set only for `ABSENT`; keep the production publisher at exactly two pinned action-only steps and confine production OIDC to it
- make unprivileged `verify-pypi` the sole terminal completion path, running after publisher success, skip, or failure and succeeding only for `EXACT_COMPLETE`
- document protected-environment approval and specific-prepare-job recovery without rebuilding, direct publisher rerun, Re-run all, or tag/Release mutation

## Resumption after prerequisite

Prerequisite #304 merged as `71b9fe6d12fa88f7d2c19c92226a4a243307f943`, restoring the issue #296 `uv_build==0.9.30` contract. This branch was mechanically rebased from old head `1017a8d4586376c147c5b41897845eeea7833b24` to `794a7efd2fc791281fe5b53409bd251b65df9223`; the implementation patch ID is unchanged apart from removing one unused YAML anchor marker required by actionlint.

## Scope

Exactly:

- `.github/workflows/release.yml`
- `tests/unit/test_release_workflow.py`
- `.github/WORKFLOWS.md`

The issue #296 binder is unchanged except for exposing the sealed artifact digest. The TestPyPI chain is behaviorally unchanged. PR #294, tags, Releases, publishers, and repository/environment/PyPI settings are untouched.

## Verification

- release workflow suite in pinned Linux/Python 3.13 image: 108 passed, 5 Docker-in-Docker skips
- skipped host-Docker cases: 5 passed, including two-build reproducibility, wrong backend/tool versions, and network denial
- full unit suite: 3,400 passed, 5 skips, 89.63% coverage
- former backend failures: 2 passed directly
- integration: 84 collected, 4 deselected, 80 credential-gated skips, exit 0
- Ruff, format, strict mypy, lock check, locked sync, YAML parsing, actionlint YAML/expression analysis, and full-SHA action-pin audit: passed
- wheel and sdist: exactly two artifacts; Twine passed; deterministic SHA-256 values remain `44266d254d6db1576adfad4a0848ee713af9cf26ecec49ca7bf87f68f6c141b7` and `eab88cc76c657421bc9c2c30b24e49c5646a6e5a19c62c85682bc2abc1ef9481`
- live read-only checks: PyPI `0.10.0b3` remains absent; pinned artifact action contracts and real Actions REST evidence match fixtures; no publication occurred
- independent review: clean after REST-envelope/digest remediation

Closes #299
Prerequisite #304

## Pre-tribunal DRY/ponytail audit

Behavior-preserving audit reduced the diff by 19 net lines: prepare/verifier now share the identical production classifier environment via a used YAML anchor, four one-element legacy TestPyPI parametrizations were collapsed to literals, and an unused classifier helper option was removed. Collection remains exactly 113 production-path cases; state transitions, artifact validation, publisher authority, terminal verification, and runbook behavior are unchanged.

## Host lifecycle remediation

Systematic debugging isolated intermittent macOS Bash 5.3 deadlocks while preparing pipe-backed Python heredocs from large YAML-derived `bash -c` scripts. Production workflow bytes remain unchanged. The test harness now materializes the exact embedded Python bodies into private temporary files, runs YAML scripts with `/dev/null` stdin and closed descriptors in fresh process sessions, applies explicit deadlines, and kills/reaps the entire process group on timeout or interruption. Old harness RED: 4/20 isolated timeouts and a 12-run stress timeout. New harness GREEN: 20/20 isolated passes, 12-run stress pass, process-group cleanup pass, and two cold 115/115 host runs.