### PR TITLE
feat(dongle): auto-detect TLS-PSK support with clean plaintext fallback (supersedes #314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rejection is treated as a definitive "no SSL support" — the same attempt
   falls back to plaintext and the negative verdict is cached per-instance
   for 24 hours (re-probed afterward, since dongle firmware can be updated
-  in the field). Generic socket errors and timeouts are inconclusive: they
-  stay on the existing retry/backoff ladder and cache no verdict (a
-  5-minute cooldown covers ambiguous TLS handshake timeouts). Once TLS has
-  negotiated on an instance it is never downgraded silently — a regression
-  is retried and logged as a warning before any fallback. On Python < 3.13
-  (stdlib `ssl` lacks TLS-PSK) AUTO uses plaintext without error; only
-  forced `use_ssl=True` raises. `eg4-modbus-diag` gained `--use-ssl` /
-  `--no-ssl` flags (default: auto-detect).
+  in the field). Generic socket errors and timeouts — including TLS
+  handshake timeouts — are inconclusive: they stay on the existing
+  retry/backoff ladder and cache no verdict, so a downgrade can never be
+  forced by stalling or dropping the handshake. Once TLS has negotiated on
+  an instance it is never downgraded: a later `ssl.SSLError` fails the
+  `connect()` call instead of falling back to plaintext. The cheap
+  `check_link()` health probe reuses the last-known channel state
+  (plaintext until TLS has proven) rather than TLS-probing inside its
+  short budget. TLS is capped at 1.2 (`ssl` PSK callbacks do not apply to
+  TLS 1.3). On Python < 3.13 (stdlib `ssl` lacks TLS-PSK) AUTO uses
+  plaintext without error; only forced `use_ssl=True` raises.
+  `eg4-modbus-diag` gained `--use-ssl` / `--no-ssl` flags (default:
+  auto-detect). `use_ssl` sits after `timeout` in the `DongleTransport`
+  signature, so pre-#314 positional callers are unaffected.
+
+  **SECURITY NOTE**: the dongle's TLS-PSK scheme derives its key from a
+  fixed value published in this source tree (and in vendor firmware)
+  plus the dongle serial, which is printed on the device and broadcast
+  in plaintext frames, with no certificate validation. It hides register
+  traffic from passive on-path observers ONLY — it does not authenticate
+  the peer, does not resist an active man-in-the-middle, and the key
+  cannot be rotated. Do not treat `use_ssl=True` as making the link
+  trustworthy.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **TLS-PSK support for the WiFi dongle transport, with automatic detection
+  and plaintext fallback** (extends PR
+  [#314](https://github.com/joyfulhouse/pylxpweb/pull/314) by
+  [@dpw13](https://github.com/dpw13), who authored the underlying TLS-PSK
+  implementation): dongle firmware V3.02 encrypts port 8000 with TLS-PSK.
+  `DongleTransport(use_ssl=...)` is now tri-state — `True` forces TLS (a
+  handshake failure propagates immediately instead of burning the retry
+  ladder on a doomed handshake), `False` forces plaintext (pre-#314
+  behavior, never probes), and `None` (the new default) auto-detects:
+  the first connection attempt probes TLS, and an `ssl.SSLError` handshake
+  rejection is treated as a definitive "no SSL support" — the same attempt
+  falls back to plaintext and the negative verdict is cached per-instance
+  for 24 hours (re-probed afterward, since dongle firmware can be updated
+  in the field). Generic socket errors and timeouts are inconclusive: they
+  stay on the existing retry/backoff ladder and cache no verdict (a
+  5-minute cooldown covers ambiguous TLS handshake timeouts). Once TLS has
+  negotiated on an instance it is never downgraded silently — a regression
+  is retried and logged as a warning before any fallback. On Python < 3.13
+  (stdlib `ssl` lacks TLS-PSK) AUTO uses plaintext without error; only
+  forced `use_ssl=True` raises. `eg4-modbus-diag` gained `--use-ssl` /
+  `--no-ssl` flags (default: auto-detect).
+
 ### Changed
 
 - **Minimum supported Python raised to 3.13**: required for TLS-PSK dongle
@@ -14,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses `ssl.SSLContext.set_psk_client_callback` (Python 3.13+ only). This also
   raises the minimum Home Assistant version for consumers, since HA bundles
   its own Python runtime per release.
+
+### Fixed
+
+- **Dongle response validation keyed off the negotiated channel instead of
+  the requested SSL policy**: PR #314 skipped the TCP-function byte
+  cross-check whenever SSL was *requested*; it is now skipped only when TLS
+  actually negotiated on the current connection, so an AUTO connection that
+  fell back to plaintext still validates the TCP function byte of every
+  response frame.
 
 ## [0.10.0b5] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,31 +18,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handshake rejection fails fast as `TransportConnectionError` instead of
   burning the retry ladder on a doomed handshake), `False` forces
   plaintext (pre-#314 behavior, never probes), and `None` (the new
-  default) auto-detects: the first connection attempt probes TLS, and an
-  `ssl.SSLError` handshake rejection is treated as a definitive "no SSL
-  support" — the same attempt falls back to plaintext and the negative
-  verdict is cached per-instance for 24 hours (re-probed afterward, since
-  dongle firmware can be updated in the field). A TLS probe the peer
-  neither completes nor rejects (timeout, abort, or reset — e.g. firmware
-  that silently discards the ClientHello) is an ambiguous negative: the
-  same attempt falls back to plaintext with a short ~300s re-probe
-  cooldown, and only on a never-proven instance. Failures that hit TLS
-  and plaintext alike (e.g. connection refused) stay on the existing
-  retry/backoff ladder and cache no verdict. Once TLS has negotiated on
-  an instance it is never downgraded: a later `ssl.SSLError` retries
-  TLS-only across the ladder (logged as warnings) and, if exhausted,
-  fails the `connect()` call as `TransportConnectionError` — never
-  falling back to plaintext. The cheap `check_link()` health probe
-  reuses the last-known channel state (plaintext until TLS has proven)
-  rather than TLS-probing inside its short budget, and logs when it
-  connects plaintext before auto-detection has run. TLS is capped at 1.2
-  (`ssl` PSK callbacks do not apply to TLS 1.3). On Python < 3.13
-  (stdlib `ssl` lacks TLS-PSK) AUTO uses plaintext without error; only
-  forced `use_ssl=True` raises. `eg4-modbus-diag` gained `--use-ssl` /
-  `--no-ssl` flags (default: auto-detect). `use_ssl` sits after
-  `timeout` in the `DongleTransport` signature and after
-  `inverter_family` in `DongleCollector`, so pre-#314 positional callers
-  are unaffected.
+  default) auto-detects: the first connection attempt probes TLS, and
+  ONLY a definitive `ssl.SSLError` handshake rejection is treated as "no
+  TLS support" — the same attempt falls back to plaintext and the
+  negative verdict is cached per-instance for 24 hours, re-probed after
+  the TTL expires (this re-probe is also the upgrade pin: a
+  plaintext-only dongle whose firmware is later upgraded to add TLS is
+  picked up on the next re-probe). Any other TLS-probe failure —
+  timeout, connection abort, connection reset, or any other `OSError` —
+  is fully inconclusive: it stays on the ordinary retry/backoff ladder
+  with NO cached verdict and NO plaintext fallback, so an active
+  on-path attacker cannot force a downgrade by disrupting the
+  handshake. This deliberately means firmware that silently discards
+  the TLS ClientHello (rather than cleanly rejecting it) cannot be
+  safely auto-detected — configure such a dongle explicitly with
+  `use_ssl=False` / `--no-ssl` (per the design ruling on
+  [#320](https://github.com/joyfulhouse/pylxpweb/issues/320)). Once TLS
+  has negotiated on an instance it is never downgraded: a later
+  `ssl.SSLError` retries TLS-only across the ladder (logged as
+  warnings) and, if exhausted, fails the `connect()` call as
+  `TransportConnectionError` — never falling back to plaintext. The
+  cheap `check_link()` health probe reuses the last-known channel state
+  (plaintext until TLS has proven) rather than TLS-probing inside its
+  short budget, and logs when it connects plaintext before
+  auto-detection has run. TLS is capped at 1.2 (`ssl` PSK callbacks do
+  not apply to TLS 1.3). On Python < 3.13 (stdlib `ssl` lacks TLS-PSK)
+  AUTO uses plaintext without error; only forced `use_ssl=True` raises.
+  `pylxpweb-modbus-diag` gained `--use-ssl` / `--no-ssl` flags (default:
+  auto-detect), honored by both the default collection mode and
+  `--battery-probe`.
+  `use_ssl` sits after `timeout` in the `DongleTransport` signature and
+  after `inverter_family` in `DongleCollector`, so pre-#314 positional
+  callers are unaffected.
 
   **SECURITY NOTE**: the dongle's TLS-PSK scheme derives its key from a
   fixed value published in this source tree (and in vendor firmware)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fell back to plaintext still validates the TCP function byte of every
   response frame.
 
+- **Dongle serial auto-detection no longer crashes on a garbage frame**:
+  when the inverter serial is auto-detected from the first response, a
+  frame whose serial bytes are not valid ASCII raised an uncaught
+  `UnicodeDecodeError` instead of the transport's mismatch error, and an
+  accepted serial kept its NUL padding (leaking into logs and outbound
+  frames). The detected serial is now decoded defensively and must be 10
+  printable ASCII characters; anything else rejects through the normal
+  response-mismatch path.
+
 ## [0.10.0b5] - 2026-08-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,27 +15,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [@dpw13](https://github.com/dpw13), who authored the underlying TLS-PSK
   implementation): dongle firmware V3.02 encrypts port 8000 with TLS-PSK.
   `DongleTransport(use_ssl=...)` is now tri-state — `True` forces TLS (a
-  handshake failure propagates immediately instead of burning the retry
-  ladder on a doomed handshake), `False` forces plaintext (pre-#314
-  behavior, never probes), and `None` (the new default) auto-detects:
-  the first connection attempt probes TLS, and an `ssl.SSLError` handshake
-  rejection is treated as a definitive "no SSL support" — the same attempt
-  falls back to plaintext and the negative verdict is cached per-instance
-  for 24 hours (re-probed afterward, since dongle firmware can be updated
-  in the field). Generic socket errors and timeouts — including TLS
-  handshake timeouts — are inconclusive: they stay on the existing
-  retry/backoff ladder and cache no verdict, so a downgrade can never be
-  forced by stalling or dropping the handshake. Once TLS has negotiated on
-  an instance it is never downgraded: a later `ssl.SSLError` fails the
-  `connect()` call instead of falling back to plaintext. The cheap
-  `check_link()` health probe reuses the last-known channel state
-  (plaintext until TLS has proven) rather than TLS-probing inside its
-  short budget. TLS is capped at 1.2 (`ssl` PSK callbacks do not apply to
-  TLS 1.3). On Python < 3.13 (stdlib `ssl` lacks TLS-PSK) AUTO uses
-  plaintext without error; only forced `use_ssl=True` raises.
-  `eg4-modbus-diag` gained `--use-ssl` / `--no-ssl` flags (default:
-  auto-detect). `use_ssl` sits after `timeout` in the `DongleTransport`
-  signature, so pre-#314 positional callers are unaffected.
+  handshake rejection fails fast as `TransportConnectionError` instead of
+  burning the retry ladder on a doomed handshake), `False` forces
+  plaintext (pre-#314 behavior, never probes), and `None` (the new
+  default) auto-detects: the first connection attempt probes TLS, and an
+  `ssl.SSLError` handshake rejection is treated as a definitive "no SSL
+  support" — the same attempt falls back to plaintext and the negative
+  verdict is cached per-instance for 24 hours (re-probed afterward, since
+  dongle firmware can be updated in the field). A TLS probe the peer
+  neither completes nor rejects (timeout, abort, or reset — e.g. firmware
+  that silently discards the ClientHello) is an ambiguous negative: the
+  same attempt falls back to plaintext with a short ~300s re-probe
+  cooldown, and only on a never-proven instance. Failures that hit TLS
+  and plaintext alike (e.g. connection refused) stay on the existing
+  retry/backoff ladder and cache no verdict. Once TLS has negotiated on
+  an instance it is never downgraded: a later `ssl.SSLError` retries
+  TLS-only across the ladder (logged as warnings) and, if exhausted,
+  fails the `connect()` call as `TransportConnectionError` — never
+  falling back to plaintext. The cheap `check_link()` health probe
+  reuses the last-known channel state (plaintext until TLS has proven)
+  rather than TLS-probing inside its short budget, and logs when it
+  connects plaintext before auto-detection has run. TLS is capped at 1.2
+  (`ssl` PSK callbacks do not apply to TLS 1.3). On Python < 3.13
+  (stdlib `ssl` lacks TLS-PSK) AUTO uses plaintext without error; only
+  forced `use_ssl=True` raises. `eg4-modbus-diag` gained `--use-ssl` /
+  `--no-ssl` flags (default: auto-detect). `use_ssl` sits after
+  `timeout` in the `DongleTransport` signature and after
+  `inverter_family` in `DongleCollector`, so pre-#314 positional callers
+  are unaffected.
 
   **SECURITY NOTE**: the dongle's TLS-PSK scheme derives its key from a
   fixed value published in this source tree (and in vendor firmware)

--- a/src/pylxpweb/cli/collectors/dongle.py
+++ b/src/pylxpweb/cli/collectors/dongle.py
@@ -74,7 +74,14 @@ class DongleCollector:
             inverter_serial: 10-character inverter serial (auto-detected if empty)
             port: TCP port (default 8000)
             timeout: Operation timeout in seconds
-            use_ssl: TLS-PSK policy (True=on, False=off, None=auto-detect)
+            use_ssl: TLS-PSK policy (True=on, False=off, None=auto-detect).
+                SECURITY: TLS-PSK here hides traffic from passive observers
+                only — the PSK derives from a fixed key published in this
+                source tree plus the dongle serial (printed on the device,
+                broadcast in plaintext frames), with no certificate
+                validation. It does not authenticate the peer, does not
+                resist an active man-in-the-middle, and the key cannot be
+                rotated.
             inverter_family: Inverter family for register mapping
         """
         self._host = host

--- a/src/pylxpweb/cli/collectors/dongle.py
+++ b/src/pylxpweb/cli/collectors/dongle.py
@@ -63,7 +63,7 @@ class DongleCollector:
         inverter_serial: str = "",
         port: int = 8000,
         timeout: float = 10.0,
-        use_ssl: bool = False,
+        use_ssl: bool | None = None,
         inverter_family: InverterFamily | None = None,
     ) -> None:
         """Initialize dongle collector.
@@ -74,6 +74,7 @@ class DongleCollector:
             inverter_serial: 10-character inverter serial (auto-detected if empty)
             port: TCP port (default 8000)
             timeout: Operation timeout in seconds
+            use_ssl: TLS-PSK policy (True=on, False=off, None=auto-detect)
             inverter_family: Inverter family for register mapping
         """
         self._host = host

--- a/src/pylxpweb/cli/collectors/dongle.py
+++ b/src/pylxpweb/cli/collectors/dongle.py
@@ -63,8 +63,8 @@ class DongleCollector:
         inverter_serial: str = "",
         port: int = 8000,
         timeout: float = 10.0,
-        use_ssl: bool | None = None,
         inverter_family: InverterFamily | None = None,
+        use_ssl: bool | None = None,
     ) -> None:
         """Initialize dongle collector.
 
@@ -74,6 +74,7 @@ class DongleCollector:
             inverter_serial: 10-character inverter serial (auto-detected if empty)
             port: TCP port (default 8000)
             timeout: Operation timeout in seconds
+            inverter_family: Inverter family for register mapping
             use_ssl: TLS-PSK policy (True=on, False=off, None=auto-detect).
                 SECURITY: TLS-PSK here hides traffic from passive observers
                 only — the PSK derives from a fixed key published in this
@@ -82,7 +83,6 @@ class DongleCollector:
                 validation. It does not authenticate the peer, does not
                 resist an active man-in-the-middle, and the key cannot be
                 rotated.
-            inverter_family: Inverter family for register mapping
         """
         self._host = host
         self._port = port

--- a/src/pylxpweb/cli/modbus_diag.py
+++ b/src/pylxpweb/cli/modbus_diag.py
@@ -104,10 +104,20 @@ Examples:
         "--dongle-serial",
         help="WiFi dongle serial number (required for dongle transport)",
     )
-    conn_group.add_argument(
+    ssl_group = conn_group.add_mutually_exclusive_group()
+    ssl_group.add_argument(
         "--use-ssl",
-        action="store_true",
-        help="Encrypt the local connection (only relevant for dongle transport)",
+        dest="use_ssl",
+        action="store_const",
+        const=True,
+        help="Force TLS-PSK for dongle transport",
+    )
+    ssl_group.add_argument(
+        "--no-ssl",
+        dest="use_ssl",
+        action="store_const",
+        const=False,
+        help="Disable TLS-PSK for dongle transport (default: auto-detect)",
     )
 
     # Cloud API options

--- a/src/pylxpweb/cli/modbus_diag.py
+++ b/src/pylxpweb/cli/modbus_diag.py
@@ -976,6 +976,7 @@ async def run_battery_probe(args: argparse.Namespace) -> int:
             dongle_serial=dongle_serial,
             inverter_serial=args.serial or "",
             port=args.port,
+            use_ssl=getattr(args, "use_ssl", None),
         )
     else:
         collector = ModbusCollector(

--- a/src/pylxpweb/cli/modbus_diag.py
+++ b/src/pylxpweb/cli/modbus_diag.py
@@ -110,7 +110,12 @@ Examples:
         dest="use_ssl",
         action="store_const",
         const=True,
-        help="Force TLS-PSK for dongle transport",
+        help=(
+            "Force TLS-PSK for dongle transport. NOTE: hides traffic from "
+            "passive observers only — the PSK derives from a fixed published "
+            "key plus the dongle serial, with no peer authentication and no "
+            "protection against an active man-in-the-middle"
+        ),
     )
     ssl_group.add_argument(
         "--no-ssl",
@@ -387,7 +392,7 @@ async def run_collection(args: argparse.Namespace) -> int:
                     dongle_serial=dongle_serial,
                     inverter_serial=args.serial or "",
                     port=args.port if args.transport == "dongle" else 8000,
-                    use_ssl=args.use_ssl if args.transport == "dongle" else False,
+                    use_ssl=args.use_ssl,
                 )
                 await dongle_collector.connect()
 

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -95,7 +95,6 @@ _MAX_PREFIX_SCAN_BYTES = RECV_BUFFER_SIZE
 _SHUTDOWN_CLOSE_TIMEOUT = 0.25
 _SSL_HANDSHAKE_TIMEOUT = 3.0
 _SSL_UNSUPPORTED_TTL = 86400.0
-_SSL_AMBIGUOUS_COOLDOWN = 300.0
 
 # Write resilience settings (joyfulhouse/eg4_web_monitor#201)
 # The dongle drops its TCP connection mid-sequence during parameter writes
@@ -204,8 +203,8 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         dongle_serial: str,
         inverter_serial: str,
         port: int = DEFAULT_PORT,
-        use_ssl: bool | None = None,
         timeout: float = DEFAULT_TIMEOUT,
+        use_ssl: bool | None = None,
         inverter_family: InverterFamily | None = None,
         connection_retries: int = 3,
         write_retries: int = DEFAULT_WRITE_RETRIES,
@@ -221,9 +220,19 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
             dongle_serial: 10-character dongle serial number (e.g., "BA12345678")
             inverter_serial: 10-character inverter serial number (e.g., "CE12345678")
             port: TCP port (default 8000)
+            timeout: Connection and operation timeout in seconds
             use_ssl: TLS-PSK policy: True forces TLS, False disables it, and
                 None auto-detects support (default).
-            timeout: Connection and operation timeout in seconds
+
+                SECURITY: the dongle's TLS-PSK uses a fixed key that is
+                published in this source tree (and in the vendor firmware),
+                mixed with the dongle serial — which is printed on the
+                device and broadcast in plaintext frames — and performs no
+                certificate validation. It hides register traffic from
+                passive on-path observers ONLY: it does not authenticate
+                the peer, does not resist an active man-in-the-middle, and
+                the key cannot be rotated. Do not treat ``use_ssl=True`` as
+                making the link trustworthy or the credentials secret.
             inverter_family: Inverter model family for correct register mapping.
                 If None, defaults to PV_SERIES (EG4-18KPV) for backward
                 compatibility.
@@ -264,6 +273,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         self._ssl_proven = False
         self._ssl_unsupported_until: float | None = None
         self._ssl_unavailable_logged = False
+        self._link_probe_active = False
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._receive_buffer = bytearray()
@@ -424,6 +434,9 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_ctx.check_hostname = False
         ssl_ctx.verify_mode = ssl.CERT_NONE
+        # PSK client callbacks only apply to TLS <= 1.2 (CPython docs), so a
+        # TLS 1.3 negotiation would bypass the PSK entirely — cap it.
+        ssl_ctx.maximum_version = ssl.TLSVersion.TLSv1_2
         ssl_ctx.options |= ssl.OP_NO_TLSv1
         ssl_ctx.options |= ssl.OP_NO_TLSv1_1
         ssl_ctx.set_psk_client_callback(get_psk)
@@ -433,18 +446,20 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
 
     def _auto_ssl_context(self) -> ssl.SSLContext | None:
         """Return a probe context unless AUTO has a cached negative verdict."""
-        if (
-            self._ssl_mode is None
-            and self._ssl_unsupported_until is not None
-            and time.monotonic() < self._ssl_unsupported_until
-        ):
-            return None
+        if self._ssl_mode is None:
+            if self._link_probe_active and not self._ssl_proven:
+                # The cheap link-down probe (check_link) runs on a ~5s
+                # budget: never spend it TLS-probing an undetermined
+                # channel.  Reuse the last-known state — plaintext until
+                # TLS has proven — and let a real connect() resolve
+                # capability under its full budget.
+                return None
+            if (
+                self._ssl_unsupported_until is not None
+                and time.monotonic() < self._ssl_unsupported_until
+            ):
+                return None
         return self._ssl_ctx()
-
-    @staticmethod
-    def _is_ssl_handshake_timeout(err: OSError) -> bool:
-        """Identify asyncio's dedicated SSL handshake timeout failure."""
-        return isinstance(err, ConnectionAbortedError) and "SSL handshake" in str(err)
 
     async def _open_connection(
         self, ssl_context: ssl.SSLContext | None
@@ -454,7 +469,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         if ssl_context is not None:
             kwargs = {
                 "ssl": ssl_context,
-                "ssl_handshake_timeout": _SSL_HANDSHAKE_TIMEOUT,
+                "ssl_handshake_timeout": min(self._timeout, _SSL_HANDSHAKE_TIMEOUT),
             }
         return await asyncio.wait_for(
             asyncio.open_connection(self._host, self._port, **kwargs),
@@ -514,6 +529,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                         self._raise_if_shutdown()
                         retry_delay *= 2  # Exponential backoff
 
+                    using_ssl = False
                     ssl_context = self._auto_ssl_context()
                     while True:
                         using_ssl = ssl_context is not None
@@ -529,42 +545,27 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                             break
                         except ssl.SSLError:
                             await self._close_connection()
-                            if self._ssl_mode is not None:
+                            if not using_ssl:
+                                # An SSLError off a plaintext socket is not
+                                # TLS capability evidence — ordinary failure.
                                 raise
-                            if self._ssl_proven and attempt < self._connection_retries - 1:
+                            if self._ssl_mode is not None or self._ssl_proven:
+                                # Forced TLS never falls back; an instance
+                                # where TLS has proven is never silently
+                                # downgraded.
                                 raise
-                            now = time.monotonic()
-                            if self._ssl_proven:
-                                self._ssl_unsupported_until = now + _SSL_AMBIGUOUS_COOLDOWN
-                                _LOGGER.warning(
-                                    "TLS previously negotiated successfully but this "
-                                    "connection fell back to plaintext"
-                                )
-                            else:
-                                self._ssl_unsupported_until = now + _SSL_UNSUPPORTED_TTL
-                                _LOGGER.info(
-                                    "Dongle/firmware does not support TLS-PSK on port %s; "
-                                    "will retry SSL detection in 24h",
-                                    self._port,
-                                )
+                            # First AUTO probe: a rejected handshake is a
+                            # definitive negative — plaintext for the rest of
+                            # this attempt, cached for future connects.
+                            # Generic OSError/timeout is inconclusive and
+                            # propagates to the retry ladder uncached.
+                            self._ssl_unsupported_until = time.monotonic() + _SSL_UNSUPPORTED_TTL
+                            _LOGGER.info(
+                                "Dongle/firmware does not support TLS-PSK on port %s; "
+                                "will retry SSL detection in 24h",
+                                self._port,
+                            )
                             ssl_context = None
-                        except OSError as err:
-                            await self._close_connection()
-                            if (
-                                using_ssl
-                                and self._ssl_mode is None
-                                and self._is_ssl_handshake_timeout(err)
-                            ):
-                                self._ssl_unsupported_until = (
-                                    time.monotonic() + _SSL_AMBIGUOUS_COOLDOWN
-                                )
-                                _LOGGER.warning(
-                                    "TLS handshake timed out; this connection fell back "
-                                    "to plaintext"
-                                )
-                                ssl_context = None
-                                continue
-                            raise
                     self._raise_if_shutdown()
 
                     self._ssl_active = using_ssl
@@ -586,10 +587,14 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     last_error = err
                     await self._close_connection()
                     self._raise_if_shutdown()
-                    if self._ssl_mode is True:
+                    if using_ssl:
+                        # Only forced-TLS and proven-TLS re-raise out of the
+                        # inner loop with a TLS socket: the failure is
+                        # deterministic (or a forbidden downgrade), so
+                        # retrying cannot help — propagate to the caller.
                         raise
                     _LOGGER.warning(
-                        "TLS connection failed to %s:%s: %s (attempt %d/%d)",
+                        "Connection failed to %s:%s: %s (attempt %d/%d)",
                         self._host,
                         self._port,
                         err,
@@ -1498,6 +1503,11 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
             register_count=1,
         )
         try:
+            # A probe dial must reuse the last-known channel state instead of
+            # AUTO TLS-probing (see _auto_ssl_context): a TLS-silent peer
+            # would otherwise burn the handshake timeout inside this budget
+            # and report a working plaintext dongle as down.
+            self._link_probe_active = True
             await asyncio.wait_for(
                 self._send_receive(
                     packet,
@@ -1518,6 +1528,8 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         except (TransportError, OSError) as err:
             _LOGGER.debug("[%s] Link probe failed: %s", self._serial, err)
             return False
+        finally:
+            self._link_probe_active = False
         return True
 
     async def _read_input_registers(

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -32,6 +32,8 @@ import hmac
 import logging
 import ssl
 import struct
+import sys
+import time
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from ._register_data import (
@@ -91,6 +93,9 @@ _MIN_ADVERTISED_FRAME_LENGTH = _FRAME_FIXED_FIELDS_SIZE + _FRAME_CRC_SIZE
 _MAX_PACKET_SIZE = RECV_BUFFER_SIZE
 _MAX_PREFIX_SCAN_BYTES = RECV_BUFFER_SIZE
 _SHUTDOWN_CLOSE_TIMEOUT = 0.25
+_SSL_HANDSHAKE_TIMEOUT = 3.0
+_SSL_UNSUPPORTED_TTL = 86400.0
+_SSL_AMBIGUOUS_COOLDOWN = 300.0
 
 # Write resilience settings (joyfulhouse/eg4_web_monitor#201)
 # The dongle drops its TCP connection mid-sequence during parameter writes
@@ -199,7 +204,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         dongle_serial: str,
         inverter_serial: str,
         port: int = DEFAULT_PORT,
-        use_ssl: bool = False,
+        use_ssl: bool | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         inverter_family: InverterFamily | None = None,
         connection_retries: int = 3,
@@ -216,7 +221,8 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
             dongle_serial: 10-character dongle serial number (e.g., "BA12345678")
             inverter_serial: 10-character inverter serial number (e.g., "CE12345678")
             port: TCP port (default 8000)
-            use_ssl: Use TLS-PSK over TCP. Set to true for newer firmwares
+            use_ssl: TLS-PSK policy: True forces TLS, False disables it, and
+                None auto-detects support (default).
             timeout: Connection and operation timeout in seconds
             inverter_family: Inverter model family for correct register mapping.
                 If None, defaults to PV_SERIES (EG4-18KPV) for backward
@@ -253,7 +259,11 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         self._write_retries = write_retries
         self._write_step_delay = write_step_delay
         self._verify_writes = verify_writes
-        self._use_ssl = use_ssl
+        self._ssl_mode = use_ssl
+        self._ssl_active = False
+        self._ssl_proven = False
+        self._ssl_unsupported_until: float | None = None
+        self._ssl_unavailable_logged = False
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._receive_buffer = bytearray()
@@ -376,14 +386,29 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         )
 
     def _ssl_ctx(self) -> ssl.SSLContext | None:
-        """Create the SSL context for TLS-PSK encrypted channels."""
+        """Create the SSL context for TLS-PSK encrypted channels.
 
-        if not self._use_ssl:
+        Security: the PSK uses the fixed, source-committed key
+        ``4c7578506f77657254656b21`` HMAC'd with the non-secret dongle serial,
+        which is printed on the device and broadcast in plaintext frames.
+        With ``CERT_NONE`` and no certificate validation, this provides only
+        confidentiality from passive on-path observers; it does not
+        authenticate the peer or resist an active MITM.
+        """
+
+        if self._ssl_mode is False:
             return None
 
-        if not getattr(ssl, "HAS_PSK", False):
-            # Requires an OpenSSL build with PSK support
-            raise NotImplementedError("SSL was requested but PSK support is missing")
+        if sys.version_info < (3, 13) or not getattr(ssl, "HAS_PSK", False):
+            # ssl.SSLContext.set_psk_client_callback requires Python 3.13+
+            # (ssl.HAS_PSK) and an OpenSSL build with PSK support; the
+            # version check also lets mypy see the 3.13-only API below.
+            if self._ssl_mode is True:
+                raise NotImplementedError("SSL was requested but PSK support is missing")
+            if not self._ssl_unavailable_logged:
+                _LOGGER.debug("TLS-PSK auto-detection skipped: Python lacks PSK support")
+                self._ssl_unavailable_logged = True
+            return None
 
         # Compute PSK from the key and the dongle serial
         psk = hmac.digest(
@@ -405,6 +430,36 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         ssl_ctx.set_ciphers("DHE-PSK-AES128-GCM-SHA256")
 
         return ssl_ctx
+
+    def _auto_ssl_context(self) -> ssl.SSLContext | None:
+        """Return a probe context unless AUTO has a cached negative verdict."""
+        if (
+            self._ssl_mode is None
+            and self._ssl_unsupported_until is not None
+            and time.monotonic() < self._ssl_unsupported_until
+        ):
+            return None
+        return self._ssl_ctx()
+
+    @staticmethod
+    def _is_ssl_handshake_timeout(err: OSError) -> bool:
+        """Identify asyncio's dedicated SSL handshake timeout failure."""
+        return isinstance(err, ConnectionAbortedError) and "SSL handshake" in str(err)
+
+    async def _open_connection(
+        self, ssl_context: ssl.SSLContext | None
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        """Dial once, applying the short timeout only to TLS handshakes."""
+        kwargs: dict[str, Any] = {}
+        if ssl_context is not None:
+            kwargs = {
+                "ssl": ssl_context,
+                "ssl_handshake_timeout": _SSL_HANDSHAKE_TIMEOUT,
+            }
+        return await asyncio.wait_for(
+            asyncio.open_connection(self._host, self._port, **kwargs),
+            timeout=self._timeout,
+        )
 
     async def connect(self) -> None:
         """Establish TCP connection to the WiFi dongle with retry and backoff.
@@ -459,31 +514,63 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                         self._raise_if_shutdown()
                         retry_delay *= 2  # Exponential backoff
 
-                    # Only pass the ssl kwarg when TLS is enabled so the
-                    # plain-TCP path keeps the original
-                    # open_connection(host, port) call signature.
-                    ssl_ctx = self._ssl_ctx()
-                    if ssl_ctx is not None:
-                        open_conn = asyncio.open_connection(self._host, self._port, ssl=ssl_ctx)
-                    else:
-                        open_conn = asyncio.open_connection(self._host, self._port)
-                    self._reader, self._writer = await asyncio.wait_for(
-                        open_conn,
-                        timeout=self._timeout,
-                    )
-                    if self._shutdown_requested:
-                        await self._close_connection()
-                        self._raise_if_shutdown()
+                    ssl_context = self._auto_ssl_context()
+                    while True:
+                        using_ssl = ssl_context is not None
+                        try:
+                            self._reader, self._writer = await self._open_connection(ssl_context)
+                            if self._shutdown_requested:
+                                await self._close_connection()
+                                self._raise_if_shutdown()
 
-                    # Discard any initial data the dongle sends after
-                    # connection (some dongles send unsolicited packets that
-                    # can confuse subsequent reads) BEFORE declaring the
-                    # connection usable — an OSError here fails this attempt
-                    # instead of leaking a connected-looking transport with
-                    # a broken socket.
-                    await self._discard_initial_data()
+                            # The first read can surface a deferred TLS error,
+                            # so it is part of capability detection.
+                            await self._discard_initial_data()
+                            break
+                        except ssl.SSLError:
+                            await self._close_connection()
+                            if self._ssl_mode is not None:
+                                raise
+                            if self._ssl_proven and attempt < self._connection_retries - 1:
+                                raise
+                            now = time.monotonic()
+                            if self._ssl_proven:
+                                self._ssl_unsupported_until = now + _SSL_AMBIGUOUS_COOLDOWN
+                                _LOGGER.warning(
+                                    "TLS previously negotiated successfully but this "
+                                    "connection fell back to plaintext"
+                                )
+                            else:
+                                self._ssl_unsupported_until = now + _SSL_UNSUPPORTED_TTL
+                                _LOGGER.info(
+                                    "Dongle/firmware does not support TLS-PSK on port %s; "
+                                    "will retry SSL detection in 24h",
+                                    self._port,
+                                )
+                            ssl_context = None
+                        except OSError as err:
+                            await self._close_connection()
+                            if (
+                                using_ssl
+                                and self._ssl_mode is None
+                                and self._is_ssl_handshake_timeout(err)
+                            ):
+                                self._ssl_unsupported_until = (
+                                    time.monotonic() + _SSL_AMBIGUOUS_COOLDOWN
+                                )
+                                _LOGGER.warning(
+                                    "TLS handshake timed out; this connection fell back "
+                                    "to plaintext"
+                                )
+                                ssl_context = None
+                                continue
+                            raise
                     self._raise_if_shutdown()
 
+                    self._ssl_active = using_ssl
+                    if using_ssl:
+                        self._ssl_proven = True
+                        self._ssl_unsupported_until = None
                     self._connected = True
                     _LOGGER.info(
                         "Dongle transport connected to %s:%s (dongle=%s, inverter=%s)%s",
@@ -495,6 +582,20 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     )
                     return  # Success!
 
+                except ssl.SSLError as err:
+                    last_error = err
+                    await self._close_connection()
+                    self._raise_if_shutdown()
+                    if self._ssl_mode is True:
+                        raise
+                    _LOGGER.warning(
+                        "TLS connection failed to %s:%s: %s (attempt %d/%d)",
+                        self._host,
+                        self._port,
+                        err,
+                        attempt + 1,
+                        self._connection_retries,
+                    )
                 except TimeoutError as err:
                     last_error = err
                     await self._close_connection()
@@ -574,6 +675,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
         """
         self._shutdown_requested = True
         self._connected = False
+        self._ssl_active = False
         self._reader = None
         self._receive_buffer.clear()
         writer = self._writer
@@ -974,7 +1076,7 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                         expected_func,
                         expected_register,
                         expected_count,
-                        expected_tcp_func=None if self._use_ssl else packet[7],
+                        expected_tcp_func=None if self._ssl_active else packet[7],
                     )
 
                 except _DongleFrameError as err:

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -95,7 +95,6 @@ _MAX_PREFIX_SCAN_BYTES = RECV_BUFFER_SIZE
 _SHUTDOWN_CLOSE_TIMEOUT = 0.25
 _SSL_HANDSHAKE_TIMEOUT = 3.0
 _SSL_UNSUPPORTED_TTL = 86400.0
-_SSL_AMBIGUOUS_COOLDOWN = 300.0
 
 # Write resilience settings (joyfulhouse/eg4_web_monitor#201)
 # The dongle drops its TCP connection mid-sequence during parameter writes
@@ -558,41 +557,20 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                                 raise
                             # First AUTO probe: a rejected handshake is a
                             # definitive negative — plaintext for the rest of
-                            # this attempt, cached for future connects.
+                            # this attempt, cached for future connects (the
+                            # TTL re-probe also picks up a later firmware
+                            # upgrade that adds TLS). Every other probe
+                            # failure — timeout, abort, reset, refused — is
+                            # inconclusive and propagates to the outer retry
+                            # ladder uncached: never treat a disrupted
+                            # handshake as capability evidence, or an on-path
+                            # attacker could force a plaintext downgrade by
+                            # stalling it.
                             self._ssl_unsupported_until = time.monotonic() + _SSL_UNSUPPORTED_TTL
                             _LOGGER.info(
                                 "Dongle/firmware does not support TLS-PSK on port %s; "
                                 "will retry SSL detection in 24h",
                                 self._port,
-                            )
-                            ssl_context = None
-                        except (
-                            TimeoutError,
-                            ConnectionAbortedError,
-                            ConnectionResetError,
-                        ):
-                            await self._close_connection()
-                            if not using_ssl or self._ssl_mode is not None or self._ssl_proven:
-                                # Not first-probe evidence: plaintext dials,
-                                # forced modes, and proven-TLS instances take
-                                # the ordinary retry ladder (which never
-                                # downgrades a proven or forced channel).
-                                raise
-                            # First AUTO probe: the peer neither completed nor
-                            # rejected the handshake (e.g. firmware that
-                            # silently discards the ClientHello) — an
-                            # ambiguous negative. Fall back to plaintext for
-                            # this attempt with a short re-probe cooldown; the
-                            # 24h TTL is reserved for the definitive SSLError.
-                            # Other OSErrors (e.g. connection refused) fail
-                            # TLS and plaintext alike, so they stay on the
-                            # retry ladder uncached.
-                            self._ssl_unsupported_until = time.monotonic() + _SSL_AMBIGUOUS_COOLDOWN
-                            _LOGGER.info(
-                                "TLS-PSK probe to port %s got no handshake answer; "
-                                "using plaintext and re-probing in %.0fs",
-                                self._port,
-                                _SSL_AMBIGUOUS_COOLDOWN,
                             )
                             ssl_context = None
                     self._raise_if_shutdown()

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -1417,7 +1417,13 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     f"got {resp_serial_str} ({mismatch_context})"
                 )
         else:
-            self._serial = response_serial.decode()
+            # A garbage frame must reject through the mismatch path, not
+            # crash with UnicodeDecodeError, and NUL padding must not leak
+            # into logs or outbound frames via the stored serial.
+            detected = response_serial.decode("ascii", errors="replace").rstrip("\x00")
+            if len(detected) != 10 or not detected.isascii() or not detected.isprintable():
+                _raise_mismatch(f"Unparseable response serial {detected!r} ({mismatch_context})")
+            self._serial = detected
             _LOGGER.debug("Detected inverter serial: %s", self._serial)
 
         # 2. Function code must match (mask high bit for exception responses)

--- a/src/pylxpweb/transports/dongle.py
+++ b/src/pylxpweb/transports/dongle.py
@@ -95,6 +95,7 @@ _MAX_PREFIX_SCAN_BYTES = RECV_BUFFER_SIZE
 _SHUTDOWN_CLOSE_TIMEOUT = 0.25
 _SSL_HANDSHAKE_TIMEOUT = 3.0
 _SSL_UNSUPPORTED_TTL = 86400.0
+_SSL_AMBIGUOUS_COOLDOWN = 300.0
 
 # Write resilience settings (joyfulhouse/eg4_web_monitor#201)
 # The dongle drops its TCP connection mid-sequence during parameter writes
@@ -550,20 +551,48 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                                 # TLS capability evidence — ordinary failure.
                                 raise
                             if self._ssl_mode is not None or self._ssl_proven:
-                                # Forced TLS never falls back; an instance
-                                # where TLS has proven is never silently
-                                # downgraded.
+                                # Forced TLS fails fast (outer handler wraps
+                                # it); a proven-TLS instance retries TLS-only
+                                # on the outer ladder — neither ever falls
+                                # back to plaintext.
                                 raise
                             # First AUTO probe: a rejected handshake is a
                             # definitive negative — plaintext for the rest of
                             # this attempt, cached for future connects.
-                            # Generic OSError/timeout is inconclusive and
-                            # propagates to the retry ladder uncached.
                             self._ssl_unsupported_until = time.monotonic() + _SSL_UNSUPPORTED_TTL
                             _LOGGER.info(
                                 "Dongle/firmware does not support TLS-PSK on port %s; "
                                 "will retry SSL detection in 24h",
                                 self._port,
+                            )
+                            ssl_context = None
+                        except (
+                            TimeoutError,
+                            ConnectionAbortedError,
+                            ConnectionResetError,
+                        ):
+                            await self._close_connection()
+                            if not using_ssl or self._ssl_mode is not None or self._ssl_proven:
+                                # Not first-probe evidence: plaintext dials,
+                                # forced modes, and proven-TLS instances take
+                                # the ordinary retry ladder (which never
+                                # downgrades a proven or forced channel).
+                                raise
+                            # First AUTO probe: the peer neither completed nor
+                            # rejected the handshake (e.g. firmware that
+                            # silently discards the ClientHello) — an
+                            # ambiguous negative. Fall back to plaintext for
+                            # this attempt with a short re-probe cooldown; the
+                            # 24h TTL is reserved for the definitive SSLError.
+                            # Other OSErrors (e.g. connection refused) fail
+                            # TLS and plaintext alike, so they stay on the
+                            # retry ladder uncached.
+                            self._ssl_unsupported_until = time.monotonic() + _SSL_AMBIGUOUS_COOLDOWN
+                            _LOGGER.info(
+                                "TLS-PSK probe to port %s got no handshake answer; "
+                                "using plaintext and re-probing in %.0fs",
+                                self._port,
+                                _SSL_AMBIGUOUS_COOLDOWN,
                             )
                             ssl_context = None
                     self._raise_if_shutdown()
@@ -572,6 +601,23 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     if using_ssl:
                         self._ssl_proven = True
                         self._ssl_unsupported_until = None
+                    elif (
+                        self._link_probe_active
+                        and self._ssl_mode is None
+                        and not self._ssl_proven
+                        and self._ssl_unsupported_until is None
+                    ):
+                        # A link probe forced this plaintext dial before TLS
+                        # auto-detection ever ran; the connection may be kept
+                        # past the health check, so leave a trail. Detection
+                        # runs on the next fresh (non-probe) dial.
+                        _LOGGER.info(
+                            "Link probe connected to %s:%s in plaintext before TLS "
+                            "auto-detection ran; TLS will be probed on the next "
+                            "fresh connection",
+                            self._host,
+                            self._port,
+                        )
                     self._connected = True
                     _LOGGER.info(
                         "Dongle transport connected to %s:%s (dongle=%s, inverter=%s)%s",
@@ -587,20 +633,35 @@ class DongleTransport(RegisterDataMixin, BaseTransport):
                     last_error = err
                     await self._close_connection()
                     self._raise_if_shutdown()
+                    if using_ssl and self._ssl_mode is True:
+                        # Forced TLS: a handshake rejection is deterministic —
+                        # fail fast, wrapped to connect()'s documented type.
+                        raise TransportConnectionError(
+                            f"TLS connection to {self._host}:{self._port} failed: {err}"
+                        ) from err
                     if using_ssl:
-                        # Only forced-TLS and proven-TLS re-raise out of the
-                        # inner loop with a TLS socket: the failure is
-                        # deterministic (or a forbidden downgrade), so
-                        # retrying cannot help — propagate to the caller.
-                        raise
-                    _LOGGER.warning(
-                        "Connection failed to %s:%s: %s (attempt %d/%d)",
-                        self._host,
-                        self._port,
-                        err,
-                        attempt + 1,
-                        self._connection_retries,
-                    )
+                        # Proven-TLS regression: retry TLS-only on the ladder,
+                        # never falling back to plaintext; exhaustion wraps in
+                        # TransportConnectionError below.
+                        _LOGGER.warning(
+                            "TLS regression on %s:%s (previously negotiated "
+                            "successfully): %s — retrying TLS, never plaintext "
+                            "(attempt %d/%d)",
+                            self._host,
+                            self._port,
+                            err,
+                            attempt + 1,
+                            self._connection_retries,
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "Connection failed to %s:%s: %s (attempt %d/%d)",
+                            self._host,
+                            self._port,
+                            err,
+                            attempt + 1,
+                            self._connection_retries,
+                        )
                 except TimeoutError as err:
                     last_error = err
                     await self._close_connection()

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -1243,6 +1243,41 @@ class TestDongleResponseValidation:
         with pytest.raises(TransportReadError, match="serial mismatch"):
             transport._parse_response(response)
 
+    def test_garbage_serial_in_detection_frame_rejected(self) -> None:
+        """Serial auto-detection rejects a garbage frame instead of crashing.
+
+        A frame whose serial bytes are not valid ASCII must raise the
+        normal mismatch error, not an uncaught UnicodeDecodeError, and
+        must not be stored as the detected serial.
+        """
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="",
+        )
+        response = bytearray(_build_mock_response())
+        # Serial field lives at data-frame offset 2:12 (response 22:32);
+        # recompute the CRC over the spliced data frame.
+        response[22:32] = b"\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a"
+        response[-2:] = struct.pack("<H", compute_crc16(bytes(response[20:-2])))
+
+        with pytest.raises(TransportReadError, match="Unparseable response serial"):
+            transport._parse_response(bytes(response))
+        assert transport.serial == ""
+
+    def test_detected_serial_strips_nul_padding_rejected_if_short(self) -> None:
+        """A NUL-padded (short) serial is rejected, never stored with padding."""
+        transport = DongleTransport(
+            host="192.168.1.100",
+            dongle_serial="BA12345678",
+            inverter_serial="",
+        )
+        response = bytearray(_build_mock_response(inverter_serial="CE123"))
+
+        with pytest.raises(TransportReadError, match="Unparseable response serial"):
+            transport._parse_response(bytes(response))
+        assert transport.serial == ""
+
     def test_serial_always_checked(self) -> None:
         """Serial is validated even when expected_func/expected_register are None."""
         transport = self._make_transport()

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -683,6 +683,7 @@ class TestDongleConnection:
             host="192.168.1.100",
             dongle_serial="BA12345678",
             inverter_serial="CE12345678",
+            use_ssl=False,
         )
         open_started = asyncio.Event()
         release_open = asyncio.Event()
@@ -860,6 +861,7 @@ class TestDongleConnection:
             host="192.168.1.100",
             dongle_serial="BA12345678",
             inverter_serial="CE12345678",
+            use_ssl=False,
         )
         open_started = asyncio.Event()
         release_open = asyncio.Event()
@@ -899,6 +901,7 @@ class TestDongleConnection:
             host="192.168.1.100",
             dongle_serial="BA12345678",
             inverter_serial="CE12345678",
+            use_ssl=False,
         )
         close_started = asyncio.Event()
         release_close = asyncio.Event()
@@ -3035,6 +3038,7 @@ class TestDongleSilentPathLoss:
             port=port,
             timeout=timeout,
             connection_retries=1,
+            use_ssl=False,
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import logging
 import ssl
 import struct
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -152,7 +151,16 @@ class TestDongleConnection:
         assert transport._ssl_active is False
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("error", [OSError("unreachable"), TimeoutError("timeout")])
+    @pytest.mark.parametrize(
+        "error",
+        [
+            OSError("unreachable"),
+            TimeoutError("timeout"),
+            ConnectionAbortedError(
+                "SSL handshake is taking longer than 3.0 seconds: aborting the connection"
+            ),
+        ],
+    )
     async def test_auto_generic_failure_keeps_retry_ladder_and_no_verdict(
         self, error: OSError
     ) -> None:
@@ -266,35 +274,110 @@ class TestDongleConnection:
         )
 
     @pytest.mark.asyncio
-    async def test_proven_ssl_regression_uses_short_warning_cooldown(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=1)
-        transport._ssl_proven = True
+    async def test_tls_connection_skips_tcp_function_validation(self) -> None:
+        """The dongle omits the plaintext TCP function semantics on TLS channels."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
         context = MagicMock()
         socket = self._successful_socket()
-        caplog.set_level(logging.INFO)
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", return_value=socket),
+        ):
+            await transport.connect()
+        assert transport._ssl_active is True
+
+        packet = bytearray(18)
+        packet[7] = TCP_FUNC_TRANSLATED
+        socket[1].drain = AsyncMock()
+        transport._drain_buffer = AsyncMock()
+        transport._receive_frame = AsyncMock(return_value=b"response")
+        transport._parse_response = MagicMock(return_value=[])
+        await transport._send_receive(bytes(packet))
+
+        assert transport._parse_response.call_args.kwargs["expected_tcp_func"] is None
+
+    @pytest.mark.asyncio
+    async def test_check_link_probe_skips_auto_tls_probing(self) -> None:
+        """The budgeted link probe never TLS-probes an undetermined channel."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        socket = self._successful_socket()
+        socket[1].drain = AsyncMock()
+
+        with (
+            patch.object(transport, "_ssl_ctx") as ssl_ctx,
+            patch("asyncio.open_connection", return_value=socket) as open_connection,
+        ):
+            assert await transport.check_link() is False
+
+        ssl_ctx.assert_not_called()
+        assert "ssl" not in open_connection.await_args.kwargs
+        assert transport._link_probe_active is False
+
+    @pytest.mark.asyncio
+    async def test_handshake_timeout_capped_by_transport_timeout(self) -> None:
+        """A caller timeout below 3s must still bound the TLS handshake."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678", timeout=1.0, use_ssl=True)
+        context = MagicMock()
+        socket = self._successful_socket()
 
         with (
             patch.object(transport, "_ssl_ctx", return_value=context),
-            patch(
-                "asyncio.open_connection",
-                side_effect=[ssl.SSLError("regression"), socket],
-            ),
-            patch("pylxpweb.transports.dongle.time.monotonic", return_value=20.0),
+            patch("asyncio.open_connection", return_value=socket) as open_connection,
         ):
             await transport.connect()
 
-        assert transport._ssl_unsupported_until == 320.0
-        assert "previously negotiated successfully" in caplog.text
-        assert any(
-            record.levelno == logging.WARNING and "fell back to plaintext" in record.message
-            for record in caplog.records
-        )
-        assert not any(
-            record.levelno == logging.INFO and "does not support" in record.message
-            for record in caplog.records
-        )
+        assert open_connection.await_args.kwargs["ssl_handshake_timeout"] == 1.0
+
+    def test_positional_timeout_backward_compatible(self) -> None:
+        """Pre-#314 callers pass timeout as the fifth positional argument."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678", 8000, 5.0)
+
+        assert transport._timeout == 5.0
+        assert transport._ssl_mode is None
+
+    @pytest.mark.asyncio
+    async def test_proven_ssl_regression_raises_without_downgrade(self) -> None:
+        """A proven-TLS instance never opens a plaintext socket on SSLError."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=3)
+        transport._ssl_proven = True
+        context = MagicMock()
+        open_connection = AsyncMock(side_effect=ssl.SSLError("regression"))
+        sleep = AsyncMock()
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", open_connection),
+            patch("asyncio.sleep", sleep),
+            pytest.raises(ssl.SSLError, match="regression"),
+        ):
+            await transport.connect()
+
+        open_connection.assert_awaited_once()
+        assert open_connection.await_args.kwargs["ssl"] is context
+        sleep.assert_not_awaited()
+        assert transport._ssl_unsupported_until is None
+
+    @pytest.mark.asyncio
+    async def test_plaintext_ssl_error_retries_like_ordinary_failure(self) -> None:
+        """An SSLError off a plaintext socket is not TLS capability evidence."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=2)
+        transport._ssl_unsupported_until = 100.0
+        socket = self._successful_socket()
+        open_connection = AsyncMock(side_effect=[ssl.SSLError("stray"), socket])
+        sleep = AsyncMock()
+
+        with (
+            patch.object(transport, "_ssl_ctx") as ssl_ctx,
+            patch("asyncio.open_connection", open_connection),
+            patch("asyncio.sleep", sleep),
+            patch("pylxpweb.transports.dongle.time.monotonic", return_value=50.0),
+        ):
+            await transport.connect()
+
+        ssl_ctx.assert_not_called()
+        assert all("ssl" not in call.kwargs for call in open_connection.await_args_list)
+        sleep.assert_awaited_once_with(1.0)
+        assert transport._ssl_unsupported_until == 100.0
 
     @pytest.mark.asyncio
     async def test_auto_without_python_psk_uses_plaintext(self) -> None:

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
+import ssl
 import struct
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -115,6 +117,211 @@ class TestDongleTransport:
 
 class TestDongleConnection:
     """Tests for dongle connection handling."""
+
+    @staticmethod
+    def _successful_socket() -> tuple[AsyncMock, MagicMock]:
+        reader = AsyncMock()
+        reader.read = AsyncMock(side_effect=TimeoutError())
+        writer = MagicMock()
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+        return reader, writer
+
+    @pytest.mark.asyncio
+    async def test_auto_ssl_error_falls_back_without_backoff_and_caches(self) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        context = MagicMock()
+        socket = self._successful_socket()
+        open_connection = AsyncMock(side_effect=[ssl.SSLError("wrong version"), socket])
+        sleep = AsyncMock()
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", open_connection),
+            patch("asyncio.sleep", sleep),
+            patch("pylxpweb.transports.dongle.time.monotonic", return_value=10.0),
+        ):
+            await transport.connect()
+
+        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
+            context,
+            None,
+        ]
+        sleep.assert_not_awaited()
+        assert transport._ssl_unsupported_until == 86410.0
+        assert transport._ssl_active is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("error", [OSError("unreachable"), TimeoutError("timeout")])
+    async def test_auto_generic_failure_keeps_retry_ladder_and_no_verdict(
+        self, error: OSError
+    ) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=2)
+        context = MagicMock()
+        socket = self._successful_socket()
+        open_connection = AsyncMock(side_effect=[error, socket])
+        sleep = AsyncMock()
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", open_connection),
+            patch("asyncio.sleep", sleep),
+        ):
+            await transport.connect()
+
+        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
+            context,
+            context,
+        ]
+        sleep.assert_awaited_once_with(1.0)
+        assert transport._ssl_unsupported_until is None
+        assert transport._ssl_active is True
+
+    @pytest.mark.asyncio
+    async def test_auto_cached_negative_skips_tls(self) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        transport._ssl_unsupported_until = 100.0
+        socket = self._successful_socket()
+
+        with (
+            patch.object(transport, "_ssl_ctx") as ssl_ctx,
+            patch("asyncio.open_connection", return_value=socket) as open_connection,
+            patch("pylxpweb.transports.dongle.time.monotonic", return_value=50.0),
+        ):
+            await transport.connect()
+
+        ssl_ctx.assert_not_called()
+        assert "ssl" not in open_connection.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_auto_expired_negative_reprobes_tls(self) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        transport._ssl_unsupported_until = 100.0
+        context = MagicMock()
+        socket = self._successful_socket()
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", return_value=socket) as open_connection,
+            patch("pylxpweb.transports.dongle.time.monotonic", return_value=101.0),
+        ):
+            await transport.connect()
+
+        assert open_connection.await_args.kwargs["ssl"] is context
+        assert transport._ssl_proven is True
+        assert transport._ssl_unsupported_until is None
+
+    @pytest.mark.asyncio
+    async def test_forced_ssl_never_falls_back(self) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678", use_ssl=True)
+        context = MagicMock()
+        open_connection = AsyncMock(side_effect=ssl.SSLError("wrong version"))
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", open_connection),
+            pytest.raises(ssl.SSLError, match="wrong version"),
+        ):
+            await transport.connect()
+
+        open_connection.assert_awaited_once()
+        assert open_connection.await_args.kwargs["ssl"] is context
+
+    @pytest.mark.asyncio
+    async def test_forced_plaintext_never_probes(self) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678", use_ssl=False)
+        assert transport._ssl_ctx() is None
+        socket = self._successful_socket()
+
+        with patch("asyncio.open_connection", return_value=socket) as open_connection:
+            await transport.connect()
+
+        assert "ssl" not in open_connection.await_args.kwargs
+        assert transport._ssl_active is False
+
+    @pytest.mark.asyncio
+    async def test_auto_plaintext_fallback_validates_tcp_function(self) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        context = MagicMock()
+        socket = self._successful_socket()
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch(
+                "asyncio.open_connection",
+                side_effect=[ssl.SSLError("wrong version"), socket],
+            ),
+        ):
+            await transport.connect()
+
+        packet = bytearray(18)
+        packet[7] = TCP_FUNC_TRANSLATED
+        socket[1].drain = AsyncMock()
+        transport._drain_buffer = AsyncMock()
+        transport._receive_frame = AsyncMock(return_value=b"response")
+        transport._parse_response = MagicMock(return_value=[])
+        await transport._send_receive(bytes(packet))
+
+        assert transport._parse_response.call_args.kwargs["expected_tcp_func"] == (
+            TCP_FUNC_TRANSLATED
+        )
+
+    @pytest.mark.asyncio
+    async def test_proven_ssl_regression_uses_short_warning_cooldown(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=1)
+        transport._ssl_proven = True
+        context = MagicMock()
+        socket = self._successful_socket()
+        caplog.set_level(logging.INFO)
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch(
+                "asyncio.open_connection",
+                side_effect=[ssl.SSLError("regression"), socket],
+            ),
+            patch("pylxpweb.transports.dongle.time.monotonic", return_value=20.0),
+        ):
+            await transport.connect()
+
+        assert transport._ssl_unsupported_until == 320.0
+        assert "previously negotiated successfully" in caplog.text
+        assert any(
+            record.levelno == logging.WARNING and "fell back to plaintext" in record.message
+            for record in caplog.records
+        )
+        assert not any(
+            record.levelno == logging.INFO and "does not support" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_auto_without_python_psk_uses_plaintext(self) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        socket = self._successful_socket()
+
+        with (
+            patch.object(ssl, "HAS_PSK", False, create=True),
+            patch("asyncio.open_connection", return_value=socket) as open_connection,
+        ):
+            await transport.connect()
+
+        assert "ssl" not in open_connection.await_args.kwargs
+        assert transport._ssl_active is False
+
+    @pytest.mark.asyncio
+    async def test_forced_ssl_without_python_psk_raises(self) -> None:
+        transport = DongleTransport("host", "BA12345678", "CE12345678", use_ssl=True)
+
+        with (
+            patch.object(ssl, "HAS_PSK", False, create=True),
+            patch("asyncio.open_connection", AsyncMock()) as open_connection,
+            pytest.raises(NotImplementedError, match="PSK support is missing"),
+        ):
+            await transport.connect()
+
+        open_connection.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_connect_success(self) -> None:

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -155,12 +155,22 @@ class TestDongleConnection:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "error",
-        [OSError("unreachable"), ConnectionRefusedError("refused")],
+        [
+            OSError("unreachable"),
+            ConnectionRefusedError("refused"),
+            TimeoutError("timeout"),
+            ConnectionAbortedError(
+                "SSL handshake is taking longer than 3.0 seconds: aborting the connection"
+            ),
+            ConnectionResetError("reset during handshake"),
+        ],
     )
     async def test_auto_generic_failure_keeps_retry_ladder_and_no_verdict(
         self, error: OSError
     ) -> None:
-        """Failures that hit TLS and plaintext alike cache no verdict."""
+        """Every non-SSLError probe failure is inconclusive: ordinary retry
+        ladder, TLS re-probed on the next attempt, no verdict cached — a
+        disrupted handshake must never trigger a plaintext downgrade."""
         transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=2)
         context = MagicMock()
         socket = self._successful_socket()
@@ -184,80 +194,11 @@ class TestDongleConnection:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "error",
-        [
-            TimeoutError("timeout"),
-            ConnectionAbortedError(
-                "SSL handshake is taking longer than 3.0 seconds: aborting the connection"
-            ),
-            ConnectionResetError("reset during handshake"),
-        ],
-    )
-    async def test_auto_ambiguous_probe_failure_falls_back_with_short_cooldown(
-        self, error: OSError
-    ) -> None:
-        """A TLS probe the peer neither completes nor rejects is an ambiguous
-        negative: same-attempt plaintext fallback, short re-probe cooldown."""
-        transport = DongleTransport("host", "BA12345678", "CE12345678")
-        context = MagicMock()
-        socket = self._successful_socket()
-        open_connection = AsyncMock(side_effect=[error, socket])
-        sleep = AsyncMock()
-
-        with (
-            patch.object(transport, "_ssl_ctx", return_value=context),
-            patch("asyncio.open_connection", open_connection),
-            patch("asyncio.sleep", sleep),
-            patch("pylxpweb.transports.dongle.time.monotonic", return_value=10.0),
-        ):
-            await transport.connect()
-
-        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
-            context,
-            None,
-        ]
-        sleep.assert_not_awaited()
-        assert transport._ssl_unsupported_until == 310.0
-        assert transport._ssl_active is False
-
-    @pytest.mark.asyncio
-    async def test_auto_ambiguous_cooldown_reprobes_after_expiry(self) -> None:
-        """The ambiguous verdict re-probes after ~300s, not the 24h TTL."""
-        transport = DongleTransport("host", "BA12345678", "CE12345678")
-        context = MagicMock()
-        first_socket = self._successful_socket()
-        second_socket = self._successful_socket()
-        open_connection = AsyncMock(
-            side_effect=[TimeoutError("timeout"), first_socket, second_socket]
-        )
-        monotonic = MagicMock(return_value=10.0)
-
-        with (
-            patch.object(transport, "_ssl_ctx", return_value=context),
-            patch("asyncio.open_connection", open_connection),
-            patch("pylxpweb.transports.dongle.time.monotonic", monotonic),
-        ):
-            await transport.connect()
-            assert transport._ssl_unsupported_until == 310.0
-
-            await transport.disconnect()
-            monotonic.return_value = 311.0
-            await transport.connect()
-
-        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
-            context,
-            None,
-            context,
-        ]
-        assert transport._ssl_proven is True
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
         ("use_ssl", "proven"),
         [(None, True), (True, False)],
         ids=["proven", "forced"],
     )
-    async def test_ambiguous_fallback_never_fires_for_proven_or_forced(
+    async def test_probe_timeout_never_downgrades_proven_or_forced(
         self, use_ssl: bool | None, proven: bool
     ) -> None:
         """Proven and forced instances retry TLS-only; no plaintext, no cache."""

--- a/tests/unit/transports/test_dongle.py
+++ b/tests/unit/transports/test_dongle.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import ssl
 import struct
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from pylxpweb.cli.collectors.dongle import DongleCollector
 from pylxpweb.registers import PV4_6_INPUT_REGISTER_GROUP
 from pylxpweb.transports.capabilities import DONGLE_CAPABILITIES
 from pylxpweb.transports.dongle import (
@@ -153,17 +155,12 @@ class TestDongleConnection:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "error",
-        [
-            OSError("unreachable"),
-            TimeoutError("timeout"),
-            ConnectionAbortedError(
-                "SSL handshake is taking longer than 3.0 seconds: aborting the connection"
-            ),
-        ],
+        [OSError("unreachable"), ConnectionRefusedError("refused")],
     )
     async def test_auto_generic_failure_keeps_retry_ladder_and_no_verdict(
         self, error: OSError
     ) -> None:
+        """Failures that hit TLS and plaintext alike cache no verdict."""
         transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=2)
         context = MagicMock()
         socket = self._successful_socket()
@@ -182,6 +179,108 @@ class TestDongleConnection:
             context,
         ]
         sleep.assert_awaited_once_with(1.0)
+        assert transport._ssl_unsupported_until is None
+        assert transport._ssl_active is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error",
+        [
+            TimeoutError("timeout"),
+            ConnectionAbortedError(
+                "SSL handshake is taking longer than 3.0 seconds: aborting the connection"
+            ),
+            ConnectionResetError("reset during handshake"),
+        ],
+    )
+    async def test_auto_ambiguous_probe_failure_falls_back_with_short_cooldown(
+        self, error: OSError
+    ) -> None:
+        """A TLS probe the peer neither completes nor rejects is an ambiguous
+        negative: same-attempt plaintext fallback, short re-probe cooldown."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        context = MagicMock()
+        socket = self._successful_socket()
+        open_connection = AsyncMock(side_effect=[error, socket])
+        sleep = AsyncMock()
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", open_connection),
+            patch("asyncio.sleep", sleep),
+            patch("pylxpweb.transports.dongle.time.monotonic", return_value=10.0),
+        ):
+            await transport.connect()
+
+        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
+            context,
+            None,
+        ]
+        sleep.assert_not_awaited()
+        assert transport._ssl_unsupported_until == 310.0
+        assert transport._ssl_active is False
+
+    @pytest.mark.asyncio
+    async def test_auto_ambiguous_cooldown_reprobes_after_expiry(self) -> None:
+        """The ambiguous verdict re-probes after ~300s, not the 24h TTL."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        context = MagicMock()
+        first_socket = self._successful_socket()
+        second_socket = self._successful_socket()
+        open_connection = AsyncMock(
+            side_effect=[TimeoutError("timeout"), first_socket, second_socket]
+        )
+        monotonic = MagicMock(return_value=10.0)
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", open_connection),
+            patch("pylxpweb.transports.dongle.time.monotonic", monotonic),
+        ):
+            await transport.connect()
+            assert transport._ssl_unsupported_until == 310.0
+
+            await transport.disconnect()
+            monotonic.return_value = 311.0
+            await transport.connect()
+
+        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
+            context,
+            None,
+            context,
+        ]
+        assert transport._ssl_proven is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("use_ssl", "proven"),
+        [(None, True), (True, False)],
+        ids=["proven", "forced"],
+    )
+    async def test_ambiguous_fallback_never_fires_for_proven_or_forced(
+        self, use_ssl: bool | None, proven: bool
+    ) -> None:
+        """Proven and forced instances retry TLS-only; no plaintext, no cache."""
+        transport = DongleTransport(
+            "host", "BA12345678", "CE12345678", use_ssl=use_ssl, connection_retries=2
+        )
+        transport._ssl_proven = proven
+        context = MagicMock()
+        socket = self._successful_socket()
+        open_connection = AsyncMock(side_effect=[TimeoutError("timeout"), socket])
+        sleep = AsyncMock()
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", open_connection),
+            patch("asyncio.sleep", sleep),
+        ):
+            await transport.connect()
+
+        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
+            context,
+            context,
+        ]
         assert transport._ssl_unsupported_until is None
         assert transport._ssl_active is True
 
@@ -221,6 +320,7 @@ class TestDongleConnection:
 
     @pytest.mark.asyncio
     async def test_forced_ssl_never_falls_back(self) -> None:
+        """Forced TLS fails fast, wrapped to connect()'s documented type."""
         transport = DongleTransport("host", "BA12345678", "CE12345678", use_ssl=True)
         context = MagicMock()
         open_connection = AsyncMock(side_effect=ssl.SSLError("wrong version"))
@@ -228,10 +328,11 @@ class TestDongleConnection:
         with (
             patch.object(transport, "_ssl_ctx", return_value=context),
             patch("asyncio.open_connection", open_connection),
-            pytest.raises(ssl.SSLError, match="wrong version"),
+            pytest.raises(TransportConnectionError, match="TLS connection") as exc_info,
         ):
             await transport.connect()
 
+        assert isinstance(exc_info.value.__cause__, ssl.SSLError)
         open_connection.assert_awaited_once()
         assert open_connection.await_args.kwargs["ssl"] is context
 
@@ -314,6 +415,26 @@ class TestDongleConnection:
         assert transport._link_probe_active is False
 
     @pytest.mark.asyncio
+    async def test_check_link_plaintext_dial_logs_deferred_detection(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A probe-forced plaintext dial on an undetermined channel leaves a
+        log trail, since the connection may be kept past the health check."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678")
+        socket = self._successful_socket()
+        socket[1].drain = AsyncMock()
+        caplog.set_level(logging.INFO)
+
+        with (
+            patch.object(transport, "_ssl_ctx") as ssl_ctx,
+            patch("asyncio.open_connection", return_value=socket),
+        ):
+            await transport.check_link()
+
+        ssl_ctx.assert_not_called()
+        assert any("before TLS auto-detection ran" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
     async def test_handshake_timeout_capped_by_transport_timeout(self) -> None:
         """A caller timeout below 3s must still bound the TLS handshake."""
         transport = DongleTransport("host", "BA12345678", "CE12345678", timeout=1.0, use_ssl=True)
@@ -335,27 +456,75 @@ class TestDongleConnection:
         assert transport._timeout == 5.0
         assert transport._ssl_mode is None
 
+    def test_collector_positional_inverter_family_backward_compatible(self) -> None:
+        """Pre-#314 DongleCollector callers pass inverter_family positionally.
+
+        Lives here (not a CLI test module) because the regression came in
+        with the transport's use_ssl plumbing and shares its fixtures.
+        """
+        from pylxpweb.devices.inverters._features import InverterFamily
+
+        collector = DongleCollector(
+            "host", "BA12345678", "CE12345678", 8000, 5.0, InverterFamily.LXP
+        )
+
+        assert collector._timeout == 5.0
+        assert collector._inverter_family is InverterFamily.LXP
+        assert collector._use_ssl is None
+
     @pytest.mark.asyncio
-    async def test_proven_ssl_regression_raises_without_downgrade(self) -> None:
-        """A proven-TLS instance never opens a plaintext socket on SSLError."""
-        transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=3)
+    async def test_proven_ssl_regression_retries_tls_only_and_recovers(self) -> None:
+        """A proven-TLS instance retries the SSLError on the ladder, TLS-only."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=2)
         transport._ssl_proven = True
         context = MagicMock()
-        open_connection = AsyncMock(side_effect=ssl.SSLError("regression"))
+        socket = self._successful_socket()
+        open_connection = AsyncMock(side_effect=[ssl.SSLError("regression"), socket])
         sleep = AsyncMock()
 
         with (
             patch.object(transport, "_ssl_ctx", return_value=context),
             patch("asyncio.open_connection", open_connection),
             patch("asyncio.sleep", sleep),
-            pytest.raises(ssl.SSLError, match="regression"),
         ):
             await transport.connect()
 
-        open_connection.assert_awaited_once()
-        assert open_connection.await_args.kwargs["ssl"] is context
-        sleep.assert_not_awaited()
+        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
+            context,
+            context,
+        ]
+        sleep.assert_awaited_once_with(1.0)
+        assert transport._ssl_active is True
         assert transport._ssl_unsupported_until is None
+
+    @pytest.mark.asyncio
+    async def test_proven_ssl_regression_exhausts_wrapped_never_plaintext(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Exhausted TLS regression wraps in TransportConnectionError with
+        warnings, having never opened a plaintext socket or cached a verdict."""
+        transport = DongleTransport("host", "BA12345678", "CE12345678", connection_retries=2)
+        transport._ssl_proven = True
+        context = MagicMock()
+        open_connection = AsyncMock(side_effect=ssl.SSLError("regression"))
+        sleep = AsyncMock()
+        caplog.set_level(logging.WARNING)
+
+        with (
+            patch.object(transport, "_ssl_ctx", return_value=context),
+            patch("asyncio.open_connection", open_connection),
+            patch("asyncio.sleep", sleep),
+            pytest.raises(TransportConnectionError) as exc_info,
+        ):
+            await transport.connect()
+
+        assert isinstance(exc_info.value.__cause__, ssl.SSLError)
+        assert [call.kwargs.get("ssl") for call in open_connection.await_args_list] == [
+            context,
+            context,
+        ]
+        assert transport._ssl_unsupported_until is None
+        assert sum("TLS regression" in record.message for record in caplog.records) == 2
 
     @pytest.mark.asyncio
     async def test_plaintext_ssl_error_retries_like_ordinary_failure(self) -> None:


### PR DESCRIPTION
## Summary

Hardens the WiFi dongle TLS-PSK support from #314 with automatic detection and clean plaintext fallback, and fixes a response-validation bug in it.

**Credit:** the underlying TLS-PSK implementation (PSK derivation, cipher/context setup, port-8000 SSL support for dongle firmware V3.02) was authored by @dpw13 in #314. This PR builds directly on that commit, preserving their authorship, and extends it. It **supersedes #314 but does not auto-close it** — #314 can be closed as superseded once this merges; leaving that call to a maintainer.

## Why

As written in #314, `use_ssl` is a static boolean:

1. A dongle that doesn't support SSL burns the entire connection retry ladder on a doomed TLS handshake when `use_ssl=True`, and users must know their firmware version to pick the right flag.
2. Response validation skipped the TCP-function byte cross-check based on whether SSL was *requested*, not whether TLS actually negotiated — so a plaintext connection under an SSL-requested policy would skip validation it should perform.

## What changed

- **Tri-state `use_ssl: bool | None`** on `DongleTransport` (and `DongleCollector`):
  - `True` — force TLS. Never falls back; a handshake failure propagates immediately instead of burning retries on a deterministic failure.
  - `False` — force plaintext. Never probes; identical to pre-#314 behavior.
  - `None` (**new default**) — auto-detect.
- **AUTO probing folds into the first dial of the existing retry loop** (no extra probe connection):
  - `ssl.SSLError` on the handshake = definitive "no SSL support" → same attempt falls back to plaintext; negative verdict cached **per-instance for 24h** (re-probed afterward, since dongle firmware can be field-updated). No extra retry-ladder attempts are burned.
  - EVERY other TLS-probe failure — timeout, connection abort, connection reset, connection refused, any `OSError` — = **fully inconclusive**: ordinary retry/backoff ladder, **no cached verdict, no plaintext fallback**, so an active on-path attacker cannot force a downgrade by disrupting the handshake. Consequence (per the design ruling on #320): firmware that silently discards the ClientHello (rather than cleanly rejecting it) cannot be safely auto-detected and must be configured explicitly with `use_ssl=False` / `--no-ssl`. The 24h TTL re-probe on a definitive negative doubles as the upgrade pin for firmware later upgraded to add TLS.
  - Once TLS has negotiated on an instance it is **never downgraded**: a later `ssl.SSLError` retries TLS-only across the backoff ladder (WARNING per attempt) and, when exhausted, fails `connect()` as `TransportConnectionError` — never a plaintext socket. Forced `use_ssl=True` fails fast, also wrapped as `TransportConnectionError`.
- **Fix:** `expected_tcp_func` validation now keys off whether TLS actually negotiated on the current connection (`_ssl_active`), not the requested policy — an AUTO connection that fell back to plaintext validates the TCP function byte of every response frame.
- **Python < 3.13** (stdlib `ssl` has no TLS-PSK): AUTO falls back to plaintext without error; only forced `use_ssl=True` raises `NotImplementedError`. The `sys.version_info` gate also fixes the `mypy --strict` failure on `set_psk_client_callback` under the project's `python_version = "3.12"` mypy config (present in #314 as written).
- **CLI:** `eg4-modbus-diag` gains mutually exclusive `--use-ssl` / `--no-ssl` flags; default is auto-detect.

## Tribunal round 1 (commits `de0ec6b`, `55b2021`)

All 12 findings addressed: removed the ambiguous handshake-timeout fallback/cache (downgrade-resistance), proven-TLS regressions now fail `connect()` instead of downgrading, TLS capped at 1.2 (PSK callbacks don't apply to 1.3), `SSLError` off a plaintext socket takes the ordinary retry path, `check_link()` reuses the last-known channel state instead of TLS-probing inside its budget, `ssl_handshake_timeout` bounded by `min(timeout, 3s)`, `use_ssl` moved after `timeout` (positional back-compat), tri-state passes through `--transport both`, security limits of the PSK scheme documented at every consumer surface, plus a mirror tcp_func test. Separate commit: serial auto-detection no longer crashes (`UnicodeDecodeError`) on a garbage frame and validates 10 printable ASCII chars.

## Tribunal round 2 (commit `339a72a`)

Restored contract-aligned semantics after r2's over-correction: proven-TLS regressions retry TLS-only with warnings and wrap exhaustion in `TransportConnectionError` (A); ambiguous TLS-probe failures (timeout/abort/reset) fall back with a 300s cooldown, gated to AUTO+never-proven (B); `DongleCollector` positional back-compat for `inverter_family` (C); `check_link` logs when a probe dial connects plaintext before auto-detection has run (D).

## Tribunal round 3 — design ruling (commit `8590e91`)

Human ruling on [#320](https://github.com/joyfulhouse/pylxpweb/issues/320) ("Do not fallback to non-TLS if it is enabled for the dongle. This is a config-time detection and an upgrade pin...") resolved the codex-vs-claude_code/cursor disagreement in favor of security: the ambiguous-handshake plaintext fallback (`_SSL_AMBIGUOUS_COOLDOWN`, added in r2 item B) is removed entirely — timeout/abort/reset during a TLS probe now retry on the ordinary ladder with no verdict and no fallback. Also folded in (agy advisory): `--battery-probe` now honors `--use-ssl`/`--no-ssl`, and the CHANGELOG names the real entrypoint (`pylxpweb-modbus-diag`).

## How verified

- `uv run pytest tests/unit/` — **3462 passed, 5 skipped** (collected test cases; includes 11 new dongle SSL test cases from 10 new test functions in `tests/unit/transports/test_dongle.py`).
- `uv run mypy src/pylxpweb/ --strict` — clean (fails on the base commit).
- `uv run ruff check` + `ruff format` — clean.
- **Mutation check** on every new test: with `src/pylxpweb/transports/dongle.py` reverted to the #314 base commit, 9 of 11 new test cases fail; the remaining 2 were each shown to fail under a targeted mutation (re-keying `expected_tcp_func` off the requested policy; replacing the forced-SSL `NotImplementedError` with silent fallback).

## Follow-ups (not addressed here)

- `ruff format` (v0.15.x) wants to reformat Python code blocks inside 12 committed Markdown docs (`CHANGELOG.md`, `README.md`, `docs/**`); left untouched as out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



