### PR TITLE
chore(release): 0.10.0b6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0b6] - 2026-09-02
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.10.0b5"
+version = "0.10.0b6"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.10.0b5"
+version = "0.10.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release 0.10.0b6: the H105 on-grid discharge SOC cutoff ceiling fix (#322, eg4_web_monitor #603) plus the TLS-PSK dongle work already on main since 0.10.0b5. Version bump, changelog dated, lock refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)