### PR TITLE
ci: remove release review-approval requirement

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -34,13 +34,38 @@ Publishing is a linear seven-job promotion chain:
    pull request. Its first parent is the previous `main`, its second parent is the
    final pull-request head, and the first parent must be an ancestor of that head.
    The PR base is `main`; GitHub's mutable `pull.base.sha` is not used as historical
-   merge evidence. An effective non-self approval covers the exact head whenever
-   the repository has at least one write-or-higher collaborator other than the PR
-   author; when the author is the sole write-or-higher collaborator, the approval
-   binding is waived and an explicit `solo-maintainer waiver` notice is printed
-   into the job log. The waiver decision is derived from the same GitHub
-   collaborator-permission data the review gate already trusts, and any error
-   while listing collaborators fails closed — an error is never a waiver. The
+   merge evidence. An effective non-self approval covers the exact head, unless
+   the solo-maintainer waiver applies. The waiver fires only when **all** of the
+   following hold: the repository Actions **variable** `RELEASE_SOLO_MAINTAINER`
+   equals `true` (unset or any other value renders empty in the step env and the
+   original assertion stands byte-for-byte); the PR author probes as `admin` via
+   `repos/{repo}/collaborators/{author}/permission` (a solo maintainer is
+   necessarily admin — the variable alone can never waive a mere-write author);
+   and no write-or-higher non-author reviewer has an effective `APPROVED` or
+   `CHANGES_REQUESTED` review on the PR (if one does, the original exact-head
+   binding runs unchanged). A waived run prints an explicit
+   `solo-maintainer waiver` notice into the job log and writes an audit record —
+   variable value, author, probed permission, and the review evidence examined —
+   into the job summary. Any error in the corroboration probe fails closed; an
+   error is never a waiver, and the probe response is indexed strictly so schema
+   drift also fails closed.
+
+   Token-scope facts, verified empirically under this job's exact `GITHUB_TOKEN`
+   permission grants (probe runs 32191036659 and 32191166538, 2026-08-18): the
+   collaborators **list** endpoint (`repos/{repo}/collaborators`) returns HTTP
+   200 with an **empty** list under the job token and must never be used as a
+   binding input; the **per-user** permission endpoint
+   (`repos/{repo}/collaborators/{login}/permission`) works and returns the full
+   permission payload. That is why the waiver corroborates through the per-user
+   endpoint and a declared variable rather than collaborator enumeration.
+
+   Residual admin window (stated honestly): this review binding does **not**
+   prevent bypass by an actor with repository administration rights. Such an
+   actor can set `RELEASE_SOLO_MAINTAINER`, and could equally manage
+   collaborators or branch protection. The variable is accepted precisely
+   because it adds no marginal attacker capability beyond what repo admin
+   already concedes, while being explicit, auditable in the job summary, and
+   revocable in one line. The
    head's single `CI Success` check must come from GitHub Actions and resolve to a
    successful pull-request run of this repository's `.github/workflows/ci.yml`.
 2. The same job builds once in the official uv/Python 3.13 image pinned by the
@@ -194,12 +219,13 @@ unfreezing publication and again during release review:
 - `main` is protected: the final release-candidate PR requires review, dismisses
   stale approval, requires `CI Success`, requires the branch to be up to date,
   prevents bypass, and is merged with GitHub's **Create a merge commit** method.
-  On a solo-maintainer repository (the PR author is the only write-or-higher
-  collaborator), required review cannot be satisfied by anyone else; the
-  workflow's approval binding waives itself in that case, and the branch
-  protection review requirement may be relaxed accordingly until a second
-  eligible collaborator exists — at which point the non-self approval binding
-  re-arms automatically.
+  On a solo-maintainer repository, required review cannot be satisfied by anyone
+  else; the maintainer declares that state by setting the repository Actions
+  variable `RELEASE_SOLO_MAINTAINER` to `true` and may relax the branch
+  protection review requirement accordingly. Restoring full team mode is one
+  line — `gh variable delete RELEASE_SOLO_MAINTAINER` (or set it to anything
+  but `true`) — and an effective write-or-higher non-author review on the
+  release PR re-arms the exact-head binding even while the variable is set.
 - A tag ruleset protects `v*` tags from update and deletion except for the narrow,
   audited recovery operation described below.
 - The `pypi` environment requires an independent reviewer (on a solo-maintainer
@@ -220,8 +246,10 @@ or mutate repository, environment, or package-index settings.
 1. Prepare the final version and every release-tree change in one final candidate
    pull request. `project.version` must equal the intended tag without `v`.
 2. Obtain an effective approval and successful required CI on the exact final head.
-   If the head changes, repeat both gates. On a solo-maintainer repository the
-   workflow waives the approval gate (with a logged notice); CI is still required.
+   If the head changes, repeat both gates. On a solo-maintainer repository with
+   `RELEASE_SOLO_MAINTAINER=true` and an admin author, the workflow waives the
+   approval gate (with a logged notice and a job-summary audit record); required
+   CI on the exact head is never waived.
 3. Merge with GitHub **Create a merge commit**. Do not squash or rebase.
 4. Confirm no later commit has reached `main`, then create the protected `v*` tag
    on that GitHub merge commit and publish the GitHub Release for the same tag.

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -34,38 +34,13 @@ Publishing is a linear seven-job promotion chain:
    pull request. Its first parent is the previous `main`, its second parent is the
    final pull-request head, and the first parent must be an ancestor of that head.
    The PR base is `main`; GitHub's mutable `pull.base.sha` is not used as historical
-   merge evidence. An effective non-self approval covers the exact head, unless
-   the solo-maintainer waiver applies. The waiver fires only when **all** of the
-   following hold: the repository Actions **variable** `RELEASE_SOLO_MAINTAINER`
-   equals `true` (unset or any other value renders empty in the step env and the
-   original assertion stands byte-for-byte); the PR author probes as `admin` via
-   `repos/{repo}/collaborators/{author}/permission` (a solo maintainer is
-   necessarily admin — the variable alone can never waive a mere-write author);
-   and no write-or-higher non-author reviewer has an effective `APPROVED` or
-   `CHANGES_REQUESTED` review on the PR (if one does, the original exact-head
-   binding runs unchanged). A waived run prints an explicit
-   `solo-maintainer waiver` notice into the job log and writes an audit record —
-   variable value, author, probed permission, and the review evidence examined —
-   into the job summary. Any error in the corroboration probe fails closed; an
-   error is never a waiver, and the probe response is indexed strictly so schema
-   drift also fails closed.
-
-   Token-scope facts, verified empirically under this job's exact `GITHUB_TOKEN`
-   permission grants (probe runs 32191036659 and 32191166538, 2026-08-18): the
-   collaborators **list** endpoint (`repos/{repo}/collaborators`) returns HTTP
-   200 with an **empty** list under the job token and must never be used as a
-   binding input; the **per-user** permission endpoint
-   (`repos/{repo}/collaborators/{login}/permission`) works and returns the full
-   permission payload. That is why the waiver corroborates through the per-user
-   endpoint and a declared variable rather than collaborator enumeration.
-
-   Residual admin window (stated honestly): this review binding does **not**
-   prevent bypass by an actor with repository administration rights. Such an
-   actor can set `RELEASE_SOLO_MAINTAINER`, and could equally manage
-   collaborators or branch protection. The variable is accepted precisely
-   because it adds no marginal attacker capability beyond what repo admin
-   already concedes, while being explicit, auditable in the job summary, and
-   revocable in one line. The
+   merge evidence. Review approval is **not** required: this is a
+   solo-maintainer repository, and bot merges and self-merges are explicitly
+   acceptable. (The former non-self approval binding from PR #297 was
+   unsatisfiable here — zero eligible non-self reviewers exist, and the
+   collaborators list endpoint returns an empty list under the job's
+   `GITHUB_TOKEN`, verified empirically in probe runs 32191036659 and
+   32191166538 on 2026-08-18 — so the maintainer removed it.) The
    head's single `CI Success` check must come from GitHub Actions and resolve to a
    successful pull-request run of this repository's `.github/workflows/ci.yml`.
 2. The same job builds once in the official uv/Python 3.13 image pinned by the
@@ -216,21 +191,16 @@ attestation to expose the same GitHub run or attempt as a PyPI-enforced property
 The workflow cannot create or repair these external controls. Verify them before
 unfreezing publication and again during release review:
 
-- `main` is protected: the final release-candidate PR requires review, dismisses
-  stale approval, requires `CI Success`, requires the branch to be up to date,
-  prevents bypass, and is merged with GitHub's **Create a merge commit** method.
-  On a solo-maintainer repository, required review cannot be satisfied by anyone
-  else; the maintainer declares that state by setting the repository Actions
-  variable `RELEASE_SOLO_MAINTAINER` to `true` and may relax the branch
-  protection review requirement accordingly. Restoring full team mode is one
-  line — `gh variable delete RELEASE_SOLO_MAINTAINER` (or set it to anything
-  but `true`) — and an effective write-or-higher non-author review on the
-  release PR re-arms the exact-head binding even while the variable is set.
+- `main` is protected: direct pushes are prevented, `CI Success` is required,
+  the branch must be up to date, bypass is prevented, and the final
+  release-candidate PR is merged with GitHub's **Create a merge commit**
+  method. Review approval is **not** required — this is a solo-maintainer
+  repository and bot/self merges are acceptable.
 - A tag ruleset protects `v*` tags from update and deletion except for the narrow,
   audited recovery operation described below.
-- The `pypi` environment requires an independent reviewer (on a solo-maintainer
-  repository, the maintainer themself — the explicit human promotion decision),
-  limits deployments to protected `v*` tags, and disallows administrator bypass.
+- The `pypi` environment requires a deployment reviewer (the maintainer — the
+  explicit human promotion decision), limits deployments to protected `v*`
+  tags, and disallows administrator bypass.
 - The `testpypi` environment limits deployments to protected `v*` tags.
 - PyPI and TestPyPI trusted-publisher bindings match this repository, the
   `release.yml` workflow, and their respective environment names.
@@ -245,11 +215,8 @@ or mutate repository, environment, or package-index settings.
 
 1. Prepare the final version and every release-tree change in one final candidate
    pull request. `project.version` must equal the intended tag without `v`.
-2. Obtain an effective approval and successful required CI on the exact final head.
-   If the head changes, repeat both gates. On a solo-maintainer repository with
-   `RELEASE_SOLO_MAINTAINER=true` and an admin author, the workflow waives the
-   approval gate (with a logged notice and a job-summary audit record); required
-   CI on the exact head is never waived.
+2. Obtain successful required CI on the exact final head. If the head changes,
+   repeat the gate. Review approval is not required.
 3. Merge with GitHub **Create a merge commit**. Do not squash or rebase.
 4. Confirm no later commit has reached `main`, then create the protected `v*` tag
    on that GitHub merge commit and publish the GitHub Release for the same tag.
@@ -266,7 +233,7 @@ or mutate repository, environment, or package-index settings.
 - If `main` moves before artifact sealing, the second equality check fails and no
   package-index upload occurs. Delete the unpublished or failed GitHub Release and
   its tag using the audited tag-recovery path. Prepare a new final candidate on
-  current `main`, obtain fresh exact-head review and CI, merge it, and create a new
+  current `main`, obtain fresh exact-head CI, merge it, and create a new
   release tag. Do not retarget or recreate the old candidate tag.
 - Movement of `main` after the sealing check does not change the sealed artifact.
   The bound commit/tree/PR/workflow/container and attestation results remain visible
@@ -304,10 +271,10 @@ gh run rerun --repo joyfulhouse/pylxpweb --job "$prepare_job_id"
   terminal verifier completes from the sealed artifact and exact remote bytes.
 - **Partial publication:** MUST preserve the run summaries and package-index
   evidence, treat the version as burned, and prepare a new version through the
-  normal reviewed release process. Never upload the missing file as a top-up.
+  normal release process. Never upload the missing file as a top-up.
 - **Mismatch, yanked, extra, or competing publication:** MUST stop publication,
   preserve all evidence, and begin the compromise assessment below before creating
-  a new reviewed version. Do not normalize, delete, or overwrite remote evidence.
+  a new version. Do not normalize, delete, or overwrite remote evidence.
 - **Uncertain evidence:** MUST NOT approve or publish. Retry only `prepare-pypi`
   and its dependent verifier/classifier path after the transient condition is
   understood. Repeated uncertainty is not evidence of absence.
@@ -336,7 +303,7 @@ If a release workflow or authorized GitHub identity may be compromised:
    keys. Review repository, environment, release, and package-index audit records
    for unauthorized changes or publications.
 4. Restore environments and trusted-publisher bindings only after recovery,
-   identity rotation, artifact verification, and review are complete.
+   identity rotation and artifact verification are complete.
 
 Trusted publishing remains secretless. No long-lived package-index credential is
 introduced for normal publication or recovery.
@@ -368,7 +335,7 @@ the GitHub-hosted release event, protected environments, and trusted publishing.
 ## Troubleshooting
 
 - A source-identity failure means the event tag, project version, commit, tree,
-  tag-resident workflow identity, reviewed merge identity, or freshly fetched
+  tag-resident workflow identity, merged-PR identity, or freshly fetched
   `main` did not agree. Correct the release inputs; do not weaken the check.
 - A TestPyPI verification failure means the remote name, version, filenames,
   yanked state, hashes, or downloaded distributions did not match the sealed

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -34,7 +34,13 @@ Publishing is a linear seven-job promotion chain:
    pull request. Its first parent is the previous `main`, its second parent is the
    final pull-request head, and the first parent must be an ancestor of that head.
    The PR base is `main`; GitHub's mutable `pull.base.sha` is not used as historical
-   merge evidence. An effective non-self approval covers the exact head. The
+   merge evidence. An effective non-self approval covers the exact head whenever
+   the repository has at least one write-or-higher collaborator other than the PR
+   author; when the author is the sole write-or-higher collaborator, the approval
+   binding is waived and an explicit `solo-maintainer waiver` notice is printed
+   into the job log. The waiver decision is derived from the same GitHub
+   collaborator-permission data the review gate already trusts, and any error
+   while listing collaborators fails closed — an error is never a waiver. The
    head's single `CI Success` check must come from GitHub Actions and resolve to a
    successful pull-request run of this repository's `.github/workflows/ci.yml`.
 2. The same job builds once in the official uv/Python 3.13 image pinned by the
@@ -188,10 +194,17 @@ unfreezing publication and again during release review:
 - `main` is protected: the final release-candidate PR requires review, dismisses
   stale approval, requires `CI Success`, requires the branch to be up to date,
   prevents bypass, and is merged with GitHub's **Create a merge commit** method.
+  On a solo-maintainer repository (the PR author is the only write-or-higher
+  collaborator), required review cannot be satisfied by anyone else; the
+  workflow's approval binding waives itself in that case, and the branch
+  protection review requirement may be relaxed accordingly until a second
+  eligible collaborator exists — at which point the non-self approval binding
+  re-arms automatically.
 - A tag ruleset protects `v*` tags from update and deletion except for the narrow,
   audited recovery operation described below.
-- The `pypi` environment requires an independent reviewer, limits deployments to
-  protected `v*` tags, and disallows administrator bypass.
+- The `pypi` environment requires an independent reviewer (on a solo-maintainer
+  repository, the maintainer themself — the explicit human promotion decision),
+  limits deployments to protected `v*` tags, and disallows administrator bypass.
 - The `testpypi` environment limits deployments to protected `v*` tags.
 - PyPI and TestPyPI trusted-publisher bindings match this repository, the
   `release.yml` workflow, and their respective environment names.
@@ -207,7 +220,8 @@ or mutate repository, environment, or package-index settings.
 1. Prepare the final version and every release-tree change in one final candidate
    pull request. `project.version` must equal the intended tag without `v`.
 2. Obtain an effective approval and successful required CI on the exact final head.
-   If the head changes, repeat both gates.
+   If the head changes, repeat both gates. On a solo-maintainer repository the
+   workflow waives the approval gate (with a logged notice); CI is still required.
 3. Merge with GitHub **Create a merge commit**. Do not squash or rebase.
 4. Confirm no later commit has reached `main`, then create the protected `v*` tag
    on that GitHub merge commit and publish the GitHub Release for the same tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           EVENT_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_SOLO_MAINTAINER: ${{ vars.RELEASE_SOLO_MAINTAINER }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           REPOSITORY: ${{ github.repository }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
@@ -164,11 +165,18 @@ jobs:
               "repos/$REPOSITORY/collaborators/$reviewer/permission" --jq .permission)
             printf '%s\t%s\n' "$reviewer" "$permission" >> "$api_dir/permissions.tsv"
           done < "$api_dir/reviewers.txt"
-          gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
-            "repos/$REPOSITORY/collaborators" > "$api_dir/collaborators.json"
+          if [[ "${RELEASE_SOLO_MAINTAINER:-}" == "true" ]]; then
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/$REPOSITORY/collaborators/$author/permission" \
+              > "$api_dir/author-permission.json"
+          else
+            printf 'null' > "$api_dir/author-permission.json"
+          fi
           python3 - "$api_dir/effective-reviews.json" "$api_dir/permissions.tsv" \
-            "$api_dir/collaborators.json" "$head" "$author" <<'PY'
+            "$api_dir/author-permission.json" "${RELEASE_SOLO_MAINTAINER:-}" \
+            "$head" "$author" <<'PY'
           import json
+          import os
           import pathlib
           import sys
 
@@ -177,9 +185,8 @@ jobs:
               line.split("\t", 1)
               for line in pathlib.Path(sys.argv[2]).read_text().splitlines()
           )
-          collaborator_pages = json.loads(pathlib.Path(sys.argv[3]).read_text())
-          collaborators = [entry for page in collaborator_pages for entry in page]
-          head, author = sys.argv[4:]
+          author_probe = json.loads(pathlib.Path(sys.argv[3]).read_text())
+          solo_flag, head, author = sys.argv[4:]
           eligible = {
               login: review
               for login, review in effective.items()
@@ -188,24 +195,37 @@ jobs:
           assert not any(
               review["state"] == "CHANGES_REQUESTED" for review in eligible.values()
           ), "an eligible reviewer still requests changes"
-          eligible_collaborators = {
-              entry["login"]
-              for entry in collaborators
-              if any(entry["permissions"].get(level) for level in ("push", "maintain", "admin"))
-          }
-          assert eligible_collaborators, "no write-or-higher collaborator is visible"
-          if eligible_collaborators - {author}:
+          eligible_non_author = sorted(login for login in eligible if login != author)
+          waive = (
+              solo_flag == "true"
+              and not eligible_non_author
+              and author_probe["permission"] == "admin"
+          )
+          if waive:
+              print(
+                  "solo-maintainer waiver: no eligible non-author reviewer exists; "
+                  "approval binding waived"
+              )
+              with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+                  summary.write(
+                      "## Solo-maintainer waiver audit\n\n"
+                      f"- `RELEASE_SOLO_MAINTAINER` variable: `{solo_flag}`\n"
+                      f"- PR author: `{author}`\n"
+                      "- Author permission probed via "
+                      f"`repos/.../collaborators/{author}/permission`: "
+                      f"`{author_probe['permission']}`\n"
+                      "- Effective reviews examined: "
+                      f"{json.dumps({login: review['state'] for login, review in sorted(effective.items())})}\n"
+                      "- Eligible non-author reviewers found: "
+                      f"{json.dumps(eligible_non_author)}\n"
+                  )
+          else:
               assert any(
                   login != author
                   and review["state"] == "APPROVED"
                   and review["commit_id"] == head
                   for login, review in eligible.items()
               ), "no effective eligible non-self approval covers the exact PR head"
-          else:
-              print(
-                  "solo-maintainer waiver: no eligible non-author reviewer exists; "
-                  "approval binding waived"
-              )
           PY
 
           gh api --paginate --slurp -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,8 +164,10 @@ jobs:
               "repos/$REPOSITORY/collaborators/$reviewer/permission" --jq .permission)
             printf '%s\t%s\n' "$reviewer" "$permission" >> "$api_dir/permissions.tsv"
           done < "$api_dir/reviewers.txt"
+          gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/collaborators" > "$api_dir/collaborators.json"
           python3 - "$api_dir/effective-reviews.json" "$api_dir/permissions.tsv" \
-            "$head" "$author" <<'PY'
+            "$api_dir/collaborators.json" "$head" "$author" <<'PY'
           import json
           import pathlib
           import sys
@@ -175,7 +177,9 @@ jobs:
               line.split("\t", 1)
               for line in pathlib.Path(sys.argv[2]).read_text().splitlines()
           )
-          head, author = sys.argv[3:]
+          collaborator_pages = json.loads(pathlib.Path(sys.argv[3]).read_text())
+          collaborators = [entry for page in collaborator_pages for entry in page]
+          head, author = sys.argv[4:]
           eligible = {
               login: review
               for login, review in effective.items()
@@ -184,12 +188,24 @@ jobs:
           assert not any(
               review["state"] == "CHANGES_REQUESTED" for review in eligible.values()
           ), "an eligible reviewer still requests changes"
-          assert any(
-              login != author
-              and review["state"] == "APPROVED"
-              and review["commit_id"] == head
-              for login, review in eligible.items()
-          ), "no effective eligible non-self approval covers the exact PR head"
+          eligible_collaborators = {
+              entry["login"]
+              for entry in collaborators
+              if any(entry["permissions"].get(level) for level in ("push", "maintain", "admin"))
+          }
+          assert eligible_collaborators, "no write-or-higher collaborator is visible"
+          if eligible_collaborators - {author}:
+              assert any(
+                  login != author
+                  and review["state"] == "APPROVED"
+                  and review["commit_id"] == head
+                  for login, review in eligible.items()
+              ), "no effective eligible non-self approval covers the exact PR head"
+          else:
+              print(
+                  "solo-maintainer waiver: no eligible non-author reviewer exists; "
+                  "approval binding waived"
+              )
           PY
 
           gh api --paginate --slurp -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,12 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - id: bind-source
-        name: Bind the event, workflow, merge, review, and CI identity
+        name: Bind the event, workflow, merge, and CI identity
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_DRAFT: ${{ github.event.release.draft }}
-          RELEASE_SOLO_MAINTAINER: ${{ vars.RELEASE_SOLO_MAINTAINER }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           REPOSITORY: ${{ github.repository }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
@@ -130,103 +129,10 @@ jobs:
           assert pull["head"]["sha"] == second_parent, "PR head is not second parent"
           print(pull["number"])
           print(pull["head"]["sha"])
-          print(pull["user"]["login"])
           PY
           )
           pr="${pr_identity[0]}"
           head="${pr_identity[1]}"
-          author="${pr_identity[2]}"
-
-          gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
-            "repos/$REPOSITORY/pulls/$pr/reviews" > "$api_dir/reviews.json"
-          python3 - "$api_dir/reviews.json" "$api_dir/effective-reviews.json" \
-            > "$api_dir/reviewers.txt" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          pages = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          reviews = [review for page in pages for review in page]
-          effective = {}
-          for review in sorted(
-              reviews,
-              key=lambda item: (item.get("submitted_at") or "", item.get("id", 0)),
-          ):
-              if review["state"] in {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}:
-                  effective[review["user"]["login"]] = review
-          pathlib.Path(sys.argv[2]).write_text(json.dumps(effective))
-          for login, review in sorted(effective.items()):
-              if review["state"] in {"APPROVED", "CHANGES_REQUESTED"}:
-                  print(login)
-          PY
-          : > "$api_dir/permissions.tsv"
-          while IFS= read -r reviewer; do
-            permission=$(gh api -H "Accept: application/vnd.github+json" \
-              "repos/$REPOSITORY/collaborators/$reviewer/permission" --jq .permission)
-            printf '%s\t%s\n' "$reviewer" "$permission" >> "$api_dir/permissions.tsv"
-          done < "$api_dir/reviewers.txt"
-          if [[ "${RELEASE_SOLO_MAINTAINER:-}" == "true" ]]; then
-            gh api -H "Accept: application/vnd.github+json" \
-              "repos/$REPOSITORY/collaborators/$author/permission" \
-              > "$api_dir/author-permission.json"
-          else
-            printf 'null' > "$api_dir/author-permission.json"
-          fi
-          python3 - "$api_dir/effective-reviews.json" "$api_dir/permissions.tsv" \
-            "$api_dir/author-permission.json" "${RELEASE_SOLO_MAINTAINER:-}" \
-            "$head" "$author" <<'PY'
-          import json
-          import os
-          import pathlib
-          import sys
-
-          effective = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          permissions = dict(
-              line.split("\t", 1)
-              for line in pathlib.Path(sys.argv[2]).read_text().splitlines()
-          )
-          author_probe = json.loads(pathlib.Path(sys.argv[3]).read_text())
-          solo_flag, head, author = sys.argv[4:]
-          eligible = {
-              login: review
-              for login, review in effective.items()
-              if permissions.get(login) in {"write", "maintain", "admin"}
-          }
-          assert not any(
-              review["state"] == "CHANGES_REQUESTED" for review in eligible.values()
-          ), "an eligible reviewer still requests changes"
-          eligible_non_author = sorted(login for login in eligible if login != author)
-          waive = (
-              solo_flag == "true"
-              and not eligible_non_author
-              and author_probe["permission"] == "admin"
-          )
-          if waive:
-              print(
-                  "solo-maintainer waiver: no eligible non-author reviewer exists; "
-                  "approval binding waived"
-              )
-              with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
-                  summary.write(
-                      "## Solo-maintainer waiver audit\n\n"
-                      f"- `RELEASE_SOLO_MAINTAINER` variable: `{solo_flag}`\n"
-                      f"- PR author: `{author}`\n"
-                      "- Author permission probed via "
-                      f"`repos/.../collaborators/{author}/permission`: "
-                      f"`{author_probe['permission']}`\n"
-                      "- Effective reviews examined: "
-                      f"{json.dumps({login: review['state'] for login, review in sorted(effective.items())})}\n"
-                      "- Eligible non-author reviewers found: "
-                      f"{json.dumps(eligible_non_author)}\n"
-                  )
-          else:
-              assert any(
-                  login != author
-                  and review["state"] == "APPROVED"
-                  and review["commit_id"] == head
-                  for login, review in eligible.items()
-              ), "no effective eligible non-self approval covers the exact PR head"
-          PY
 
           gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
             "repos/$REPOSITORY/commits/$head/check-runs" > "$api_dir/checks.json"

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -273,9 +273,6 @@ if len(sys.argv) >= 2 and sys.argv[1] == "api":
         print(f"unexpected endpoint: {endpoint}", file=sys.stderr)
         raise SystemExit(2)
     value = fixtures[endpoint]
-    if "--jq" in sys.argv:
-        print(value[sys.argv[sys.argv.index("--jq") + 1].removeprefix(".")])
-        raise SystemExit(0)
     if "--slurp" in sys.argv:
         if isinstance(value, list):
             pages = [value[index : index + 30] for index in range(0, len(value), 30)]
@@ -967,7 +964,7 @@ def test_checkout_depth_exposes_both_merge_parents(tmp_path: Path) -> None:
 def test_binding_rejects_event_workflow_and_version_identity_mismatch(
     tmp_path: Path, override: dict[str, str], message: str
 ) -> None:
-    """Weakening any event/workflow/tag equality permits an unreviewed identity."""
+    """Weakening any event/workflow/tag equality permits an unbound identity."""
     case = _release_repo(tmp_path)
     if override.get("RELEASE_TAG") == "v9.9.9":
         override["WORKFLOW_REF"] = (
@@ -1009,7 +1006,7 @@ def test_binding_rejects_merge_tree_not_tested_on_exact_pr_head(tmp_path: Path) 
     case = _release_repo(tmp_path)
     repo: Path = case["repo"]
     old_merge = case["merge"]
-    repo.joinpath("injected.txt").write_text("not reviewed\n")
+    repo.joinpath("injected.txt").write_text("not CI-tested\n")
     subprocess.run(["git", "add", "injected.txt"], cwd=repo, check=True)
     tree = _git(repo, "write-tree")
     altered = subprocess.check_output(
@@ -1067,7 +1064,7 @@ def test_binding_does_not_treat_mutable_pr_base_sha_as_merge_parent(tmp_path: Pa
     ],
 )
 def test_binding_rejects_invalid_merge_and_associated_pr(tmp_path: Path, mutation: str) -> None:
-    """Relaxing merge geometry or PR identity admits a non-reviewed candidate."""
+    """Relaxing merge geometry or PR identity admits a non-CI-tested candidate."""
     case = _release_repo(tmp_path)
     repo: Path = case["repo"]
     pull_key = f"repos/joyfulhouse/pylxpweb/commits/{case['merge']}/pulls"
@@ -1125,12 +1122,14 @@ def test_binding_rejects_invalid_merge_and_associated_pr(tmp_path: Path, mutatio
     assert result.returncode != 0
 
 
-@pytest.mark.parametrize("mutation", ["failed-ci", "wrong-ci-head"])
+@pytest.mark.parametrize("mutation", ["missing-ci", "failed-ci", "wrong-ci-head"])
 def test_binding_rejects_missing_or_stale_required_ci(tmp_path: Path, mutation: str) -> None:
     """Dropping the exact-head CI-success binding permits an untested candidate."""
     case = _release_repo(tmp_path)
     check_key = f"repos/joyfulhouse/pylxpweb/commits/{case['head']}/check-runs"
-    if mutation == "failed-ci":
+    if mutation == "missing-ci":
+        case["fixtures"][check_key]["check_runs"] = []
+    elif mutation == "failed-ci":
         case["fixtures"][check_key]["check_runs"][0]["conclusion"] = "failure"
     elif mutation == "wrong-ci-head":
         case["fixtures"][check_key]["check_runs"][0]["head_sha"] = case["parent"]

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -337,27 +337,6 @@ raise SystemExit(2)
     gh.chmod(0o755)
 
 
-def _permission_payload(login: str, permission: str) -> dict[str, Any]:
-    """Mirror the real ``collaborators/{login}/permission`` response shape.
-
-    Captured live under the release job's own GITHUB_TOKEN grants (probe runs
-    32191036659 and 32191166538): the legacy ``permission`` field plus a full
-    ``user`` object carrying fine-grained ``permissions`` booleans and
-    duplicated ``role_name`` keys.
-    """
-    grants = ["pull", "triage", "push", "maintain", "admin"]
-    granted = grants[: grants.index("push" if permission == "write" else permission) + 1]
-    return {
-        "permission": permission,
-        "role_name": permission,
-        "user": {
-            "login": login,
-            "permissions": {grant: grant in granted for grant in grants},
-            "role_name": permission,
-        },
-    }
-
-
 def _release_repo(
     tmp_path: Path, *, lightweight: bool = False, stale_candidate: bool = False
 ) -> dict[str, Any]:
@@ -415,17 +394,6 @@ def _release_repo(
                 "user": {"login": "author"},
             }
         ],
-        f"repos/{repository}/pulls/17/reviews": [
-            {
-                "state": "APPROVED",
-                "commit_id": head,
-                "submitted_at": "2026-08-16T11:00:00Z",
-                "user": {"login": "reviewer"},
-            }
-        ],
-        f"repos/{repository}/collaborators/reviewer/permission": _permission_payload(
-            "reviewer", "write"
-        ),
         f"repos/{repository}/commits/{head}/check-runs": {
             "check_runs": [
                 {
@@ -943,9 +911,7 @@ def test_harness_never_hands_bash_a_python_heredoc(
 
 
 @pytest.mark.parametrize("lightweight", [False, True], ids=["annotated", "lightweight"])
-def test_binding_accepts_exact_reviewed_merge_and_peels_tag(
-    tmp_path: Path, lightweight: bool
-) -> None:
+def test_binding_accepts_exact_merged_pr_and_peels_tag(tmp_path: Path, lightweight: bool) -> None:
     """Changing tag peeling or exact merge binding rejects a valid release."""
     case = _release_repo(tmp_path, lightweight=lightweight)
     result = _run_binding(case, tmp_path)
@@ -1159,47 +1125,12 @@ def test_binding_rejects_invalid_merge_and_associated_pr(tmp_path: Path, mutatio
     assert result.returncode != 0
 
 
-@pytest.mark.parametrize(
-    "mutation",
-    [
-        "dismissed",
-        "old-head",
-        "self",
-        "outsider",
-        "eligible-change-request",
-        "failed-ci",
-        "wrong-ci-head",
-    ],
-)
-def test_binding_rejects_ineffective_review_or_required_ci(tmp_path: Path, mutation: str) -> None:
-    """Dropping exact-head approval or CI checks permits stale review state."""
+@pytest.mark.parametrize("mutation", ["failed-ci", "wrong-ci-head"])
+def test_binding_rejects_missing_or_stale_required_ci(tmp_path: Path, mutation: str) -> None:
+    """Dropping the exact-head CI-success binding permits an untested candidate."""
     case = _release_repo(tmp_path)
-    review_key = "repos/joyfulhouse/pylxpweb/pulls/17/reviews"
     check_key = f"repos/joyfulhouse/pylxpweb/commits/{case['head']}/check-runs"
-    if mutation == "dismissed":
-        case["fixtures"][review_key][0]["state"] = "DISMISSED"
-    elif mutation == "old-head":
-        case["fixtures"][review_key][0]["commit_id"] = case["parent"]
-    elif mutation == "self":
-        case["fixtures"][review_key][0]["user"]["login"] = "author"
-    elif mutation == "outsider":
-        case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators/reviewer/permission"][
-            "permission"
-        ] = "read"
-    elif mutation == "eligible-change-request":
-        case["fixtures"][review_key].append(
-            {
-                "id": 2,
-                "state": "CHANGES_REQUESTED",
-                "commit_id": case["head"],
-                "submitted_at": "2026-08-16T11:30:00Z",
-                "user": {"login": "blocker"},
-            }
-        )
-        case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators/blocker/permission"] = {
-            "permission": "maintain"
-        }
-    elif mutation == "failed-ci":
+    if mutation == "failed-ci":
         case["fixtures"][check_key]["check_runs"][0]["conclusion"] = "failure"
     elif mutation == "wrong-ci-head":
         case["fixtures"][check_key]["check_runs"][0]["head_sha"] = case["parent"]
@@ -1248,103 +1179,17 @@ def test_binding_rejects_same_name_ci_from_untrusted_producer(
     assert result.returncode != 0
 
 
-def test_binding_reads_all_review_pages_before_deciding(tmp_path: Path) -> None:
-    """Dropping pagination can miss a later blocking review after page one."""
+def test_binding_releases_merged_pr_with_zero_reviews(tmp_path: Path) -> None:
+    """Review approval is not required: a merged two-parent PR releases as-is.
+
+    The fixtures contain no review data at all, so any re-introduction of a
+    review-approval binding (which would have to fetch and assert on reviews)
+    fails this test rather than silently tightening the release contract.
+    """
     case = _release_repo(tmp_path)
-    review_key = "repos/joyfulhouse/pylxpweb/pulls/17/reviews"
-    reviews = case["fixtures"][review_key]
-    reviews.extend(
-        {
-            "id": index,
-            "state": "COMMENTED",
-            "commit_id": case["head"],
-            "submitted_at": f"2026-08-16T11:{index:02d}:00Z",
-            "user": {"login": f"commenter-{index}"},
-        }
-        for index in range(1, 31)
-    )
-    reviews.append(
-        {
-            "id": 31,
-            "state": "CHANGES_REQUESTED",
-            "commit_id": case["head"],
-            "submitted_at": "2026-08-16T12:00:00Z",
-            "user": {"login": "late-blocker"},
-        }
-    )
-    case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators/late-blocker/permission"] = {
-        "permission": "write"
-    }
+    assert not any("reviews" in endpoint for endpoint in case["fixtures"])
     result = _run_binding(case, tmp_path)
-    assert result.returncode != 0
-
-
-_SOLO_WAIVER_NOTICE = (
-    "solo-maintainer waiver: no eligible non-author reviewer exists; approval binding waived"
-)
-
-
-_AUTHOR_PERMISSION_KEY = "repos/joyfulhouse/pylxpweb/collaborators/author/permission"
-_REVIEWS_KEY = "repos/joyfulhouse/pylxpweb/pulls/17/reviews"
-
-
-@pytest.mark.parametrize("variable", [None, "false"], ids=["unset", "false"])
-def test_binding_requires_non_self_approval_without_solo_variable(
-    tmp_path: Path, variable: str | None
-) -> None:
-    """Without RELEASE_SOLO_MAINTAINER == 'true' the original binding stands."""
-    case = _release_repo(tmp_path)
-    case["fixtures"][_REVIEWS_KEY] = []
-    case["fixtures"][_AUTHOR_PERMISSION_KEY] = _permission_payload("author", "admin")
-    overrides = {} if variable is None else {"RELEASE_SOLO_MAINTAINER": variable}
-    result = _run_binding(case, tmp_path, **overrides)
-    assert result.returncode != 0
-    assert "no effective eligible non-self approval" in result.stderr
-    assert _SOLO_WAIVER_NOTICE not in result.stdout
-
-
-def test_binding_waives_approval_for_declared_solo_admin_author(tmp_path: Path) -> None:
-    """Variable set, admin author, no eligible reviews: waiver plus audit record."""
-    case = _release_repo(tmp_path)
-    case["fixtures"][_REVIEWS_KEY] = []
-    case["fixtures"][_AUTHOR_PERMISSION_KEY] = _permission_payload("author", "admin")
-    result = _run_binding(case, tmp_path, RELEASE_SOLO_MAINTAINER="true")
     assert result.returncode == 0, result.stderr
-    assert _SOLO_WAIVER_NOTICE in result.stdout
-    summary = (tmp_path / "github-summary").read_text()
-    assert "Solo-maintainer waiver audit" in summary
-    assert "- PR author: `author`" in summary
-    assert "`admin`" in summary
-    assert "Eligible non-author reviewers found: []" in summary
-
-
-def test_binding_ignores_solo_variable_for_non_admin_author(tmp_path: Path) -> None:
-    """A write-not-admin author cannot be waived by the variable alone."""
-    case = _release_repo(tmp_path)
-    case["fixtures"][_REVIEWS_KEY] = []
-    case["fixtures"][_AUTHOR_PERMISSION_KEY] = _permission_payload("author", "write")
-    result = _run_binding(case, tmp_path, RELEASE_SOLO_MAINTAINER="true")
-    assert result.returncode != 0
-    assert "no effective eligible non-self approval" in result.stderr
-    assert _SOLO_WAIVER_NOTICE not in result.stdout
-
-
-def test_binding_prefers_existing_eligible_review_over_waiver(tmp_path: Path) -> None:
-    """An eligible non-author review re-arms the exact-head binding despite the variable."""
-    case = _release_repo(tmp_path)
-    case["fixtures"][_AUTHOR_PERMISSION_KEY] = _permission_payload("author", "admin")
-    result = _run_binding(case, tmp_path, RELEASE_SOLO_MAINTAINER="true")
-    assert result.returncode == 0, result.stderr
-    assert _SOLO_WAIVER_NOTICE not in result.stdout
-
-
-def test_binding_fails_closed_when_author_permission_probe_errors(tmp_path: Path) -> None:
-    """An error probing the author's permission must fail the release, never waive it."""
-    case = _release_repo(tmp_path)
-    case["fixtures"][_REVIEWS_KEY] = []
-    result = _run_binding(case, tmp_path, RELEASE_SOLO_MAINTAINER="true")
-    assert result.returncode != 0
-    assert _SOLO_WAIVER_NOTICE not in result.stdout
 
 
 @pytest.mark.parametrize("step_id", ["assert-clean-source", "seal-source"])
@@ -2299,7 +2144,7 @@ def test_verify_pypi_retries_absent_but_prepare_classifies_once() -> None:
     """Prepare must keep single-pass semantics; only terminal verification retries.
 
     A retrying prepare could wait out genuine absence differently than the
-    reviewed publish gate expects, while a non-retrying terminal verifier fails
+    publish gate expects, while a non-retrying terminal verifier fails
     the happy path on routine PyPI index-propagation lag after publish-pypi.
     """
     prepare_env = _step("prepare-pypi", "classify-pypi-state")["env"]

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -403,6 +403,28 @@ def _release_repo(
             }
         ],
         f"repos/{repository}/collaborators/reviewer/permission": {"permission": "write"},
+        f"repos/{repository}/collaborators": [
+            {
+                "login": "author",
+                "permissions": {
+                    "admin": True,
+                    "maintain": True,
+                    "push": True,
+                    "triage": True,
+                    "pull": True,
+                },
+            },
+            {
+                "login": "reviewer",
+                "permissions": {
+                    "admin": False,
+                    "maintain": False,
+                    "push": True,
+                    "triage": True,
+                    "pull": True,
+                },
+            },
+        ],
         f"repos/{repository}/commits/{head}/check-runs": {
             "check_runs": [
                 {
@@ -1254,6 +1276,68 @@ def test_binding_reads_all_review_pages_before_deciding(tmp_path: Path) -> None:
     }
     result = _run_binding(case, tmp_path)
     assert result.returncode != 0
+
+
+_SOLO_WAIVER_NOTICE = (
+    "solo-maintainer waiver: no eligible non-author reviewer exists; approval binding waived"
+)
+
+
+def test_binding_still_requires_non_self_approval_when_team_exists(tmp_path: Path) -> None:
+    """Another write-or-higher collaborator existing keeps the approval binding armed."""
+    case = _release_repo(tmp_path)
+    review_key = "repos/joyfulhouse/pylxpweb/pulls/17/reviews"
+    case["fixtures"][review_key][0]["user"]["login"] = "author"
+    case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators/author/permission"] = {
+        "permission": "admin"
+    }
+    result = _run_binding(case, tmp_path)
+    assert result.returncode != 0
+    assert "no effective eligible non-self approval" in result.stderr
+    assert _SOLO_WAIVER_NOTICE not in result.stdout
+
+
+def test_binding_waives_approval_when_author_is_sole_eligible_collaborator(
+    tmp_path: Path,
+) -> None:
+    """A solo-maintainer repo releases without approval, with an explicit log notice."""
+    case = _release_repo(tmp_path)
+    case["fixtures"]["repos/joyfulhouse/pylxpweb/pulls/17/reviews"] = []
+    case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators"] = [
+        {
+            "login": "author",
+            "permissions": {
+                "admin": True,
+                "maintain": True,
+                "push": True,
+                "triage": True,
+                "pull": True,
+            },
+        },
+        {
+            "login": "watcher",
+            "permissions": {
+                "admin": False,
+                "maintain": False,
+                "push": False,
+                "triage": False,
+                "pull": True,
+            },
+        },
+    ]
+    result = _run_binding(case, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert _SOLO_WAIVER_NOTICE in result.stdout
+
+
+def test_binding_fails_closed_when_collaborator_listing_errors(tmp_path: Path) -> None:
+    """An error while listing collaborators must fail the release, never waive it."""
+    case = _release_repo(tmp_path)
+    case["fixtures"]["repos/joyfulhouse/pylxpweb/pulls/17/reviews"] = []
+    del case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators"]
+    result = _run_binding(case, tmp_path)
+    assert result.returncode != 0
+    assert _SOLO_WAIVER_NOTICE not in result.stdout
 
 
 @pytest.mark.parametrize("step_id", ["assert-clean-source", "seal-source"])

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -337,6 +337,27 @@ raise SystemExit(2)
     gh.chmod(0o755)
 
 
+def _permission_payload(login: str, permission: str) -> dict[str, Any]:
+    """Mirror the real ``collaborators/{login}/permission`` response shape.
+
+    Captured live under the release job's own GITHUB_TOKEN grants (probe runs
+    32191036659 and 32191166538): the legacy ``permission`` field plus a full
+    ``user`` object carrying fine-grained ``permissions`` booleans and
+    duplicated ``role_name`` keys.
+    """
+    grants = ["pull", "triage", "push", "maintain", "admin"]
+    granted = grants[: grants.index("push" if permission == "write" else permission) + 1]
+    return {
+        "permission": permission,
+        "role_name": permission,
+        "user": {
+            "login": login,
+            "permissions": {grant: grant in granted for grant in grants},
+            "role_name": permission,
+        },
+    }
+
+
 def _release_repo(
     tmp_path: Path, *, lightweight: bool = False, stale_candidate: bool = False
 ) -> dict[str, Any]:
@@ -402,29 +423,9 @@ def _release_repo(
                 "user": {"login": "reviewer"},
             }
         ],
-        f"repos/{repository}/collaborators/reviewer/permission": {"permission": "write"},
-        f"repos/{repository}/collaborators": [
-            {
-                "login": "author",
-                "permissions": {
-                    "admin": True,
-                    "maintain": True,
-                    "push": True,
-                    "triage": True,
-                    "pull": True,
-                },
-            },
-            {
-                "login": "reviewer",
-                "permissions": {
-                    "admin": False,
-                    "maintain": False,
-                    "push": True,
-                    "triage": True,
-                    "pull": True,
-                },
-            },
-        ],
+        f"repos/{repository}/collaborators/reviewer/permission": _permission_payload(
+            "reviewer", "write"
+        ),
         f"repos/{repository}/commits/{head}/check-runs": {
             "check_runs": [
                 {
@@ -1283,59 +1284,65 @@ _SOLO_WAIVER_NOTICE = (
 )
 
 
-def test_binding_still_requires_non_self_approval_when_team_exists(tmp_path: Path) -> None:
-    """Another write-or-higher collaborator existing keeps the approval binding armed."""
+_AUTHOR_PERMISSION_KEY = "repos/joyfulhouse/pylxpweb/collaborators/author/permission"
+_REVIEWS_KEY = "repos/joyfulhouse/pylxpweb/pulls/17/reviews"
+
+
+@pytest.mark.parametrize("variable", [None, "false"], ids=["unset", "false"])
+def test_binding_requires_non_self_approval_without_solo_variable(
+    tmp_path: Path, variable: str | None
+) -> None:
+    """Without RELEASE_SOLO_MAINTAINER == 'true' the original binding stands."""
     case = _release_repo(tmp_path)
-    review_key = "repos/joyfulhouse/pylxpweb/pulls/17/reviews"
-    case["fixtures"][review_key][0]["user"]["login"] = "author"
-    case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators/author/permission"] = {
-        "permission": "admin"
-    }
-    result = _run_binding(case, tmp_path)
+    case["fixtures"][_REVIEWS_KEY] = []
+    case["fixtures"][_AUTHOR_PERMISSION_KEY] = _permission_payload("author", "admin")
+    overrides = {} if variable is None else {"RELEASE_SOLO_MAINTAINER": variable}
+    result = _run_binding(case, tmp_path, **overrides)
     assert result.returncode != 0
     assert "no effective eligible non-self approval" in result.stderr
     assert _SOLO_WAIVER_NOTICE not in result.stdout
 
 
-def test_binding_waives_approval_when_author_is_sole_eligible_collaborator(
-    tmp_path: Path,
-) -> None:
-    """A solo-maintainer repo releases without approval, with an explicit log notice."""
+def test_binding_waives_approval_for_declared_solo_admin_author(tmp_path: Path) -> None:
+    """Variable set, admin author, no eligible reviews: waiver plus audit record."""
     case = _release_repo(tmp_path)
-    case["fixtures"]["repos/joyfulhouse/pylxpweb/pulls/17/reviews"] = []
-    case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators"] = [
-        {
-            "login": "author",
-            "permissions": {
-                "admin": True,
-                "maintain": True,
-                "push": True,
-                "triage": True,
-                "pull": True,
-            },
-        },
-        {
-            "login": "watcher",
-            "permissions": {
-                "admin": False,
-                "maintain": False,
-                "push": False,
-                "triage": False,
-                "pull": True,
-            },
-        },
-    ]
-    result = _run_binding(case, tmp_path)
+    case["fixtures"][_REVIEWS_KEY] = []
+    case["fixtures"][_AUTHOR_PERMISSION_KEY] = _permission_payload("author", "admin")
+    result = _run_binding(case, tmp_path, RELEASE_SOLO_MAINTAINER="true")
     assert result.returncode == 0, result.stderr
     assert _SOLO_WAIVER_NOTICE in result.stdout
+    summary = (tmp_path / "github-summary").read_text()
+    assert "Solo-maintainer waiver audit" in summary
+    assert "- PR author: `author`" in summary
+    assert "`admin`" in summary
+    assert "Eligible non-author reviewers found: []" in summary
 
 
-def test_binding_fails_closed_when_collaborator_listing_errors(tmp_path: Path) -> None:
-    """An error while listing collaborators must fail the release, never waive it."""
+def test_binding_ignores_solo_variable_for_non_admin_author(tmp_path: Path) -> None:
+    """A write-not-admin author cannot be waived by the variable alone."""
     case = _release_repo(tmp_path)
-    case["fixtures"]["repos/joyfulhouse/pylxpweb/pulls/17/reviews"] = []
-    del case["fixtures"]["repos/joyfulhouse/pylxpweb/collaborators"]
-    result = _run_binding(case, tmp_path)
+    case["fixtures"][_REVIEWS_KEY] = []
+    case["fixtures"][_AUTHOR_PERMISSION_KEY] = _permission_payload("author", "write")
+    result = _run_binding(case, tmp_path, RELEASE_SOLO_MAINTAINER="true")
+    assert result.returncode != 0
+    assert "no effective eligible non-self approval" in result.stderr
+    assert _SOLO_WAIVER_NOTICE not in result.stdout
+
+
+def test_binding_prefers_existing_eligible_review_over_waiver(tmp_path: Path) -> None:
+    """An eligible non-author review re-arms the exact-head binding despite the variable."""
+    case = _release_repo(tmp_path)
+    case["fixtures"][_AUTHOR_PERMISSION_KEY] = _permission_payload("author", "admin")
+    result = _run_binding(case, tmp_path, RELEASE_SOLO_MAINTAINER="true")
+    assert result.returncode == 0, result.stderr
+    assert _SOLO_WAIVER_NOTICE not in result.stdout
+
+
+def test_binding_fails_closed_when_author_permission_probe_errors(tmp_path: Path) -> None:
+    """An error probing the author's permission must fail the release, never waive it."""
+    case = _release_repo(tmp_path)
+    case["fixtures"][_REVIEWS_KEY] = []
+    result = _run_binding(case, tmp_path, RELEASE_SOLO_MAINTAINER="true")
     assert result.returncode != 0
     assert _SOLO_WAIVER_NOTICE not in result.stdout
 


### PR DESCRIPTION
## Summary

Final maintainer ruling: **remove the release review-approval requirement entirely.** This is a solo-maintainer repository; bot merges and self-merges are explicitly acceptable. No waiver machinery, no variables, no corroboration probes.

## Background

PR #297 added an assertion to `bind-build-attest` requiring an effective non-self approval, by a write-or-higher reviewer, covering the exact release-PR head. On this repository that control was **unsatisfiable by construction**:

- The repo has exactly one collaborator, so the eligible non-self reviewer set is empty. The assertion blocked the v0.10.0b3 cut.
- Two intermediate designs (collaborator-list-derived waiver; declared-variable waiver with an admin corroboration probe) were built and tribunal-reviewed on this branch. Empirical probes under the bind job's **exact `GITHUB_TOKEN` permission grants** (probe runs [32191036659](https://github.com/joyfulhouse/pylxpweb/actions/runs/32191036659) and [32191166538](https://github.com/joyfulhouse/pylxpweb/actions/runs/32191166538), 2026-08-18) additionally proved the collaborators **list** endpoint returns HTTP 200 with an **empty list** under the job token (the per-user permission endpoint works), so collaborator enumeration can never soundly drive such a control here.
- Rather than approximate an unsatisfiable control, the maintainer ruled to remove it. The interim `RELEASE_SOLO_MAINTAINER` repository variable has been deleted.

## What is removed

From `bind-build-attest`: the review-list fetch, the effective-review reduction, the per-reviewer permission probes, the eligible CHANGES_REQUESTED block, the non-self exact-head approval assertion, and all waiver machinery. The PR author login is no longer extracted.

## What stays byte-identical

Every non-review provenance binding: release-event + tag-resident workflow identity, two-parent merged-PR shape with exact-head/tree binding and first-parent ancestry, the exact-head `CI Success` binding to this repository's `ci.yml` `pull_request` run, source-cleanliness checks, the sealing linearization point, and artifact/attestation verification. Releases still require a merged two-parent PR with green CI and bound, attested artifacts — review approval is simply not among the gates.

`WORKFLOWS.md` now states this plainly (and keeps the probe-run evidence for the record); the required-review repository-settings claims are gone.

## Tests

Dead review-binding and waiver-matrix tests removed with their fixtures/helpers; the CI-mutation rejections remain as `test_binding_rejects_missing_or_stale_required_ci`. New happy path `test_binding_releases_merged_pr_with_zero_reviews` pins the simplified contract (fixtures contain no review data at all): **RED** with a review-approval assertion re-introduced into the workflow (the binding then demands review data the release does not guarantee), **GREEN** as shipped.

Gates: ruff check/format clean, `mypy --strict src/pylxpweb/` clean, `uv lock --check` clean. Full `tests/unit/test_release_workflow.py`: 138 passed in the gate run + all load-flaked binding tests confirmed passing in isolation; the only real failures are the 5 pre-existing Docker-daemon-dependent build-container cases (daemon not running locally), untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)