### PR TITLE
chore(release): 0.10.0b5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0b5] - 2026-08-29
 
 ### Fixed
+
+- **Unreported battery state of health is `None`, not a fabricated 100**
+  ([#309](https://github.com/joyfulhouse/pylxpweb/issues/309), based on
+  [#286](https://github.com/joyfulhouse/pylxpweb/pull/286) by @sjordan0228):
+  a SoH byte of 0 means the BMS did not report, but every decode path rewrote
+  it to 100 — indistinguishable from a genuinely healthy pack. All Modbus
+  decode sites, the eg4_master/eg4_slave battery protocols, the cloud
+  per-battery path, and the cloud-backed `Battery.soh` property now surface
+  unreported SoH as `None`; `BatteryBank.min_soh`/`soh_delta` exclude
+  unreported batteries, and `is_corrupt()` tolerates `None` while keeping the
+  >100 canary.
 
 - **GridBOSS Modbus discovery: serial number falls back to holding
   registers 2-6**
@@ -2810,7 +2821,8 @@ ac_power = inverter.ac_charge_power_limit  # Property access (uses 1-hour cache)
 - **v0.1.1** (2025-11-15): Bug fixes and improvements
 - **v0.1.0** (2025-11-14): Initial release with core functionality
 
-[Unreleased]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b3...HEAD
+[0.10.0b5]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b4...v0.10.0b5
+[0.10.0b4]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b3...v0.10.0b4
 [0.10.0b3]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b2...v0.10.0b3
 [0.10.0b2]: https://github.com/joyfulhouse/pylxpweb/compare/v0.10.0b1...v0.10.0b2
 [0.10.0b1]: https://github.com/joyfulhouse/pylxpweb/compare/v0.9.39b11...v0.10.0b1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.10.0b4"
+version = "0.10.0b5"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.10.0b4"
+version = "0.10.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release 0.10.0b5.

Contains:
- #315 — GridBOSS Modbus discovery serial-number holding-register fallback (eg4_web_monitor#593)
- #316 — unreported battery SoH is None, not a fabricated 100 (#309, based on #286 by @sjordan0228)
- #317 — skip parallel-config read for GridBOSS during Modbus discovery (eg4_web_monitor#596)

Per the release process this PR must be merged with **a merge commit** (never squash/rebase) so the tag points at a two-parent merge whose second parent is the CI-tested head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)