### PR TITLE
fix: fall back to holding registers 2-6 for serial number read (GridBOSS Modbus discovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **GridBOSS Modbus discovery: serial number falls back to holding
+  registers 2-6**
+  ([eg4_web_monitor#593](https://github.com/joyfulhouse/eg4_web_monitor/issues/593)):
+  the "serial at input registers 115-119" layout is inverter-family-specific —
+  on MID/GridBOSS devices those registers are AC-couple ports 3-4
+  lifetime-energy counters (`registers/gridboss.py`), which read as zeros on a
+  unit with those ports unused, so local Modbus TCP discovery failed with
+  "Failed to read serial number from device". `read_serial_number()` now falls
+  back to holding registers 2-6 (`HOLD_SERIAL_NUM`, documented for every
+  family) whenever the input-register decode yields fewer than 10 characters.
+  This also stops a latent wrong-identity case: a GridBOSS *with* accumulated
+  AC-couple energy at 115-119 could decode those bytes into printable garbage
+  and silently adopt it as the device serial.
+
 ## [0.10.0b4] - 2026-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unit with those ports unused, so local Modbus TCP discovery failed with
   "Failed to read serial number from device". `read_serial_number()` now falls
   back to holding registers 2-6 (`HOLD_SERIAL_NUM`, documented for every
-  family) whenever the input-register decode yields fewer than 10 characters.
-  This also stops a latent wrong-identity case: a GridBOSS *with* accumulated
-  AC-couple energy at 115-119 could decode those bytes into printable garbage
-  and silently adopt it as the device serial.
+  family) whenever the input-register decode is not a plausible serial —
+  exactly 10 printable ASCII alphanumeric characters. The same plausibility
+  check gates the holding-register result, so a partial or garbage holding
+  decode is never adopted either; the pre-fallback input result is returned
+  unchanged in that case. This also stops a latent wrong-identity case: a
+  GridBOSS *with* accumulated AC-couple energy at 115-119 could decode those
+  bytes into printable garbage and silently adopt it as the device serial.
 
 ## [0.10.0b4] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exactly 10 printable ASCII alphanumeric characters. The same plausibility
   check gates the holding-register result, so a partial or garbage holding
   decode is never adopted either; the pre-fallback input result is returned
-  unchanged in that case. This also stops a latent wrong-identity case: a
+  unchanged in that case, and a holding read that fails outright (restricted
+  register map) is swallowed the same way rather than turning discovery into
+  a hard failure. The fallback also honors the transport's
+  `inter_register_delay` before switching from input (FC 04) to holding
+  (FC 03) reads, matching the existing MID mixed-space read pattern — WiFi
+  dongles corrupt payloads without that pause. This also stops a latent
+  wrong-identity case: a
   GridBOSS *with* accumulated AC-couple energy at 115-119 could decode those
   bytes into printable garbage and silently adopt it as the device serial.
 

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -1789,8 +1789,9 @@ class RegisterDataMixin(_DataMixinBase):
         """Read device serial number.
 
         Input registers 115-119 first; falls back to holding registers 2-6
-        (HOLD_SERIAL_NUM) when the input decode is incomplete — GridBOSS
-        units keep AC-couple energy counters at input 115-119.
+        (HOLD_SERIAL_NUM) when the input decode is not a plausible 10-char
+        alphanumeric serial — GridBOSS units keep AC-couple energy counters
+        at input 115-119.
         """
         segments = self._new_observed_segments()
         holding_segments = self._new_observed_segments()

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -1797,7 +1797,17 @@ class RegisterDataMixin(_DataMixinBase):
         holding_segments = self._new_observed_segments()
         reader = _capture_register_reads(self._read_input_registers, segments)
         holding_reader = _capture_register_reads(self._read_holding_registers, holding_segments)
-        result = await read_serial_number_async(reader, self._serial, read_holding=holding_reader)
+
+        async def delayed_holding_reader(address: int, count: int) -> list[int]:
+            # Delay before switching from input (FC 04) to holding (FC 03)
+            # registers — WiFi dongles need time between function code changes
+            # to avoid corrupt reads. Only paid when the fallback fires.
+            await asyncio.sleep(self._inter_register_delay)
+            return await holding_reader(address, count)
+
+        result = await read_serial_number_async(
+            reader, self._serial, read_holding=delayed_holding_reader
+        )
         if segments or holding_segments:
             await self._notify_observed_segments(
                 (RegisterSpace.INPUT, segments),

--- a/src/pylxpweb/transports/_register_data.py
+++ b/src/pylxpweb/transports/_register_data.py
@@ -1786,12 +1786,22 @@ class RegisterDataMixin(_DataMixinBase):
     # ------------------------------------------------------------------
 
     async def read_serial_number(self) -> str:
-        """Read inverter serial number from input registers 115-119."""
+        """Read device serial number.
+
+        Input registers 115-119 first; falls back to holding registers 2-6
+        (HOLD_SERIAL_NUM) when the input decode is incomplete — GridBOSS
+        units keep AC-couple energy counters at input 115-119.
+        """
         segments = self._new_observed_segments()
+        holding_segments = self._new_observed_segments()
         reader = _capture_register_reads(self._read_input_registers, segments)
-        result = await read_serial_number_async(reader, self._serial)
-        if segments:
-            await self._notify_observed_segments((RegisterSpace.INPUT, segments))
+        holding_reader = _capture_register_reads(self._read_holding_registers, holding_segments)
+        result = await read_serial_number_async(reader, self._serial, read_holding=holding_reader)
+        if segments or holding_segments:
+            await self._notify_observed_segments(
+                (RegisterSpace.INPUT, segments),
+                (RegisterSpace.HOLDING, holding_segments),
+            )
         return result
 
     async def read_firmware_version(self) -> str:

--- a/src/pylxpweb/transports/_register_readers.py
+++ b/src/pylxpweb/transports/_register_readers.py
@@ -190,7 +190,10 @@ async def read_serial_number_async(
     an empty, truncated, or garbage-punctuation string — falls back to
     holding registers 2-6 (HOLD_SERIAL_NUM), the canonical location shared
     by all families. A holding decode that is itself not plausible is not
-    adopted; the input-register result is returned unchanged in that case.
+    adopted, and a holding read that fails outright is swallowed — either
+    way the input-register result is returned unchanged, so a device with
+    a restricted register map degrades exactly as it did before the
+    fallback existed instead of turning discovery into a hard failure.
 
     Args:
         read_input: Async function to read input registers
@@ -213,9 +216,17 @@ async def read_serial_number_async(
         result,
         serial,
     )
-    holding_values = await read_holding(
-        SERIAL_NUMBER_HOLDING_START_REGISTER, SERIAL_NUMBER_REGISTER_COUNT
-    )
+    try:
+        holding_values = await read_holding(
+            SERIAL_NUMBER_HOLDING_START_REGISTER, SERIAL_NUMBER_REGISTER_COUNT
+        )
+    except Exception as err:
+        _LOGGER.debug(
+            "Holding-register serial fallback failed for %s, keeping input-register result: %s",
+            serial,
+            err,
+        )
+        return result
     holding_result = decode_serial_from_registers(holding_values)
     if _is_plausible_serial(holding_result):
         _LOGGER.debug(

--- a/src/pylxpweb/transports/_register_readers.py
+++ b/src/pylxpweb/transports/_register_readers.py
@@ -23,9 +23,10 @@ DEVICE_TYPE_REGISTER = 19
 
 # Serial number is stored in input registers 115-119 (5 registers, 10 ASCII chars)
 # on inverter-family devices. On MID/GridBOSS devices those input registers are
-# AC-couple lifetime-energy counters (see registers/gridboss.py), so the serial
-# read falls back to holding registers 2-6 (HOLD_SERIAL_NUM), which hold the
-# serial on every documented family (eg4_web_monitor#593).
+# AC-couple lifetime-energy counters (see registers/gridboss.py), so when the
+# input decode is not a plausible serial the read falls back to holding
+# registers 2-6 (HOLD_SERIAL_NUM), which hold the serial on every documented
+# family (eg4_web_monitor#593).
 SERIAL_NUMBER_START_REGISTER = 115
 SERIAL_NUMBER_REGISTER_COUNT = 5
 SERIAL_NUMBER_HOLDING_START_REGISTER = 2
@@ -74,6 +75,19 @@ def is_midbox_device(device_type_code: int) -> bool:
         True if device is a MID/GridBOSS, False for inverters
     """
     return device_type_code == DEVICE_TYPE_MIDBOX
+
+
+def _is_plausible_serial(candidate: str) -> bool:
+    """Return True when candidate looks like a genuine device serial.
+
+    Serials across every documented family are exactly 10 ASCII alphanumeric
+    characters — letters can appear anywhere (e.g. "BA12345678",
+    "52842P0581"), so digits-only must not be assumed.
+    decode_serial_from_registers only emits printable ASCII, so a decode of
+    non-serial data (e.g. GridBOSS AC-couple energy counters at input
+    115-119) is rejected here as too short or as containing punctuation.
+    """
+    return len(candidate) == SERIAL_NUMBER_LENGTH and candidate.isascii() and candidate.isalnum()
 
 
 def decode_serial_from_registers(values: list[int]) -> str:
@@ -171,10 +185,12 @@ async def read_serial_number_async(
     """Read device serial number.
 
     Tries input registers 115-119 first (inverter-family layout). If the
-    decoded result is not a complete 10-character serial — GridBOSS units
-    keep AC-couple energy counters there, which decode to an empty or
-    truncated string — falls back to holding registers 2-6
-    (HOLD_SERIAL_NUM), the canonical location shared by all families.
+    decoded result is not a plausible 10-character alphanumeric serial —
+    GridBOSS units keep AC-couple energy counters there, which decode to
+    an empty, truncated, or garbage-punctuation string — falls back to
+    holding registers 2-6 (HOLD_SERIAL_NUM), the canonical location shared
+    by all families. A holding decode that is itself not plausible is not
+    adopted; the input-register result is returned unchanged in that case.
 
     Args:
         read_input: Async function to read input registers
@@ -187,12 +203,12 @@ async def read_serial_number_async(
     """
     values = await read_input(SERIAL_NUMBER_START_REGISTER, SERIAL_NUMBER_REGISTER_COUNT)
     result = decode_serial_from_registers(values)
-    if len(result) == SERIAL_NUMBER_LENGTH or read_holding is None:
+    if _is_plausible_serial(result) or read_holding is None:
         _LOGGER.debug("Read serial number from device %s: %s", serial, result)
         return result
 
     _LOGGER.debug(
-        "Input registers 115-119 returned incomplete serial %r for %s; "
+        "Input registers 115-119 decoded to %r for %s, not a plausible serial; "
         "falling back to holding registers 2-6",
         result,
         serial,
@@ -201,13 +217,19 @@ async def read_serial_number_async(
         SERIAL_NUMBER_HOLDING_START_REGISTER, SERIAL_NUMBER_REGISTER_COUNT
     )
     holding_result = decode_serial_from_registers(holding_values)
-    if holding_result:
+    if _is_plausible_serial(holding_result):
         _LOGGER.debug(
             "Read serial number from holding registers for device %s: %s",
             serial,
             holding_result,
         )
         return holding_result
+    _LOGGER.debug(
+        "Holding registers 2-6 decoded to %r for %s, not a plausible serial; "
+        "keeping input-register result",
+        holding_result,
+        serial,
+    )
     return result
 
 

--- a/src/pylxpweb/transports/_register_readers.py
+++ b/src/pylxpweb/transports/_register_readers.py
@@ -22,8 +22,14 @@ DEVICE_TYPE_MIDBOX = 50
 DEVICE_TYPE_REGISTER = 19
 
 # Serial number is stored in input registers 115-119 (5 registers, 10 ASCII chars)
+# on inverter-family devices. On MID/GridBOSS devices those input registers are
+# AC-couple lifetime-energy counters (see registers/gridboss.py), so the serial
+# read falls back to holding registers 2-6 (HOLD_SERIAL_NUM), which hold the
+# serial on every documented family (eg4_web_monitor#593).
 SERIAL_NUMBER_START_REGISTER = 115
 SERIAL_NUMBER_REGISTER_COUNT = 5
+SERIAL_NUMBER_HOLDING_START_REGISTER = 2
+SERIAL_NUMBER_LENGTH = 10
 
 # Firmware version is in holding registers 7-10
 FIRMWARE_REGISTER_START = 7
@@ -160,19 +166,48 @@ async def read_device_type_async(
 async def read_serial_number_async(
     read_input: Callable[[int, int], Coroutine[None, None, list[int]]],
     serial: str,
+    read_holding: Callable[[int, int], Coroutine[None, None, list[int]]] | None = None,
 ) -> str:
-    """Read inverter serial number from input registers 115-119.
+    """Read device serial number.
+
+    Tries input registers 115-119 first (inverter-family layout). If the
+    decoded result is not a complete 10-character serial — GridBOSS units
+    keep AC-couple energy counters there, which decode to an empty or
+    truncated string — falls back to holding registers 2-6
+    (HOLD_SERIAL_NUM), the canonical location shared by all families.
 
     Args:
         read_input: Async function to read input registers
         serial: Device serial for logging
+        read_holding: Optional async function to read holding registers,
+            enabling the holding-register fallback
 
     Returns:
         10-character serial number string (e.g., "BA12345678")
     """
     values = await read_input(SERIAL_NUMBER_START_REGISTER, SERIAL_NUMBER_REGISTER_COUNT)
     result = decode_serial_from_registers(values)
-    _LOGGER.debug("Read serial number from device %s: %s", serial, result)
+    if len(result) == SERIAL_NUMBER_LENGTH or read_holding is None:
+        _LOGGER.debug("Read serial number from device %s: %s", serial, result)
+        return result
+
+    _LOGGER.debug(
+        "Input registers 115-119 returned incomplete serial %r for %s; "
+        "falling back to holding registers 2-6",
+        result,
+        serial,
+    )
+    holding_values = await read_holding(
+        SERIAL_NUMBER_HOLDING_START_REGISTER, SERIAL_NUMBER_REGISTER_COUNT
+    )
+    holding_result = decode_serial_from_registers(holding_values)
+    if holding_result:
+        _LOGGER.debug(
+            "Read serial number from holding registers for device %s: %s",
+            serial,
+            holding_result,
+        )
+        return holding_result
     return result
 
 

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -140,24 +140,26 @@ PUBLIC_OBSERVATION_READS: tuple[object, ...] = (
 )
 
 CANONICAL_OBSERVATION_READS: tuple[object, ...] = (
+    # The fake transport reads all-zero registers, so read_serial_number's
+    # holding-register fallback (GridBOSS, eg4_web_monitor#593) also fires.
     pytest.param(
         lambda transport: transport.read_serial_number(),
-        (RegisterSpace.INPUT, 115, 5),
+        ((RegisterSpace.INPUT, 115, 5), (RegisterSpace.HOLDING, 2, 5)),
         id="serial",
     ),
     pytest.param(
         lambda transport: transport.read_firmware_version(),
-        (RegisterSpace.HOLDING, 7, 4),
+        ((RegisterSpace.HOLDING, 7, 4),),
         id="firmware",
     ),
     pytest.param(
         lambda transport: transport.read_device_type(),
-        (RegisterSpace.HOLDING, 19, 1),
+        ((RegisterSpace.HOLDING, 19, 1),),
         id="device-type",
     ),
     pytest.param(
         lambda transport: transport.read_parallel_config(),
-        (RegisterSpace.INPUT, 113, 1),
+        ((RegisterSpace.INPUT, 113, 1),),
         id="parallel",
     ),
 )
@@ -420,12 +422,12 @@ async def test_observer_adds_zero_reads_and_preserves_request_order() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("public_read", "expected_read"),
+    ("public_read", "expected_reads"),
     CANONICAL_OBSERVATION_READS,
 )
 async def test_canonical_readers_observe_enabled_terminal_segment_without_extra_reads(
     public_read: PublicRead,
-    expected_read: tuple[RegisterSpace, int, int],
+    expected_reads: tuple[tuple[RegisterSpace, int, int], ...],
 ) -> None:
     baseline = _FakeRegisterTransport()
     observed: list[ObservationBatch] = []
@@ -434,16 +436,16 @@ async def test_canonical_readers_observe_enabled_terminal_segment_without_extra_
     baseline_result = await public_read(baseline)
     enabled_result = await public_read(enabled)
 
-    space, start, count = expected_read
     assert enabled_result == baseline_result
-    assert baseline.reads == [expected_read]
-    assert enabled.reads == [expected_read]
+    assert baseline.reads == list(expected_reads)
+    assert enabled.reads == list(expected_reads)
     assert observed == [
-        (
+        tuple(
             RegisterObservation(
                 space,
                 (RegisterSegment(start, (0,) * count),),
-            ),
+            )
+            for space, start, count in expected_reads
         )
     ]
 

--- a/tests/unit/transports/test_register_observer.py
+++ b/tests/unit/transports/test_register_observer.py
@@ -9,7 +9,7 @@ import types
 import weakref
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import asdict, is_dataclass
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -448,6 +448,20 @@ async def test_canonical_readers_observe_enabled_terminal_segment_without_extra_
             for space, start, count in expected_reads
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_serial_holding_fallback_waits_inter_register_delay() -> None:
+    # Switching from input (FC 04) to holding (FC 03) reads without a pause
+    # corrupts payloads on WiFi dongles (_inter_register_delay = 0.5 there),
+    # so the serial fallback must sleep the transport's delay first.
+    transport = _FakeRegisterTransport()
+    transport._inter_register_delay = 0.25
+    with patch("asyncio.sleep", new=AsyncMock()) as sleep_mock:
+        result = await transport.read_serial_number()
+    assert result == ""
+    assert (RegisterSpace.HOLDING, 2, 5) in transport.reads
+    sleep_mock.assert_awaited_once_with(0.25)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/transports/test_register_readers.py
+++ b/tests/unit/transports/test_register_readers.py
@@ -1,0 +1,98 @@
+"""Tests for shared register-reading helpers (_register_readers).
+
+Covers the GridBOSS serial fallback (eg4_web_monitor#593): MID devices keep
+AC-couple lifetime-energy counters at input registers 115-119, so the serial
+read must fall back to holding registers 2-6 (HOLD_SERIAL_NUM).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pylxpweb.transports._register_readers import (
+    decode_firmware_from_registers,
+    decode_serial_from_registers,
+    read_serial_number_async,
+)
+
+# Reporter's GridBOSS (fw IAAB-1600) holding registers 2-6: ASCII serial,
+# low byte first per register (same byte order as the firmware code regs).
+GRIDBOSS_HOLDING_SERIAL_REGS = [0x3036, 0x3333, 0x3538, 0x3730, 0x3438]
+GRIDBOSS_HOLDING_SERIAL = "6033850784"
+
+INVERTER_INPUT_SERIAL_REGS = [0x4142, 0x3231, 0x3433, 0x3635, 0x3837]
+INVERTER_INPUT_SERIAL = "BA12345678"
+
+
+class TestDecodeSerialFromRegisters:
+    def test_decodes_low_byte_first(self) -> None:
+        assert decode_serial_from_registers(GRIDBOSS_HOLDING_SERIAL_REGS) == GRIDBOSS_HOLDING_SERIAL
+
+    def test_all_zero_registers_decode_empty(self) -> None:
+        assert decode_serial_from_registers([0, 0, 0, 0, 0]) == ""
+
+    def test_byte_order_matches_firmware_decode(self) -> None:
+        # Firmware regs 7-10 from the same device dump decode to IAAB-1600,
+        # anchoring the low-byte-first ordering used for the serial.
+        assert decode_firmware_from_registers([0x4149, 0x4241, 0x1600, 0x0100]) == ("IAAB-1600")
+
+
+class TestReadSerialNumberAsync:
+    @pytest.mark.asyncio
+    async def test_input_registers_preferred(self) -> None:
+        holding_calls: list[tuple[int, int]] = []
+
+        async def read_input(address: int, count: int) -> list[int]:
+            assert (address, count) == (115, 5)
+            return INVERTER_INPUT_SERIAL_REGS
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            holding_calls.append((address, count))
+            return GRIDBOSS_HOLDING_SERIAL_REGS
+
+        result = await read_serial_number_async(read_input, "test", read_holding=read_holding)
+        assert result == INVERTER_INPUT_SERIAL
+        assert holding_calls == []
+
+    @pytest.mark.asyncio
+    async def test_gridboss_zero_input_falls_back_to_holding(self) -> None:
+        async def read_input(address: int, count: int) -> list[int]:
+            return [0, 0, 0, 0, 0]
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            assert (address, count) == (2, 5)
+            return GRIDBOSS_HOLDING_SERIAL_REGS
+
+        result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
+        assert result == GRIDBOSS_HOLDING_SERIAL
+
+    @pytest.mark.asyncio
+    async def test_truncated_input_serial_falls_back(self) -> None:
+        # Printable garbage shorter than 10 chars (e.g. partial AC-couple
+        # energy bytes) must not be accepted as a serial.
+        async def read_input(address: int, count: int) -> list[int]:
+            return [0x4142, 0, 0, 0, 0]
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            return GRIDBOSS_HOLDING_SERIAL_REGS
+
+        result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
+        assert result == GRIDBOSS_HOLDING_SERIAL
+
+    @pytest.mark.asyncio
+    async def test_no_holding_reader_preserves_legacy_behavior(self) -> None:
+        async def read_input(address: int, count: int) -> list[int]:
+            return [0, 0, 0, 0, 0]
+
+        assert await read_serial_number_async(read_input, "discovery") == ""
+
+    @pytest.mark.asyncio
+    async def test_both_sources_empty_returns_input_result(self) -> None:
+        async def read_input(address: int, count: int) -> list[int]:
+            return [0, 0, 0, 0, 0]
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            return [0, 0, 0, 0, 0]
+
+        result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
+        assert result == ""

--- a/tests/unit/transports/test_register_readers.py
+++ b/tests/unit/transports/test_register_readers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from pylxpweb.transports._register_readers import (
+    _is_plausible_serial,
     decode_firmware_from_registers,
     decode_serial_from_registers,
     read_serial_number_async,
@@ -23,6 +24,15 @@ GRIDBOSS_HOLDING_SERIAL = "6033850784"
 INVERTER_INPUT_SERIAL_REGS = [0x4142, 0x3231, 0x3433, 0x3635, 0x3837]
 INVERTER_INPUT_SERIAL = "BA12345678"
 
+# Serial with a letter mid-string (real FlexBOSS21-style serial), low byte first.
+LETTERED_INPUT_SERIAL_REGS = [0x3235, 0x3438, 0x5032, 0x3530, 0x3138]
+LETTERED_INPUT_SERIAL = "52842P0581"
+
+# Energy-counter bytes that happen to decode to 10 printable but
+# non-alphanumeric chars (".*" per register) — must not pass as a serial.
+GARBAGE_PRINTABLE_REGS = [0x2A2E] * 5
+GARBAGE_PRINTABLE_DECODE = ".*.*.*.*.*"
+
 
 class TestDecodeSerialFromRegisters:
     def test_decodes_low_byte_first(self) -> None:
@@ -35,6 +45,22 @@ class TestDecodeSerialFromRegisters:
         # Firmware regs 7-10 from the same device dump decode to IAAB-1600,
         # anchoring the low-byte-first ordering used for the serial.
         assert decode_firmware_from_registers([0x4149, 0x4241, 0x1600, 0x0100]) == ("IAAB-1600")
+
+
+class TestIsPlausibleSerial:
+    @pytest.mark.parametrize(
+        "serial",
+        ["1234567890", "1234A56789", "52842P0581", "BA12345678", "ba12345678"],
+    )
+    def test_accepts_10_char_alphanumeric(self, serial: str) -> None:
+        assert _is_plausible_serial(serial)
+
+    @pytest.mark.parametrize(
+        "candidate",
+        ["", "BA", "123456789", "12345678901", GARBAGE_PRINTABLE_DECODE, "BA12345 67"],
+    )
+    def test_rejects_non_serial_decodes(self, candidate: str) -> None:
+        assert not _is_plausible_serial(candidate)
 
 
 class TestReadSerialNumberAsync:
@@ -78,6 +104,64 @@ class TestReadSerialNumberAsync:
 
         result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
         assert result == GRIDBOSS_HOLDING_SERIAL
+
+    @pytest.mark.asyncio
+    async def test_lettered_input_serial_accepted_without_fallback(self) -> None:
+        # Regression guard for inverters: a genuine serial with a letter
+        # mid-string must short-circuit — no holding read.
+        holding_calls: list[tuple[int, int]] = []
+
+        async def read_input(address: int, count: int) -> list[int]:
+            return LETTERED_INPUT_SERIAL_REGS
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            holding_calls.append((address, count))
+            return GRIDBOSS_HOLDING_SERIAL_REGS
+
+        result = await read_serial_number_async(read_input, "test", read_holding=read_holding)
+        assert result == LETTERED_INPUT_SERIAL
+        assert holding_calls == []
+
+    @pytest.mark.asyncio
+    async def test_ten_char_printable_garbage_input_falls_back(self) -> None:
+        # GridBOSS with accumulated AC-couple energy: input 115-119 can
+        # decode to 10 printable but non-alphanumeric chars. That must not
+        # be adopted as the identity — the holding fallback still fires.
+        async def read_input(address: int, count: int) -> list[int]:
+            return GARBAGE_PRINTABLE_REGS
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            assert (address, count) == (2, 5)
+            return GRIDBOSS_HOLDING_SERIAL_REGS
+
+        result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
+        assert result == GRIDBOSS_HOLDING_SERIAL
+
+    @pytest.mark.asyncio
+    async def test_partial_holding_decode_not_adopted(self) -> None:
+        # A truncated holding decode (e.g. flaky read) must not be adopted
+        # as the serial; the input-register result is kept.
+        async def read_input(address: int, count: int) -> list[int]:
+            return [0, 0, 0, 0, 0]
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            return [0x4142, 0, 0, 0, 0]
+
+        result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_garbage_holding_decode_not_adopted(self) -> None:
+        # Both sources garbage: keep the input-register result unchanged
+        # (pre-fallback behavior) rather than adopting holding garbage.
+        async def read_input(address: int, count: int) -> list[int]:
+            return GARBAGE_PRINTABLE_REGS
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            return GARBAGE_PRINTABLE_REGS
+
+        result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
+        assert result == GARBAGE_PRINTABLE_DECODE
 
     @pytest.mark.asyncio
     async def test_no_holding_reader_preserves_legacy_behavior(self) -> None:

--- a/tests/unit/transports/test_register_readers.py
+++ b/tests/unit/transports/test_register_readers.py
@@ -15,6 +15,7 @@ from pylxpweb.transports._register_readers import (
     decode_serial_from_registers,
     read_serial_number_async,
 )
+from pylxpweb.transports.exceptions import TransportReadError
 
 # Reporter's GridBOSS (fw IAAB-1600) holding registers 2-6: ASCII serial,
 # low byte first per register (same byte order as the firmware code regs).
@@ -162,6 +163,20 @@ class TestReadSerialNumberAsync:
 
         result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
         assert result == GARBAGE_PRINTABLE_DECODE
+
+    @pytest.mark.asyncio
+    async def test_holding_read_error_keeps_input_result(self) -> None:
+        # Devices with a restricted register map can reject holding reads
+        # 2-6; the fallback must degrade to the pre-fallback input result,
+        # not turn discovery into a hard transport failure.
+        async def read_input(address: int, count: int) -> list[int]:
+            return [0, 0, 0, 0, 0]
+
+        async def read_holding(address: int, count: int) -> list[int]:
+            raise TransportReadError("holding registers rejected")
+
+        result = await read_serial_number_async(read_input, "discovery", read_holding=read_holding)
+        assert result == ""
 
     @pytest.mark.asyncio
     async def test_no_holding_reader_preserves_legacy_behavior(self) -> None:


### PR DESCRIPTION
Fixes joyfulhouse/eg4_web_monitor#593.

## Problem

The "serial at input registers 115-119" layout is **inverter-family specific**. On MID/GridBOSS devices those input registers are AC-couple ports 3-4 lifetime-energy counters (per our own map in `registers/gridboss.py`, regs 104-118). On a GridBOSS with those ports unused they read as clean zeros, so local Modbus TCP discovery hard-failed with `Failed to read serial number from device`.

The reporter's diagnostic dump confirms it: input 115-119 all zero, while holding 2-6 hold the ASCII serial and holding 7-10 decode to exactly their reported firmware `IAAB-1600` — anchoring the low-byte-first byte order `decode_serial_from_registers()` already uses.

**Latent worse case also closed:** a GridBOSS *with* accumulated AC-couple energy at 115-119 could decode those bytes into printable garbage and silently adopt it as the device serial (and `validate_serial()` would then compare against it on every reconnect).

## Fix

`read_serial_number()` now falls back to holding registers 2-6 (`HOLD_SERIAL_NUM`, documented for every family: FlexBoss, 18KPV, GridBoss) whenever the input-register decode yields fewer than 10 characters. Inverters short-circuit on the input read as before; the fallback only fires on an incomplete decode. Register-observer segments for the holding read are captured and published alongside the input segment.

`read_serial_number_async()` keeps its legacy behavior when no holding reader is passed.

## Testing

- New `tests/unit/transports/test_register_readers.py` (8 tests) including the reporter's exact register values as the regression case
- Updated the canonical-observation test: the all-zero fake transport now legitimately performs the holding fallback read
- Full unit suite: 3447 passed; ruff + ruff-format + mypy clean

## Not in this PR

Discovery also reads parallel config from input 113 unconditionally — on MID that's the high word of `ac_couple3_energy_total_l1`, so a GridBOSS past 6553.6 kWh lifetime on AC-couple port 3 would report a bogus parallel role/phase/group. That guard belongs in eg4_web_monitor's `_read_device_info_from_transport()` (skip for `is_gridboss`); follow-up issue to be filed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)