### PR TITLE
fix(ci): build executables with Python 3.13 to match requires-python

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Bump `build-executables.yml` runner Python from 3.12 to 3.13.
- `pyproject.toml` declares `requires-python = ">=3.13"`, so `pip install .` failed on the v0.10.0b6 and v0.10.0b7 release builds with `Package 'pylxpweb' requires a different Python: 3.12.14 not in '>=3.13'`.
- Matches `ci.yml` and the 3.13 check in `release.yml`.

Closes #325

## Test plan
- [ ] CI passes on this PR
- [ ] Next release's Build Executables workflow succeeds on all three OS runners (or trigger via `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)