### PR TITLE
chore(release): 0.10.0b7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0b6] - 2026-09-02
+## [0.10.0b7] - 2026-09-02
+
+_0.10.0b6 was tagged but never published (the release workflow rejected a squash-merged release commit); this is the same content._
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.10.0b6"
+version = "0.10.0b7"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.10.0b6"
+version = "0.10.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Re-cut of 0.10.0b6, which was tagged but never published: the release workflow requires the tagged commit to be a two-parent merge of the CI-tested PR head, and #323 was squash-merged. Same content (H105 ceiling fix #322 for eg4_web_monitor #603, plus TLS-PSK dongle support #318). **Merge this with a merge commit, not squash.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)