### PR TITLE
build: restore sealed uv_build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ pylxpweb-collect = "pylxpweb.cli.collect_device_data:main"
 pylxpweb-modbus-diag = "pylxpweb.cli.modbus_diag:main"
 
 [build-system]
-requires = ["uv_build==0.12.4"]
+requires = ["uv_build==0.9.30"]
 build-backend = "uv_build"
 
 [tool.ruff]


### PR DESCRIPTION
Closes #302

Restores the exact PEP 517 backend bundled by the dual-reviewed, digest-pinned offline release container:

- changes `[build-system].requires` from `uv_build==0.12.4` to `uv_build==0.9.30`
- records that PR #300 introduced the backend drift; PR #301's unrelated lock updates remain intact
- leaves `uv.lock` unchanged because it does not lock the PEP 517 backend
- leaves the release workflow, tests, and documentation unchanged

Validation:

- focused backend/reproducibility tests: RED before, GREEN after
- full release-workflow suite: 90 passed
- full unit suite: 3382 passed; coverage 89.63%
- local integration command: 80 skipped without live credentials, 4 deselected
- GitHub live integration job: passed
- locked sync, Ruff, format, strict mypy: passed
- Docker backend/uv/Python/network mutations: passed
- two clean networkless builds: bit-identical wheel and sdist
- exact two artifacts, metadata, Twine: passed
- actionlint and immutable action-pin tests: passed

No package publication, tagging, release, settings, or unrelated PR changes.