### PR TITLE
chore(release): 0.10.0b8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0b8] - 2026-09-02
+
 ### Added
 
 - **Complete Grid Peak Shaving library surface** (companion to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.10.0b7"
+version = "0.10.0b8"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.10.0b7"
+version = "0.10.0b8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Bump the project and lockfile version from `0.10.0b7` to `0.10.0b8`.
- Move the current Unreleased peak-shaving entries into the dated `0.10.0b8` changelog section.

## This beta ships

- Named holding-register constants for grid peak-shaving SOC/voltage: H207, H208, H218, and H219.
- Six `BaseInverter` setter/property pairs covering Power 2, SOC 1-2, and Voltage 1-2.
- Maintainer-chosen 40.0-64.0 V bounds on the two voltage holding-register rows.
- Any-of PS1/PS2 feature detection, while PV-series detection remains keyed to PS1.

These changes are the grid peak-shaving library surface merged in #327.

## Verification

- `uv sync --all-extras`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy --strict src/pylxpweb/`
- `uv run pytest tests/unit/`