### PR TITLE
fix: skip parallel-config read for GridBOSS during Modbus discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ac_couple3_energy_total_l1` 32-bit lifetime counter
   (`registers/gridboss.py`), not parallel config. Once that counter passes
   6553.6 kWh the high word (113) goes nonzero and discovery decoded a bogus
-  parallel role/phase/group (raw `0x0001` → "slave").
+  parallel role/phase/group (raw `0x0001` → "master", parallel number 0).
   `discover_device_info()` now leaves parallel fields at standalone
   defaults for GridBOSS and skips the holding 107-108 fallback as well.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **GridBOSS Modbus discovery: skip the parallel-config read (input
+  register 113)**
+  ([eg4_web_monitor#596](https://github.com/joyfulhouse/eg4_web_monitor/issues/596)):
+  on MID/GridBOSS devices input registers 112-113 are the
+  `ac_couple3_energy_total_l1` 32-bit lifetime counter
+  (`registers/gridboss.py`), not parallel config. Once that counter passes
+  6553.6 kWh the high word (113) goes nonzero and discovery decoded a bogus
+  parallel role/phase/group (raw `0x0001` → "slave").
+  `discover_device_info()` now leaves parallel fields at standalone
+  defaults for GridBOSS and skips the holding 107-108 fallback as well.
+
 ## [0.10.0b4] - 2026-08-26
 
 ### Fixed

--- a/src/pylxpweb/devices/discovery.py
+++ b/src/pylxpweb/devices/discovery.py
@@ -211,43 +211,51 @@ async def discover_device_info(transport: DiscoveryTransport) -> DeviceDiscovery
 
     # Read parallel config from input register 113 (preferred source)
     # Format: bits 0-1 = master/slave, bits 2-3 = phase, bits 8-15 = parallel number
+    #
+    # GridBOSS/MID devices are never parallel-group members, and their input
+    # registers 112-113 are the ac_couple3_energy_total_l1 lifetime counter
+    # (registers/gridboss.py), not parallel config — once that counter passes
+    # 6553.6 kWh the high word (113) goes nonzero and would decode as a bogus
+    # role/phase/group (eg4_web_monitor#596). Skip the read entirely and keep
+    # standalone defaults.
     parallel_master_slave = 0
     parallel_number = 0
     parallel_phase = 0
 
-    try:
-        reg113_raw = await transport.read_parallel_config()
-        if reg113_raw > 0:
-            # Parse packed parallel config
-            parallel_master_slave = reg113_raw & 0x03
-            parallel_phase = (reg113_raw >> 2) & 0x03
-            parallel_number = (reg113_raw >> 8) & 0xFF
-            _LOGGER.debug(
-                "Parsed register 113 for %s: raw=0x%04X, master_slave=%d, phase=%d, number=%d",
-                transport.serial,
-                reg113_raw,
-                parallel_master_slave,
-                parallel_phase,
-                parallel_number,
-            )
-    except Exception as e:
-        _LOGGER.debug(
-            "Failed to read parallel config register 113 for %s: %s, trying fallback",
-            transport.serial,
-            e,
-        )
-        # Fallback to holding registers 107-108 (less reliable)
+    if not is_gridboss:
         try:
-            parallel_regs = await transport.read_parameters(HOLD_PARALLEL_NUMBER, 2)
-            parallel_number = parallel_regs.get(HOLD_PARALLEL_NUMBER, 0) & 0xFF
-            parallel_phase = parallel_regs.get(HOLD_PARALLEL_PHASE, 0) & 0xFF
-        except Exception as e2:
+            reg113_raw = await transport.read_parallel_config()
+            if reg113_raw > 0:
+                # Parse packed parallel config
+                parallel_master_slave = reg113_raw & 0x03
+                parallel_phase = (reg113_raw >> 2) & 0x03
+                parallel_number = (reg113_raw >> 8) & 0xFF
+                _LOGGER.debug(
+                    "Parsed register 113 for %s: raw=0x%04X, master_slave=%d, phase=%d, number=%d",
+                    transport.serial,
+                    reg113_raw,
+                    parallel_master_slave,
+                    parallel_phase,
+                    parallel_number,
+                )
+        except Exception as e:
             _LOGGER.debug(
-                "Failed to read fallback parallel registers for %s: %s",
+                "Failed to read parallel config register 113 for %s: %s, trying fallback",
                 transport.serial,
-                e2,
+                e,
             )
-        # Default to standalone if both fail
+            # Fallback to holding registers 107-108 (less reliable)
+            try:
+                parallel_regs = await transport.read_parameters(HOLD_PARALLEL_NUMBER, 2)
+                parallel_number = parallel_regs.get(HOLD_PARALLEL_NUMBER, 0) & 0xFF
+                parallel_phase = parallel_regs.get(HOLD_PARALLEL_PHASE, 0) & 0xFF
+            except Exception as e2:
+                _LOGGER.debug(
+                    "Failed to read fallback parallel registers for %s: %s",
+                    transport.serial,
+                    e2,
+                )
+            # Default to standalone if both fail
 
     # Read firmware version (best effort - may fail on some devices)
     firmware_version = ""

--- a/tests/unit/devices/test_discovery.py
+++ b/tests/unit/devices/test_discovery.py
@@ -176,14 +176,14 @@ class TestDiscoverDeviceInfo:
         GridBOSS input registers 112-113 are the ac_couple3_energy_total_l1
         lifetime counter, not parallel config (eg4_web_monitor#596). A unit
         past 6553.6 kWh has a nonzero high word (0x0001 would decode as
-        "slave"), so discovery must not read register 113 at all and must
-        report standalone defaults.
+        "master" with parallel number 0), so discovery must not read
+        register 113 at all and must report standalone defaults.
         """
         transport = MagicMock()
         transport.serial = "GB12345678"
         transport.read_device_type = AsyncMock(return_value=50)
         transport.is_midbox_device = MagicMock(return_value=True)
-        # ac_couple3 energy high word nonzero — would decode as slave/group A
+        # ac_couple3 energy high word nonzero — would decode as master, number 0
         transport.read_parallel_config = AsyncMock(return_value=0x0001)
         transport.read_parameters = AsyncMock(
             return_value={

--- a/tests/unit/devices/test_discovery.py
+++ b/tests/unit/devices/test_discovery.py
@@ -161,6 +161,7 @@ class TestDiscoverDeviceInfo:
 
         info = await discover_device_info(transport)
 
+        transport.read_parallel_config.assert_awaited_once()
         assert info.parallel_master_slave == 1  # Master
         assert info.parallel_number == 1
         assert info.parallel_phase == 2  # T
@@ -170,13 +171,20 @@ class TestDiscoverDeviceInfo:
 
     @pytest.mark.asyncio
     async def test_discovers_gridboss(self) -> None:
-        """Test discovering a GridBOSS/MID device."""
+        """Test discovering a GridBOSS/MID device.
+
+        GridBOSS input registers 112-113 are the ac_couple3_energy_total_l1
+        lifetime counter, not parallel config (eg4_web_monitor#596). A unit
+        past 6553.6 kWh has a nonzero high word (0x0001 would decode as
+        "slave"), so discovery must not read register 113 at all and must
+        report standalone defaults.
+        """
         transport = MagicMock()
         transport.serial = "GB12345678"
         transport.read_device_type = AsyncMock(return_value=50)
         transport.is_midbox_device = MagicMock(return_value=True)
-        # Register 113 = 0x0101: master=1, phase=0, number=1
-        transport.read_parallel_config = AsyncMock(return_value=0x0101)
+        # ac_couple3 energy high word nonzero — would decode as slave/group A
+        transport.read_parallel_config = AsyncMock(return_value=0x0001)
         transport.read_parameters = AsyncMock(
             return_value={
                 HOLD_PARALLEL_NUMBER: 1,
@@ -189,7 +197,36 @@ class TestDiscoverDeviceInfo:
 
         assert info.device_type_code == 50
         assert info.is_gridboss is True
-        assert info.parallel_master_slave == 1
+        transport.read_parallel_config.assert_not_awaited()
+        transport.read_parameters.assert_not_awaited()
+        assert info.parallel_master_slave == 0
+        assert info.parallel_number == 0
+        assert info.parallel_phase == 0
+        assert info.is_standalone is True
+        assert info.parallel_group_name is None
+        assert info.parallel_role_name == "standalone"
+
+    @pytest.mark.asyncio
+    async def test_gridboss_skips_parallel_fallback_on_reg113_failure(self) -> None:
+        """GridBOSS discovery must not touch holding 107-108 either."""
+        transport = MagicMock()
+        transport.serial = "GB12345678"
+        transport.read_device_type = AsyncMock(return_value=50)
+        transport.is_midbox_device = MagicMock(return_value=True)
+        transport.read_parallel_config = AsyncMock(side_effect=Exception("read failed"))
+        transport.read_parameters = AsyncMock(
+            return_value={
+                HOLD_PARALLEL_NUMBER: 1,
+                HOLD_PARALLEL_PHASE: 2,
+            }
+        )
+        transport.read_firmware_version = AsyncMock(return_value="GB-1234")
+
+        info = await discover_device_info(transport)
+
+        transport.read_parallel_config.assert_not_awaited()
+        transport.read_parameters.assert_not_awaited()
+        assert info.is_standalone is True
 
     @pytest.mark.asyncio
     async def test_handles_firmware_read_failure(self) -> None:


### PR DESCRIPTION
## Summary

Library half of joyfulhouse/eg4_web_monitor#596. `discover_device_info()` (`src/pylxpweb/devices/discovery.py`) read the parallel-config register (input 113) unconditionally, including on GridBOSS/MID devices. On GridBOSS, input registers 112-113 are the `ac_couple3_energy_total_l1` 32-bit lifetime kWh counter (`src/pylxpweb/registers/gridboss.py`), not parallel config — once the counter passes 6553.6 kWh the high word (input 113) goes nonzero and discovery decoded a bogus parallel role/phase/group (raw `0x0001` → "master", parallel number 0).

The device type is already read from holding register 19 before the parallel block, so discovery now gates on that: GridBOSS units skip both the input-113 read and the holding 107-108 fallback and keep standalone defaults (`parallel_master_slave=0`, `parallel_number=0`, `parallel_phase=0`). Inverter discovery is unchanged.

Matches the integration-side fix in joyfulhouse/eg4_web_monitor#597 (wrapped the same block in `if not is_gridboss:`).

Note: `src/pylxpweb/transports/discovery.py` has a separate discovery helper that reads holding 107-108 (not input 113) for all devices; it is not affected by the #596 mechanism and is left unchanged.

## Tests

- `test_discovers_gridboss` — updated; it previously encoded the buggy behavior (asserted `parallel_master_slave == 1` from reg 113 = 0x0101). Now feeds a nonzero high word (`0x0001`) and decodes as bogus master/number-0 if read — asserts `read_parallel_config` / `read_parameters` are never awaited and all parallel fields report standalone defaults.
- `test_gridboss_skips_parallel_fallback_on_reg113_failure` — new; even if reg 113 were to raise, GridBOSS discovery must not touch holding 107-108.
- `test_discovers_parallel_group_device` — extended to assert `read_parallel_config` is still awaited for inverters.

## Gates

- `uv run ruff check src/ tests/` — pass
- `uv run ruff format --check src/ tests/` — pass
- `uv run mypy src/pylxpweb/ --strict` — pass (no issues in 95 files)
- `uv run pytest tests/unit/` — 3452 passed; 5 failures confined to `tests/unit/test_release_workflow.py` container-build tests, which also fail/time out on unmodified `origin/main` in this environment (pytest-timeout at 60s) — pre-existing, unrelated.

## Conflict assessment vs #315

#315 (`fix/593-gridboss-serial-holding-fallback`) touches `transports/_register_data.py`, `transports/_register_readers.py`, and transport tests — no file overlap with this PR's code/test changes. Both PRs add an `## [Unreleased]` section at the top of `CHANGELOG.md`, so whichever merges second will have a trivial CHANGELOG conflict (both entries should be kept under one `## [Unreleased]` heading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
