### PR TITLE
fix: restore hermetic uv_build pin broken by Dependabot bumps (#307/#308)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,8 @@ updates:
     # Ensure compatibility with uv
     reviewers:
       - "bryanli"
+    # uv_build is a hermetic release pin: it must match the uv bundled in the
+    # release workflow's digest-pinned BUILD_IMAGE (offline build). Bumping it
+    # alone breaks the release build (see #307/#308 regression).
+    ignore:
+      - dependency-name: "uv_build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,11 @@ pylxpweb-collect = "pylxpweb.cli.collect_device_data:main"
 pylxpweb-modbus-diag = "pylxpweb.cli.modbus_diag:main"
 
 [build-system]
-requires = ["uv_build==0.12.5"]
+# Hermetic release pin: must equal the uv version bundled in the release
+# workflow's digest-pinned BUILD_IMAGE (uv build --offline cannot fetch a
+# different backend). Bump ONLY together with BUILD_IMAGE and the
+# test_release_workflow.py pins. Dependabot is configured to ignore it.
+requires = ["uv_build==0.9.30"]
 build-backend = "uv_build"
 
 [tool.ruff]


### PR DESCRIPTION
## Problem

Dependabot PRs #307/#308 bumped `uv_build` to 0.12.5 and were merged **with the Unit Tests check failing**, leaving main red for every subsequent PR (currently blocking #310).

This isn't just a stale test pin: the release build is hermetic — the digest-pinned `BUILD_IMAGE` bundles uv **0.9.30** and builds with `uv build --offline`, so a mismatched `uv_build` backend is an offline cache miss that would break the actual release build.

## Fix

- Revert `uv_build` to `0.9.30` (matching the bundled builder in `BUILD_IMAGE`)
- Document the coupling at the pin site in `pyproject.toml`
- Add a Dependabot `ignore` for `uv_build` so the pin can only move deliberately, together with `BUILD_IMAGE` and the `test_release_workflow.py` pins

Unblocks #310 and the next 0.10 beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)