### PR TITLE
fix: on-grid discharge SOC cutoff (H105) accepts 91-100% (eg4 #603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **On-grid discharge SOC cutoff (H105) accepts 91-100%** (fixes
+  [eg4_web_monitor #603](https://github.com/joyfulhouse/eg4_web_monitor/issues/603)):
+  the canonical register definition, `set_battery_soc_limits` (cloud) and
+  `set_on_grid_cutoff_soc` (Modbus) all capped the value at 90, which was
+  the portal's arrow-button hint, not a firmware bound — the portal accepts
+  a typed 95, the inverter stores it (reporter diagnostics, LXP-LB-US 10K)
+  and rejects 101; the 96-100 span is inferred from that pair. Evidence is
+  one model — other families are unconfirmed and the firmware exception
+  remains the authoritative reject path. Users keeping batteries full ahead of outages could
+  no longer set it from the integration. The 10% floor is unchanged (also a
+  portal hint; unproven either way).
+
 - **Dongle response validation keyed off the negotiated channel instead of
   the requested SSL policy**: PR #314 skipped the TCP-function byte
   cross-check whenever SSL was *requested*; it is now skipped only when TLS

--- a/docs/PARAMETER_REFERENCE.md
+++ b/docs/PARAMETER_REFERENCE.md
@@ -123,15 +123,15 @@ response = await client.write_parameter(
 - **Use Case**: Prevent full charge from grid during TOU high-rate periods
 
 #### On-Grid SOC Cut-Off
-- **Parameter Name**: `HOLD_ON_GRID_DISCHG_CUT_OFF_SOC_EOD`
+- **Parameter Name**: `HOLD_DISCHG_CUT_OFF_SOC_EOD`
 - **Type**: Write
-- **Range**: 0-100 %
+- **Range**: 10-100 % (the portal's arrow buttons stop at 90, but a typed 95 is stored and 101 is rejected on an LXP-LB-US 10K; 96-100 are inferred from that pair)
 - **Unit**: Percent
 - **Purpose**: Minimum SOC before stopping discharge when grid is available
 - **Default**: Typically 10-20%
 
 #### Off-Grid SOC Cut-Off
-- **Parameter Name**: `HOLD_OFF_GRID_DISCHG_CUT_OFF_SOC_EOD`
+- **Parameter Name**: `HOLD_SOC_LOW_LIMIT_EPS_DISCHG`
 - **Type**: Write
 - **Range**: 0-100 %
 - **Unit**: Percent

--- a/docs/luxpower-api.yaml
+++ b/docs/luxpower-api.yaml
@@ -770,7 +770,7 @@ paths:
         - **59-62**: Reactive power control
         - **66-73**: AC charge configuration (power, SOC limit, schedules)
         - **74-89**: Discharge configuration
-        - **99-109**: Battery protection (voltage/current limits, SOC cutoffs)
+        - **99-109**: Battery protection (voltage/current limits; H105 on-grid SOC cutoff — the off-grid/EPS cutoff is H125)
 
         **Critical Register 21 (FuncEn)** - Function Enable Bit Field:
         - Bit 0: EPSEn (Off-grid mode)
@@ -815,7 +815,7 @@ paths:
         **Option 3: Logical Grouping** (optimized for use cases):
         ```
         AC Charge Settings: startRegister=66, pointNumber=8
-        Battery Protection: startRegister=99, pointNumber=11
+        Battery Protection: startRegister=99, pointNumber=11   (99-109; the off-grid SOC cutoff is H125 — read separately)
         Grid Protection:    startRegister=25, pointNumber=34
         Function Control:   startRegister=21, pointNumber=1
         ```
@@ -838,8 +838,8 @@ paths:
         | 21 | FuncEn | Function enable bit field | 0-65535 | R/W |
         | 66 | ACChgPowerCMD | AC charge power | 0-100% | R/W |
         | 67 | ACChgSOCLimit | AC charge SOC limit | 0-101% | R/W |
-        | 105 | EOD | On-grid discharge cutoff | 10-90% | R/W |
-        | 106 | SOC_Low_Limit_EPS | Off-grid SOC limit | 0-100% | R/W |
+        | 105 | EOD | On-grid discharge cutoff | 10-100% | R/W |
+        | 125 | SOC_Low_Limit_EPS | Off-grid SOC limit | 0-100% | R/W |
 
         **See Also**:
         - `/web/maintain/remoteSet/write` - Write parameters
@@ -929,7 +929,7 @@ paths:
         | 72 | ACChgEnable1 | Time period 1 enable | 0-1 | 1 |
         | 73 | ACChgEnable2 | Time period 2 enable | 0-1 | 0 |
 
-        ### Battery Protection (Registers 99-109)
+        ### Battery Protection (Registers 99-109, plus H125)
 
         | Register | Name | Description | Range | Example |
         |----------|------|-------------|-------|---------|
@@ -937,8 +937,8 @@ paths:
         | 100 | BatVoltMinChg | Min charge voltage | 40-55V (×100) | 4800 (48.00V) |
         | 103 | MaxChgCurr | Max charge current | 0-200A (×10) | 1000 (100.0A) |
         | 104 | MaxDisChgCurr | Max discharge current | 0-200A (×10) | 1000 (100.0A) |
-        | 105 | EOD | On-grid discharge cutoff | 10-90% | 15 |
-        | 106 | SOC_Low_Limit_EPS | Off-grid SOC limit | 0-100% | 10 |
+        | 105 | EOD | On-grid discharge cutoff | 10-100% | 15 |
+        | 125 | SOC_Low_Limit_EPS | Off-grid SOC limit | 0-100% | 10 |
 
         ### Grid Protection (Registers 25-28)
 

--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -116,7 +116,7 @@ Range 3 (240-366): 127 registers - Advanced settings (overlaps with Range 2)
 
 **Key parameters discovered:**
 - Register 21: Function enable flags (FUNC_EN_REGISTER)
-- Register 105-106: Battery SoC limits
+- Registers 105 and 125: Battery SoC limits (on-grid / off-grid discharge cutoff)
 - Register 150: Grid charge enable/disable
 - Many more documented in `docs/PARAMETER_REFERENCE.md`
 

--- a/src/pylxpweb/constants/__init__.py
+++ b/src/pylxpweb/constants/__init__.py
@@ -46,6 +46,8 @@ from .api import (
 from .devices import (
     # Register limits
     MAX_REGISTERS_PER_READ,
+    ONGRID_DISCHARGE_CUTOFF_SOC_MAX,
+    ONGRID_DISCHARGE_CUTOFF_SOC_MIN,
     SCALE_MID_FREQUENCY,
     # MID device scaling
     SCALE_MID_VOLTAGE,
@@ -668,5 +670,7 @@ __all__ = [
     "scale_mid_frequency",
     "SOC_MIN_PERCENT",
     "SOC_MAX_PERCENT",
+    "ONGRID_DISCHARGE_CUTOFF_SOC_MIN",
+    "ONGRID_DISCHARGE_CUTOFF_SOC_MAX",
     "MAX_REGISTERS_PER_READ",
 ]

--- a/src/pylxpweb/constants/devices.py
+++ b/src/pylxpweb/constants/devices.py
@@ -30,6 +30,17 @@ SCALE_MID_FREQUENCY = 100  # Frequency values are scaled by 100
 SOC_MIN_PERCENT = 0
 SOC_MAX_PERCENT = 100
 
+# On-grid discharge cutoff SOC (holding register 105) write bounds — the ONE
+# place both setters and the canonical register definition read them from.
+# Ceiling 100, not the portal's 90 arrow-button hint: a portal-typed 95 is
+# stored on a Luxpower LXP-LB-US 10K and 101 is rejected (eg4 #603); 96-100
+# are inferred from that pair, not individually tested.
+# That evidence is a single model; other families are unconfirmed, and the
+# firmware exception remains the authoritative reject path. The 10 floor is
+# the same portal hint — unproven either way — kept as shipped.
+ONGRID_DISCHARGE_CUTOFF_SOC_MIN = 10
+ONGRID_DISCHARGE_CUTOFF_SOC_MAX = 100
+
 # ==============================================================================
 # Register Reading Limits
 # ==============================================================================

--- a/src/pylxpweb/constants/registers.py
+++ b/src/pylxpweb/constants/registers.py
@@ -318,7 +318,7 @@ HOLD_BAT_VOLT_MAX_DISCHG = HOLD_LEAD_ACID_CHARGE_RATE
 HOLD_BAT_VOLT_MIN_DISCHG = HOLD_LEAD_ACID_DISCHARGE_RATE
 HOLD_MAX_CHG_CURR = 103  # Max charge current (A, /10)
 HOLD_MAX_DISCHG_CURR = 104  # Max discharge current (A, /10)
-HOLD_DISCHG_CUT_OFF_SOC_EOD = 105  # On-grid discharge cutoff SOC (10-90%)
+HOLD_DISCHG_CUT_OFF_SOC_EOD = 105  # On-grid discharge cutoff SOC (10-100%)
 HOLD_SOC_LOW_LIMIT_EPS_DISCHG = 125  # Off-grid SOC low limit (0-100%) - verified 2026-01-27
 
 # On-Grid Discharge Cutoff Voltage
@@ -772,7 +772,7 @@ REGISTER_TO_PARAM_KEYS: dict[int, list[str]] = {
     # there is no plausible alternative scale for a 0-100 percent field.
     103: ["HOLD_FEED_IN_GRID_POWER_PERCENT"],
     # SOC limits
-    105: ["HOLD_DISCHG_CUT_OFF_SOC_EOD"],  # On-grid discharge cutoff SOC (10-90%)
+    105: ["HOLD_DISCHG_CUT_OFF_SOC_EOD"],  # On-grid discharge cutoff SOC (10-100%)
     116: ["HOLD_PTOUSER_START_DISCHARGE"],  # Power-to-user start-discharge threshold (W)
     # System functions (Register 110: 16 bit fields, lineage-wide layout).
     # See REGISTER_110_PARAM_KEYS above for the per-bit evidence trail; the

--- a/src/pylxpweb/devices/inverters/base.py
+++ b/src/pylxpweb/devices/inverters/base.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 from pylxpweb.constants import (
     DEVICE_TYPE_CODE_GRIDBOSS,
     MAX_REGISTERS_PER_READ,
+    ONGRID_DISCHARGE_CUTOFF_SOC_MAX,
+    ONGRID_DISCHARGE_CUTOFF_SOC_MIN,
     SOC_MAX_PERCENT,
     SOC_MIN_PERCENT,
 )
@@ -2507,7 +2509,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         Universal control: All inverters have SOC limits.
 
         Returns:
-            Dictionary with on_grid_limit and off_grid_limit (0-100%),
+            Dictionary with on_grid_limit (10-100%) and off_grid_limit (0-100%),
             or None if parameters haven't been loaded yet
 
         Example:
@@ -2534,7 +2536,7 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
         Universal control: All inverters have SOC protection.
 
         Args:
-            on_grid_limit: On-grid discharge cutoff SOC (10-90%)
+            on_grid_limit: On-grid discharge cutoff SOC (10-100%)
             off_grid_limit: Off-grid/EPS discharge cutoff SOC (0-100%)
 
         Returns:
@@ -2544,34 +2546,60 @@ class BaseInverter(FirmwareUpdateMixin, InverterRuntimePropertiesMixin, BaseDevi
             >>> await inverter.set_battery_soc_limits(on_grid_limit=15, off_grid_limit=20)
             True
         """
-        # Write each parameter individually using parameter names
+        # Validate BOTH inputs before any I/O so an invalid pair never
+        # half-applies (the on-grid write used to land before the off-grid
+        # value was checked).
+        if on_grid_limit is not None and not (
+            ONGRID_DISCHARGE_CUTOFF_SOC_MIN <= on_grid_limit <= ONGRID_DISCHARGE_CUTOFF_SOC_MAX
+        ):
+            raise ValueError(
+                "on_grid_limit must be between "
+                f"{ONGRID_DISCHARGE_CUTOFF_SOC_MIN} and {ONGRID_DISCHARGE_CUTOFF_SOC_MAX}%"
+            )
+        if off_grid_limit is not None and not SOC_MIN_PERCENT <= off_grid_limit <= SOC_MAX_PERCENT:
+            raise ValueError(
+                f"off_grid_limit must be between {SOC_MIN_PERCENT} and {SOC_MAX_PERCENT}%"
+            )
+
+        # Write each parameter individually using parameter names. The cache
+        # is marked stale as soon as a write has been ATTEMPTED — including
+        # when the call raises, times out or is cancelled, since the device
+        # may have applied the value before the response was lost — so the
+        # next refresh re-reads the device whatever happened. Per
+        # _invalidate_parameters_cache this does NOT drop the in-memory
+        # snapshot — the pre-write value is served until that refresh lands.
         success = True
-
-        if on_grid_limit is not None:
-            if not 10 <= on_grid_limit <= 90:
-                raise ValueError("on_grid_limit must be between 10 and 90%")
-            result = await self._client.api.control.write_parameter(
-                self.serial_number,
-                "HOLD_DISCHG_CUT_OFF_SOC_EOD",
-                str(on_grid_limit),
-            )
-            success = success and result.success
-
-        if off_grid_limit is not None:
-            if not SOC_MIN_PERCENT <= off_grid_limit <= SOC_MAX_PERCENT:
-                raise ValueError(
-                    f"off_grid_limit must be between {SOC_MIN_PERCENT} and {SOC_MAX_PERCENT}%"
+        attempted = False
+        try:
+            if on_grid_limit is not None:
+                attempted = True
+                result = await self._client.api.control.write_parameter(
+                    self.serial_number,
+                    "HOLD_DISCHG_CUT_OFF_SOC_EOD",
+                    str(on_grid_limit),
                 )
-            result = await self._client.api.control.write_parameter(
-                self.serial_number,
-                "HOLD_SOC_LOW_LIMIT_EPS_DISCHG",
-                str(off_grid_limit),
-            )
-            success = success and result.success
+                success = success and result.success
 
-        # Invalidate parameter cache on successful write
-        if success:
-            self._invalidate_parameters_cache()
+            if off_grid_limit is not None:
+                attempted = True
+                result = await self._client.api.control.write_parameter(
+                    self.serial_number,
+                    "HOLD_SOC_LOW_LIMIT_EPS_DISCHG",
+                    str(off_grid_limit),
+                )
+                success = success and result.success
+        finally:
+            if attempted:
+                # Both cache layers: the inverter's parameter snapshot AND the
+                # client's short-lived response cache. The control endpoint
+                # clears the latter only on an acknowledged write; a write
+                # that applied but whose response was lost would otherwise
+                # let the next refresh promote the pre-write response. The
+                # None guard keeps a local-only placeholder client from
+                # masking the original error with a second AttributeError.
+                if self._client is not None:
+                    self._client.invalidate_cache_for_device(self.serial_number)
+                self._invalidate_parameters_cache()
 
         return success
 

--- a/src/pylxpweb/devices/inverters/hybrid.py
+++ b/src/pylxpweb/devices/inverters/hybrid.py
@@ -1510,7 +1510,7 @@ class HybridInverter(GenericInverter):
         this level while grid-connected.
 
         Returns:
-            Cutoff SOC percentage (10-90)
+            Cutoff SOC percentage (10-100)
 
         Example:
             >>> soc = await inverter.get_on_grid_cutoff_soc()
@@ -1525,7 +1525,7 @@ class HybridInverter(GenericInverter):
         """Set on-grid discharge cutoff SOC via Modbus.
 
         Args:
-            soc_percent: Cutoff SOC percentage (10-90)
+            soc_percent: Cutoff SOC percentage (10-100)
 
         Returns:
             True if successful
@@ -1537,10 +1537,18 @@ class HybridInverter(GenericInverter):
             >>> await inverter.set_on_grid_cutoff_soc(20)
             True
         """
-        from pylxpweb.constants import HOLD_DISCHG_CUT_OFF_SOC_EOD
+        from pylxpweb.constants import (
+            HOLD_DISCHG_CUT_OFF_SOC_EOD,
+            ONGRID_DISCHARGE_CUTOFF_SOC_MAX,
+            ONGRID_DISCHARGE_CUTOFF_SOC_MIN,
+        )
 
-        if not 10 <= soc_percent <= 90:
-            raise ValueError(f"soc_percent must be 10-90, got {soc_percent}")
+        if not ONGRID_DISCHARGE_CUTOFF_SOC_MIN <= soc_percent <= ONGRID_DISCHARGE_CUTOFF_SOC_MAX:
+            raise ValueError(
+                "soc_percent must be "
+                f"{ONGRID_DISCHARGE_CUTOFF_SOC_MIN}-{ONGRID_DISCHARGE_CUTOFF_SOC_MAX}, "
+                f"got {soc_percent}"
+            )
         return await self._write_modbus_register(HOLD_DISCHG_CUT_OFF_SOC_EOD, soc_percent)
 
     async def get_off_grid_cutoff_soc(self) -> int:

--- a/src/pylxpweb/registers/inverter_holding.py
+++ b/src/pylxpweb/registers/inverter_holding.py
@@ -30,6 +30,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
+from pylxpweb.constants.devices import (
+    ONGRID_DISCHARGE_CUTOFF_SOC_MAX,
+    ONGRID_DISCHARGE_CUTOFF_SOC_MIN,
+)
 from pylxpweb.registers.inverter_input import ALL, ScaleFactor
 
 
@@ -894,8 +898,10 @@ INVERTER_HOLDING_REGISTERS: tuple[HoldingRegisterDefinition, ...] = (
         api_param_key="HOLD_DISCHG_CUT_OFF_SOC_EOD",  # verified
         ha_entity_key="ongrid_discharge_soc",
         unit="%",
-        min_value=10,
-        max_value=90,
+        # Bounds owned by constants.devices (eg4 #603: ceiling 100, not the
+        # portal's 90 hint; one-model evidence, floor unproven either way).
+        min_value=ONGRID_DISCHARGE_CUTOFF_SOC_MIN,
+        max_value=ONGRID_DISCHARGE_CUTOFF_SOC_MAX,
         category=HoldingCategory.BATTERY,
         description="On-grid end-of-discharge SOC cutoff.",
     ),

--- a/tests/unit/devices/inverters/test_base.py
+++ b/tests/unit/devices/inverters/test_base.py
@@ -12,7 +12,7 @@ from pylxpweb import LuxpowerClient
 from pylxpweb.devices.inverters.base import BaseInverter
 from pylxpweb.devices.inverters.hybrid import HybridInverter
 from pylxpweb.devices.models import DeviceInfo, Entity
-from pylxpweb.exceptions import LuxpowerDeviceError
+from pylxpweb.exceptions import LuxpowerAPIError, LuxpowerConnectionError, LuxpowerDeviceError
 from pylxpweb.models import EnergyInfo, InverterRuntime, SuccessResponse
 from pylxpweb.transports.http import HTTPTransport
 from pylxpweb.transports.hybrid import HybridTransport
@@ -959,6 +959,112 @@ class TestInverterControlOperations:
         assert calls[1][0] == ("1234567890", "HOLD_SOC_LOW_LIMIT_EPS_DISCHG", "15")
 
         assert result is True
+        mock_client.invalidate_cache_for_device.assert_called_once_with("1234567890")
+
+    @pytest.mark.asyncio
+    async def test_set_battery_soc_limits_invalid_off_grid_writes_nothing(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """Both inputs are validated BEFORE any I/O: an invalid off-grid value
+        must not let the (valid) on-grid write land first."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_client.api.control = Mock()
+        mock_client.api.control.write_parameter = AsyncMock()
+
+        with pytest.raises(ValueError, match="off_grid_limit"):
+            await inverter.set_battery_soc_limits(on_grid_limit=95, off_grid_limit=101)
+
+        mock_client.api.control.write_parameter.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_battery_soc_limits_partial_failure_still_invalidates_cache(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A pair where one write fails returns False but still marks the
+        parameter cache stale, so the next refresh re-reads the applied half."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        ok, failed = Mock(), Mock()
+        ok.success, failed.success = True, False
+        mock_client.api.control = Mock()
+        mock_client.api.control.write_parameter = AsyncMock(side_effect=[ok, failed])
+        with patch.object(inverter, "_invalidate_parameters_cache") as invalidate:
+            result = await inverter.set_battery_soc_limits(on_grid_limit=20, off_grid_limit=15)
+
+        assert result is False
+        invalidate.assert_called_once()
+        mock_client.invalidate_cache_for_device.assert_called_once_with("1234567890")
+
+    @pytest.mark.asyncio
+    async def test_set_battery_soc_limits_no_args_writes_nothing_and_keeps_cache(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """No limits requested -> no write attempted -> the cache is NOT marked
+        stale (it used to be, as a side effect of the unconditional call)."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_client.api.control = Mock()
+        mock_client.api.control.write_parameter = AsyncMock()
+
+        with patch.object(inverter, "_invalidate_parameters_cache") as invalidate:
+            assert await inverter.set_battery_soc_limits() is True
+
+        mock_client.api.control.write_parameter.assert_not_awaited()
+        invalidate.assert_not_called()
+        mock_client.invalidate_cache_for_device.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_battery_soc_limits_first_write_raising_still_invalidates_cache(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A write whose response is lost (timeout/disconnect/cancel) may have
+        been applied by the device, so the cache is marked stale on ANY
+        attempted write, not only on an acknowledged one."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_client.api.control = Mock()
+        mock_client.api.control.write_parameter = AsyncMock(
+            side_effect=LuxpowerConnectionError("lost")
+        )
+
+        with (
+            patch.object(inverter, "_invalidate_parameters_cache") as invalidate,
+            pytest.raises(LuxpowerConnectionError),
+        ):
+            await inverter.set_battery_soc_limits(on_grid_limit=20)
+
+        invalidate.assert_called_once()
+        mock_client.invalidate_cache_for_device.assert_called_once_with("1234567890")
+
+    @pytest.mark.asyncio
+    async def test_set_battery_soc_limits_second_write_raising_still_invalidates_cache(
+        self, mock_client: LuxpowerClient
+    ) -> None:
+        """A second write that RAISES still leaves the cache marked stale, so
+        the next refresh re-reads the half that landed."""
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        ok = Mock()
+        ok.success = True
+        mock_client.api.control = Mock()
+        mock_client.api.control.write_parameter = AsyncMock(
+            side_effect=[ok, LuxpowerAPIError("boom")]
+        )
+
+        with (
+            patch.object(inverter, "_invalidate_parameters_cache") as invalidate,
+            pytest.raises(LuxpowerAPIError),
+        ):
+            await inverter.set_battery_soc_limits(on_grid_limit=20, off_grid_limit=15)
+
+        invalidate.assert_called_once()
+        mock_client.invalidate_cache_for_device.assert_called_once_with("1234567890")
 
     @pytest.mark.asyncio
     async def test_set_battery_soc_limits_on_grid_only(self, mock_client: LuxpowerClient) -> None:
@@ -1016,7 +1122,7 @@ class TestInverterControlOperations:
         )
 
         # Try to set on-grid limit below 10%
-        with pytest.raises(ValueError, match="on_grid_limit must be between 10 and 90%"):
+        with pytest.raises(ValueError, match="on_grid_limit must be between 10 and 100%"):
             await inverter.set_battery_soc_limits(on_grid_limit=5)
 
     @pytest.mark.asyncio
@@ -1028,9 +1134,32 @@ class TestInverterControlOperations:
             client=mock_client, serial_number="1234567890", model="TestModel"
         )
 
-        # Try to set on-grid limit above 90%
-        with pytest.raises(ValueError, match="on_grid_limit must be between 10 and 90%"):
-            await inverter.set_battery_soc_limits(on_grid_limit=95)
+        # Try to set on-grid limit above 100%
+        with pytest.raises(ValueError, match="on_grid_limit must be between 10 and 100%"):
+            await inverter.set_battery_soc_limits(on_grid_limit=101)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("limit", [91, 95, 100])
+    async def test_set_battery_soc_limits_on_grid_accepts_above_90(
+        self, mock_client: LuxpowerClient, limit: int
+    ) -> None:
+        """Client-side range: 91-100 is forwarded to the cloud writer, no ValueError.
+
+        Pins the client no longer refusing the value; firmware evidence is
+        one LXP-LB-US 10K (95 stored, 101 rejected — eg4 #603).
+        """
+        inverter = ConcreteInverter(
+            client=mock_client, serial_number="1234567890", model="TestModel"
+        )
+        mock_client.api.control = Mock()
+        mock_response = Mock()
+        mock_response.success = True
+        mock_client.api.control.write_parameter = AsyncMock(return_value=mock_response)
+
+        assert await inverter.set_battery_soc_limits(on_grid_limit=limit) is True
+        mock_client.api.control.write_parameter.assert_awaited_once_with(
+            "1234567890", "HOLD_DISCHG_CUT_OFF_SOC_EOD", str(limit)
+        )
 
     @pytest.mark.asyncio
     async def test_set_battery_soc_limits_validation_off_grid_too_low(

--- a/tests/unit/devices/inverters/test_hybrid.py
+++ b/tests/unit/devices/inverters/test_hybrid.py
@@ -1443,11 +1443,29 @@ class TestModbusOnlyChargeDischargeOperations:
     ) -> None:
         inverter = self._inverter(mock_client)
 
-        with pytest.raises(ValueError, match="soc_percent must be 10-90"):
+        with pytest.raises(ValueError, match="soc_percent must be 10-100"):
             await inverter.set_on_grid_cutoff_soc(9)
 
-        with pytest.raises(ValueError, match="soc_percent must be 10-90"):
-            await inverter.set_on_grid_cutoff_soc(91)
+        with pytest.raises(ValueError, match="soc_percent must be 10-100"):
+            await inverter.set_on_grid_cutoff_soc(101)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("soc", [91, 95, 100])
+    async def test_set_on_grid_cutoff_soc_forwards_91_to_100(
+        self, mock_client: LuxpowerClient, soc: int
+    ) -> None:
+        """Client-side range: 91-100 (inclusive) is forwarded to the reg-105 write.
+
+        The ceiling of 100 is portal-correlated on one LXP-LB-US 10K (eg4
+        #603: a portal-typed 95 stored; >100 rejected) — this pins the
+        client no longer refusing it, not firmware semantics.
+        """
+        inverter = self._inverter(mock_client)
+        inverter.write_transport_register = AsyncMock(return_value=True)
+
+        assert await inverter.set_on_grid_cutoff_soc(soc) is True
+
+        inverter.write_transport_register.assert_awaited_once_with(105, soc)
 
     @pytest.mark.asyncio
     async def test_get_on_grid_cutoff_voltage(self, mock_client: LuxpowerClient) -> None:

--- a/tests/unit/test_inverter_holding_ranges.py
+++ b/tests/unit/test_inverter_holding_ranges.py
@@ -17,3 +17,16 @@ def test_h160_firmware_range() -> None:
 
     assert register.min_value == 1
     assert register.max_value == 90
+
+
+def test_h105_range_ceiling_is_100() -> None:
+    """eg4 #603: a portal-typed 95 is stored (LXP-LB-US 10K); >100 rejected.
+
+    The ceiling is portal-correlated on one model, not firmware-proven. The 10
+    floor is the portal hint, unproven either way — pinned so a drift is loud.
+    """
+    register = BY_NAME["ongrid_discharge_cutoff_soc"]
+
+    assert register.address == 105
+    assert register.min_value == 10
+    assert register.max_value == 100


### PR DESCRIPTION
## Summary

Fixes joyfulhouse/eg4_web_monitor#603.

The canonical H105 definition, `set_battery_soc_limits` (cloud) and `set_on_grid_cutoff_soc` (Modbus) all capped the on-grid discharge SOC cutoff at 90. That 90 was the portal's arrow-button hint, not a firmware bound: a portal-typed **95 is stored** on a Luxpower LXP-LB-US 10K and **101 is rejected** (reporter diagnostics). The ceiling is now 100; 96-100 are inferred from that pair. Users keeping batteries full ahead of outages could no longer set the value from the HA integration.

## Key decisions

- `ONGRID_DISCHARGE_CUTOFF_SOC_MIN/MAX` in `constants.devices` are the single source for the register definition and both setters (review: bounds were triplicated literals, which is how the 90 hint got stuck).
- `set_battery_soc_limits` validates both inputs **before any I/O** (previously the on-grid write landed before an invalid off-grid value raised), and marks both the client response cache and the parameter cache stale in a `finally` on **any attempted write** — a write may apply on the device even when its response is lost.
- **10 floor unchanged.** It is the same portal hint, unproven either way; kept fail-closed.
- **Single-model evidence.** Other families are unconfirmed; the firmware exception remains the authoritative reject path. Stated in the constants comment, docs and CHANGELOG.
- Risk-accepted (pre-existing, out of scope): the in-flight cloud read vs. cache-invalidation generation race raised by Codex.

## Docs

`PARAMETER_REFERENCE.md` parameter names corrected; `luxpower-api.yaml` off-grid SOC row corrected from register 106 to 125 (106 is lead-acid low-temperature cutoff); `samples/README.md`.

## Test plan

- [x] `uv run ruff check` / `ruff format` clean
- [x] `uv run mypy --strict src/pylxpweb` clean
- [x] Full suite: 3582 passed (one pre-existing unrelated flake in `test_release_workflow.py` wall-deadline deselected locally; CI runs it)
- [x] New tests: 91/95/100 forwarded on cloud and Modbus paths, 101 rejected, definition ceiling pinned, first-write-raises, second-write-raises, partial failure, no-args

## Adversarial review

Five rounds. Final tree: **Codex GPT-5.6-sol (ultra)** — three LOWs, all applied; **Gemini 3.1 Pro** — one MEDIUM (None-guard on client invalidation for local-only devices), applied; **Claude Fable** — NO BLOCKING ISSUES. **Cursor Grok 4.5 waived**: the CLI returned empty output on four consecutive runs from this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)