### PR TITLE
chore(release): 0.10.0b9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0b9] - 2026-09-04
+
 ### Changed
 
 - **One serialized TCP socket per physical dongle** (closes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylxpweb"
-version = "0.10.0b8"
+version = "0.10.0b9"
 description = "Python client library for Luxpower/EG4 inverter web monitoring API"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "pylxpweb"
-version = "0.10.0b8"
+version = "0.10.0b9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Bump the project and lockfile version from `0.10.0b8` to `0.10.0b9`.
- Move the current Unreleased shared-dongle entry into the dated `0.10.0b9` changelog section.

## This beta ships

- One endpoint-scoped `DongleChannel` per physical dongle, shared by default across every `DongleTransport` construction path.
- Shared streams, connection/transaction/operation locks, TLS-PSK detection memo, generation tracking, and lease lifecycle so one dongle no longer receives competing per-device sockets.
- Bounded shared-channel shutdown behavior and per-channel serialization for multi-step operations, including `check_link()` under the operation lock and its single timeout budget.
- A keyword-only `shared_channel=False` compatibility escape hatch, plus explicit channel mismatch and event-loop errors.
- Per-transport operation knobs and lease-aware `is_connected` semantics remain intact.

These changes are the #329 shared dongle channel merged in #330.

Requires no downstream change; eg4 pin bump follows.

## Known follow-up

- Pre-existing Markdown format drift outside CI paths remains untouched.

## Verification

- `uv sync --extra dev`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy --strict src/`
- `uv run pytest tests/unit -q`